### PR TITLE
fix: remove replace directive in cmd/graymatter/go.mod to allow go install

### DIFF
--- a/cmd/graymatter/go.mod
+++ b/cmd/graymatter/go.mod
@@ -3,7 +3,7 @@ module github.com/angelnicolasc/graymatter/cmd/graymatter
 go 1.23.0
 
 require (
-	github.com/angelnicolasc/graymatter v0.0.0
+	github.com/angelnicolasc/graymatter v0.5.0
 	github.com/anthropics/anthropic-sdk-go v1.33.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4
@@ -47,5 +47,3 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 )
-
-replace github.com/angelnicolasc/graymatter => ../..


### PR DESCRIPTION
## Problem

Running `go install github.com/angelnicolasc/graymatter/cmd/graymatter@latest` fails with:

```
The go.mod file for the module providing named packages contains one or
more replace directives. It must not contain directives that would cause
it to be interpreted differently than if it were the main module.
```

This is because `cmd/graymatter/go.mod` contains:
```
replace github.com/angelnicolasc/graymatter => ../..`
```

This `replace` directive is only valid in a local `go.work` workspace context and breaks `go install` for external users.

## Fix

- Remove the `replace` directive from `cmd/graymatter/go.mod`
- Pin `github.com/angelnicolasc/graymatter` to `v0.5.0` (the latest release) instead of `v0.0.0`

The `go.work` file can still be used locally for development, but the published module will now be installable via:

```bash
go install github.com/angelnicolasc/graymatter/cmd/graymatter@latest
```

> **Note:** the `go.sum` file for `cmd/graymatter` will also need to be regenerated (`go mod tidy`) after this change to include the real checksum for `v0.5.0`.