### PR TITLE
AI Agent had issue with forget action. 

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -190,6 +190,7 @@ The old fact is dropped to weight 0; consolidation prunes it on the next pass.
 { "tool": "memory_reflect", "args": {
     "action": "forget",
     "agent":  "backend-agent",
+    "text":   "",  // placeholder (required by API)
     "text":   "Workaround for Node 14 bug (project now on Node 18)"
 }}
 ```

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -191,7 +191,7 @@ The old fact is dropped to weight 0; consolidation prunes it on the next pass.
     "action": "forget",
     "agent":  "backend-agent",
     "text":   "",  // placeholder (required by API)
-    "text":   "Workaround for Node 14 bug (project now on Node 18)"
+    "target":   "Workaround for Node 14 bug (project now on Node 18)"
 }}
 ```
 


### PR DESCRIPTION
# Documentation error: forget action example uses wrong parameter

The forget workflow example in the documentation uses `text` to pass the fact to remove, but the API actually requires `target` for the forget action.

**Current docs (lines 190-195 in AGENTS.md):**
```jsonc
{ "tool": "memory_reflect", "args": {
    "action": "forget",
    "agent":  "backend-agent",
    "text":   "Workaround for Node 14 bug (project now on Node 18)"
}}
```

**What actually works:**
```jsonc
{ "tool": "memory_reflect", "args": {
    "action": "forget",
    "agent":  "backend-agent",
    "text":   "",  // placeholder (required by API)
    "target": "Workaround for Node 14 bug (project now on Node 18)"
}}
```

The table on lines 163-168 says for forget: "text = The fact to remove (or, equivalently, pass via target)". But when using only `text` (without `target`), the API returns an error requiring `target`.

**Expected behavior:** Either the table should clarify that `target` is required for forget, or the API should accept `text` alone for forget (matching the table description).