### PR TITLE
feat: daemon mode — concurrent store access (closes #4, #8, #9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Test CLI module with coverage
         working-directory: cmd/graymatter
         shell: bash
-        run: go test -race -count=1 -timeout=120s -coverprofile=../../coverage-cli.out -covermode=atomic ./internal/harness/... ./internal/kg/... ./internal/server/... ./internal/plugin/...
+        run: go test -race -count=1 -timeout=300s -coverprofile=../../coverage-cli.out -covermode=atomic ./internal/harness/... ./internal/kg/... ./internal/server/... ./internal/plugin/... ./internal/mcp/... ./internal/daemon/...
 
       - name: Coverage gate — core library (≥70%)
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ To get both your agent-specific facts and shared facts in one go, issue two `mem
 ## Working in this codebase
 
 - Go module. Build: `go build ./...`. Tests: `go test ./...`. The CI matrix runs Ubuntu / macOS / Windows × Go 1.22 / 1.23.
-- bbolt is single-writer — running two `graymatter` processes against the same `--dir` will fight over the lock. Tracked in [issue #8](https://github.com/angelnicolasc/graymatter/issues/8); structural fix in v0.6.0.
+- bbolt is single-writer, but daemon mode handles that: a store daemon owns the lock and every `graymatter` process connects to it as a client, so concurrent TUI/MCP/CLI access works. Clients auto-start the daemon and it idle-exits when unused. `--no-daemon` opts out (and reintroduces the lock contention). Resolved [issue #8](https://github.com/angelnicolasc/graymatter/issues/8).
 
 ## More
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+**Daemon mode — concurrent store access (issue #8, closes #4 and #9)**
+- bbolt is single-writer: until now a second `graymatter` process (TUI + MCP server, two agents' MCP servers, `run` + TUI, opencode + TUI) targeting the same `--dir` timed out on the lock. Daemon mode fixes this structurally.
+- One process owns the store and serves it over a local endpoint (Unix domain socket on POSIX, TCP loopback on Windows); every other process — TUI, MCP server, one-shot CLI commands, the `run` harness — connects as a thin client. Transport is `net/rpc` + JSON (`pkg/memory/rpc`), **stdlib only, zero new dependencies** — the single-binary/zero-infra story is intact (stripped binary ≈ 18 MB).
+- **Launch-on-connect**: clients spawn the daemon on first use and it idle-exits after 2 min with no clients, so one-shot commands stay snappy and nothing lingers. No manual `serve` step.
+- **No silent degradation**: the daemon opens the store strict-write (`StrictWrite`) — if it can't own the lock it fails loudly rather than coming up read-only under its clients. The spawn race is resolved by the bbolt lock itself: only the winner writes the discovery file; losers exit and every client converges on the winner via dial-retry.
+- **Local-only auth**: the daemon mints a 256-bit token per run, written to a `0600` discovery file; clients present it as a connection preamble (constant-time compared). On Windows loopback this is the access control; on Unix the socket is also `0600`.
+- New `graymatter daemon run|status|stop`. New global `--no-daemon` (and `GRAYMATTER_NO_DAEMON=1`) for in-process debugging/air-gapped inspection.
+- `graymatter doctor` is daemon-aware: it reports store health *through* the daemon when one is running, and only flags a lock when a non-daemon process holds it.
+- Integration tests cover spawn-on-connect, four concurrent clients writing through one daemon (the #4/#9 scenario), idle-exit, and graceful stop.
+
 **`graymatter doctor` — end-to-end setup diagnosis (issue #3)**
 - New command checks the full chain that makes agent memory work: binary on `PATH`, data dir writable, store health + lock state (single-writer detection with actionable hints), MCP wiring per client config, and agent-instruction files.
 - `--json` for scripting; exit code 1 only on hard failures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ GrayMatter — a single-binary Go memory system for AI agents. Library + CLI + M
 ## Two facts that change how you work here
 
 1. **You have memory tools available** via this repo's own MCP server. See [`AGENTS.md`](AGENTS.md) for the per-tool param reference (notably: `memory_reflect` takes `agent`, the other four take `agent_id` — don't mix them up).
-2. **bbolt is single-writer**. If `graymatter tui`, `graymatter serve`, an MCP client child, or a test all run simultaneously against the same `--dir`, they fight over the lock. The structural fix is tracked in [issue #8](https://github.com/angelnicolasc/graymatter/issues/8) and lands in v0.6.0 (daemon mode).
+2. **bbolt is single-writer — daemon mode solves it.** A daemon owns the store and every other process (TUI, MCP server, CLI, `run`) connects as a client over a local socket/named pipe, so concurrent access just works. Clients spawn the daemon on first use and it idle-exits when unused. Use `--no-daemon` to bypass it for in-process debugging (then the old single-writer lock applies, and a second process will contend). See `cmd/graymatter/internal/daemon/` and `pkg/memory/rpc/`. This was [issue #8](https://github.com/angelnicolasc/graymatter/issues/8) (closes #4, #9).
 
 ## Codebase basics
 

--- a/cmd/graymatter/cmd_checkpoint.go
+++ b/cmd/graymatter/cmd_checkpoint.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	graymatter "github.com/angelnicolasc/graymatter"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
 )
 
@@ -29,18 +28,13 @@ func checkpointListCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID := args[0]
-			mem, err := openMem()
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
+			defer func() { _ = store.Close() }()
 
-			store := mem.Advanced()
-			if store == nil {
-				return fmt.Errorf("store not initialised")
-			}
-
-			checkpoints, err := session.List(store.DB(), agentID)
+			checkpoints, err := store.CheckpointList(agentID)
 			if err != nil {
 				return err
 			}
@@ -77,22 +71,17 @@ func checkpointResumeCmd() *cobra.Command {
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID := args[0]
-			mem, err := openMem()
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
-
-			store := mem.Advanced()
-			if store == nil {
-				return fmt.Errorf("store not initialised")
-			}
+			defer func() { _ = store.Close() }()
 
 			var cp *session.Checkpoint
 			if len(args) == 2 {
-				cp, err = session.Load(store.DB(), agentID, args[1])
+				cp, err = store.CheckpointLoad(agentID, args[1])
 			} else {
-				cp, err = session.Resume(store.DB(), agentID)
+				cp, err = store.CheckpointResume(agentID)
 			}
 			if err != nil {
 				return err
@@ -112,22 +101,17 @@ func checkpointSaveCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID := args[0]
-			mem, err := openMem()
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
-
-			store := mem.Advanced()
-			if store == nil {
-				return fmt.Errorf("store not initialised")
-			}
+			defer func() { _ = store.Close() }()
 
 			cp := session.Checkpoint{
 				AgentID:  agentID,
 				Metadata: map[string]string{"source": "cli"},
 			}
-			saved, err := session.Save(store.DB(), cp)
+			saved, err := store.CheckpointSave(cp)
 			if err != nil {
 				return err
 			}
@@ -135,10 +119,4 @@ func checkpointSaveCmd() *cobra.Command {
 			return nil
 		},
 	}
-}
-
-func openMem() (*graymatter.Memory, error) {
-	cfg := graymatter.DefaultConfig()
-	cfg.DataDir = dataDir
-	return graymatter.NewWithConfig(cfg)
 }

--- a/cmd/graymatter/cmd_daemon.go
+++ b/cmd/graymatter/cmd_daemon.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
+)
+
+func daemonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Manage the GrayMatter store daemon",
+		Long: `The daemon is the single owner of the bbolt store for a data directory.
+Every other graymatter process (TUI, MCP server, CLI commands) connects to
+it over a local endpoint, which is what lets them run concurrently — bbolt
+itself allows only one writer process.
+
+You normally never run these commands by hand: clients start the daemon on
+demand and it exits on its own after sitting idle. They exist for service
+managers (systemd/launchd), debugging, and forced restarts.`,
+	}
+	cmd.AddCommand(daemonRunCmd(), daemonStatusCmd(), daemonStopCmd())
+	return cmd
+}
+
+func daemonRunCmd() *cobra.Command {
+	var idleExit time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run the store daemon in the foreground",
+		Long: `Runs the daemon in the foreground until stopped (signal, ` + "`daemon stop`" + `,
+or idle-exit). Acquires the store write lock strictly: if another process
+holds it, the daemon fails fast instead of degrading to read-only.
+
+Client processes spawn this automatically with --idle-exit ` + daemon.DefaultIdleExit.String() + `.
+For service-manager setups, run it yourself with --idle-exit 0.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return daemon.Run(daemon.RunOptions{
+				DataDir:  dataDir,
+				IdleExit: idleExit,
+			})
+		},
+	}
+	cmd.Flags().DurationVar(&idleExit, "idle-exit", daemon.DefaultIdleExit,
+		"exit after this long with no clients and no traffic (0 = never)")
+	return cmd
+}
+
+func daemonStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show whether a daemon is serving this data directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := daemon.ConnectNoSpawn(dataDir)
+			if err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "daemon: not running (dir %s)\n", dataDir)
+				if pid := daemon.ReadPIDFile(dataDir); pid != 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "  stale pid file: %d (daemon likely crashed; safe to ignore)\n", pid)
+				}
+				return nil
+			}
+			defer func() { _ = c.Close() }()
+
+			addr, _ := rpc.DiscoveryAddr(c.DataDir())
+			fmt.Fprintf(cmd.OutOrStdout(), "daemon: running\n  dir:  %s\n  addr: %s\n", c.DataDir(), addr)
+			if pid := daemon.ReadPIDFile(c.DataDir()); pid != 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "  pid:  %d\n", pid)
+			}
+			return nil
+		},
+	}
+}
+
+func daemonStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the daemon serving this data directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := daemon.ConnectNoSpawn(dataDir)
+			if err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "daemon: not running (dir %s)\n", dataDir)
+				return nil
+			}
+			defer func() { _ = c.Close() }()
+			if err := c.Shutdown(); err != nil {
+				return fmt.Errorf("shutdown: %w", err)
+			}
+			if !quiet {
+				fmt.Fprintln(cmd.OutOrStdout(), "daemon: stopping")
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
@@ -151,14 +152,41 @@ func checkStore(dir string) checkResult {
 		return c
 	}
 
-	// Read-only probe: side-effect free, and lock contention tells us
-	// another process is actively holding the store.
+	// Preferred path: ask the daemon, which owns the store in normal
+	// operation. This is also what proves the daemon is healthy end to end.
+	if dc, err := daemon.ConnectNoSpawn(dir); err == nil {
+		defer func() { _ = dc.Close() }()
+		agents, err := dc.ListAgents()
+		if err != nil {
+			c.Status, c.Detail = "fail", fmt.Sprintf("daemon up but listing agents failed: %v", err)
+			return c
+		}
+		facts := 0
+		for _, a := range agents {
+			if st, err := dc.Stats(a); err == nil {
+				facts += st.FactCount
+			}
+		}
+		pending, _ := dc.PendingVectorCount()
+		c.Status = "ok"
+		c.Detail = fmt.Sprintf("served by daemon — %d fact(s) across %d agent(s)", facts, len(agents))
+		if pending > 0 {
+			c.Status = "warn"
+			c.Detail += fmt.Sprintf(", %d pending vector write(s)", pending)
+			c.Hint = "pending vectors in a quiescent system mean the embedding backend is failing — check your embedding configuration (Ollama URL / API keys)"
+		}
+		return c
+	}
+
+	// No daemon: read-only probe. Lock contention here means some non-daemon
+	// process (e.g. a Go program embedding the library, or a stale daemon)
+	// holds the write lock.
 	store, err := memory.Open(memory.StoreConfig{DataDir: dir, ReadOnly: true})
 	if err != nil {
 		if strings.Contains(err.Error(), "locked") || strings.Contains(err.Error(), "timeout") {
 			c.Status = "warn"
-			c.Detail = "gray.db is in use by another process (bbolt is single-writer)"
-			c.Hint = "this is normal while an MCP client or the TUI is running; if you started `graymatter mcp serve` manually in a terminal, kill it — MCP clients spawn their own instance" + lsofHint(dbPath)
+			c.Detail = "gray.db is held by a non-daemon process (bbolt is single-writer)"
+			c.Hint = "another program is holding the store directly — a Go app embedding the library, or `graymatter ... --no-daemon`; close it and clients will start their own daemon" + lsofHint(dbPath)
 			return c
 		}
 		c.Status, c.Detail = "fail", fmt.Sprintf("store failed to open: %v", err)
@@ -179,7 +207,7 @@ func checkStore(dir string) checkResult {
 	}
 	pending := store.PendingVectorCount()
 	c.Status = "ok"
-	c.Detail = fmt.Sprintf("%d fact(s) across %d agent(s)", facts, len(agents))
+	c.Detail = fmt.Sprintf("no daemon running — %d fact(s) across %d agent(s) (direct read)", facts, len(agents))
 	if pending > 0 {
 		c.Status = "warn"
 		c.Detail += fmt.Sprintf(", %d pending vector write(s)", pending)

--- a/cmd/graymatter/cmd_doctor_test.go
+++ b/cmd/graymatter/cmd_doctor_test.go
@@ -85,7 +85,7 @@ func TestCheckStore(t *testing.T) {
 		if c.Status != "warn" {
 			t.Fatalf("status = %s, want warn (%s)", c.Status, c.Detail)
 		}
-		if !strings.Contains(c.Detail, "in use by another process") {
+		if !strings.Contains(c.Detail, "non-daemon process") {
 			t.Errorf("detail %q should explain the single-writer lock", c.Detail)
 		}
 	})

--- a/cmd/graymatter/cmd_export.go
+++ b/cmd/graymatter/cmd_export.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	graymatter "github.com/angelnicolasc/graymatter"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/export"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
@@ -25,19 +24,11 @@ func exportCmd() *cobra.Command {
   graymatter export --format json
   graymatter export --format markdown --agent sales-closer`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := graymatter.DefaultConfig()
-			cfg.DataDir = dataDir
-
-			mem, err := graymatter.NewWithConfig(cfg)
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
-
-			store := mem.Advanced()
-			if store == nil {
-				return fmt.Errorf("store not initialised")
-			}
+			defer func() { _ = store.Close() }()
 
 			exporter, err := export.New(export.Format(format))
 			if err != nil {

--- a/cmd/graymatter/cmd_mcp.go
+++ b/cmd/graymatter/cmd_mcp.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	graymatter "github.com/angelnicolasc/graymatter"
 	gmcp "github.com/angelnicolasc/graymatter/cmd/graymatter/internal/mcp"
 )
 
@@ -40,16 +39,13 @@ Claude Code setup — add to your project's .mcp.json:
     }
   }`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := graymatter.DefaultConfig()
-			cfg.DataDir = dataDir
-
-			mem, err := graymatter.NewWithConfig(cfg)
+			store, err := openStore()
 			if err != nil {
 				return fmt.Errorf("open memory: %w", err)
 			}
-			defer mem.Close()
+			defer func() { _ = store.Close() }()
 
-			srv := gmcp.New(mem)
+			srv := gmcp.New(store)
 
 			if httpAddr != "" {
 				return srv.ServeHTTP(httpAddr)

--- a/cmd/graymatter/cmd_recall.go
+++ b/cmd/graymatter/cmd_recall.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	graymatter "github.com/angelnicolasc/graymatter"
 )
 
 func recallCmd() *cobra.Command {
@@ -26,34 +24,29 @@ func recallCmd() *cobra.Command {
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID, query := args[0], args[1]
-			cfg := graymatter.DefaultConfig()
-			cfg.DataDir = dataDir
-			if topK > 0 {
-				cfg.TopK = topK
-			}
-
-			mem, err := graymatter.NewWithConfig(cfg)
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
+			defer func() { _ = store.Close() }()
 
 			ctx := cmd.Context()
 			if ctx == nil {
 				ctx = context.Background()
 			}
 
+			// topK <= 0 means "store default" on every path.
 			var facts []string
 			var scope string
 			switch {
 			case all:
-				facts, err = mem.RecallAll(ctx, agentID, query)
+				facts, err = store.RecallAll(ctx, agentID, query, topK)
 				scope = "all"
 			case shared:
-				facts, err = mem.RecallShared(ctx, query)
+				facts, err = store.RecallShared(ctx, query, topK)
 				scope = "shared"
 			default:
-				facts, err = mem.Recall(ctx, agentID, query)
+				facts, err = store.Recall(ctx, agentID, query, topK)
 				scope = agentID
 			}
 			if err != nil {

--- a/cmd/graymatter/cmd_remember.go
+++ b/cmd/graymatter/cmd_remember.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	graymatter "github.com/angelnicolasc/graymatter"
 )
 
 func rememberCmd() *cobra.Command {
@@ -22,14 +20,11 @@ func rememberCmd() *cobra.Command {
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID, text := args[0], args[1]
-			cfg := graymatter.DefaultConfig()
-			cfg.DataDir = dataDir
-
-			mem, err := graymatter.NewWithConfig(cfg)
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
+			defer func() { _ = store.Close() }()
 
 			ctx := cmd.Context()
 			if ctx == nil {
@@ -37,7 +32,7 @@ func rememberCmd() *cobra.Command {
 			}
 
 			if shared {
-				if err := mem.RememberShared(ctx, text); err != nil {
+				if err := store.PutShared(ctx, text); err != nil {
 					return err
 				}
 				if jsonOut {
@@ -49,7 +44,7 @@ func rememberCmd() *cobra.Command {
 				return nil
 			}
 
-			if err := mem.Remember(ctx, agentID, text); err != nil {
+			if err := store.Remember(ctx, agentID, text); err != nil {
 				return err
 			}
 

--- a/cmd/graymatter/cmd_run.go
+++ b/cmd/graymatter/cmd_run.go
@@ -51,6 +51,14 @@ Examples:
 			}
 
 			// --- Foreground or background child: run the agent ---
+			// Route persistence through the shared store (daemon by default)
+			// so a run never fights the bbolt lock with a TUI or MCP server.
+			store, err := openStore()
+			if err != nil {
+				return err
+			}
+			defer func() { _ = store.Close() }()
+
 			cfg := harness.RunConfig{
 				AgentFile:  agentFile,
 				Inputs:     inputMap,
@@ -59,6 +67,7 @@ Examples:
 				ResumeID:   resumeID,
 				Stdout:     cmd.OutOrStdout(),
 				Stderr:     cmd.ErrOrStderr(),
+				Store:      store,
 			}
 			result, err := harness.Run(context.Background(), cfg)
 			if err != nil {

--- a/cmd/graymatter/cmd_sessions.go
+++ b/cmd/graymatter/cmd_sessions.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,8 +8,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
-	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
 )
 
 func sessionsCmd() *cobra.Command {
@@ -33,7 +30,13 @@ func sessionsListCmd() *cobra.Command {
 		Short: "List all sessions",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			sessions, err := harness.ListSessions(dataDir)
+			store, err := openStore()
+			if err != nil {
+				return err
+			}
+			defer func() { _ = store.Close() }()
+
+			sessions, err := store.SessionsList()
 			if err != nil {
 				return fmt.Errorf("list sessions: %w", err)
 			}
@@ -71,10 +74,31 @@ func sessionsLogsCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sessionID := args[0]
-			if err := harness.StreamLogs(sessionID, dataDir, cmd.OutOrStdout()); err != nil {
+			store, err := openStore()
+			if err != nil {
 				return err
 			}
-			return nil
+			defer func() { _ = store.Close() }()
+
+			sessions, err := store.SessionsList()
+			if err != nil {
+				return fmt.Errorf("list sessions: %w", err)
+			}
+			for _, s := range sessions {
+				if s.ID != sessionID {
+					continue
+				}
+				if s.LogFile == "" {
+					return fmt.Errorf("session %q was not started in background mode (no log file)", sessionID)
+				}
+				data, err := os.ReadFile(s.LogFile)
+				if err != nil {
+					return fmt.Errorf("read log file %q: %w", s.LogFile, err)
+				}
+				_, err = cmd.OutOrStdout().Write(data)
+				return err
+			}
+			return fmt.Errorf("session %q not found", sessionID)
 		},
 	}
 }
@@ -87,16 +111,21 @@ func sessionsKillCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			sessionID := args[0]
 
+			store, err := openStore()
+			if err != nil {
+				return err
+			}
+			defer func() { _ = store.Close() }()
+
 			// Resolve "latest" to a concrete ID.
 			if sessionID == "latest" {
-				rc, err := harness.Resume(context.Background(), "latest", dataDir)
+				sessionID, err = store.SessionResolve("", "latest")
 				if err != nil {
 					return fmt.Errorf("resolve latest: %w", err)
 				}
-				sessionID = rc.ResumeID
 			}
 
-			if err := harness.KillSession(sessionID, dataDir); err != nil {
+			if err := store.SessionKill(sessionID); err != nil {
 				return err
 			}
 			fmt.Printf("Session %s signalled.\n", sessionID)

--- a/cmd/graymatter/cmd_tui.go
+++ b/cmd/graymatter/cmd_tui.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	graymatter "github.com/angelnicolasc/graymatter"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
@@ -124,10 +123,9 @@ const (
 // ── Main model ────────────────────────────────────────────────────────────────
 
 type tuiModel struct {
-	store    graymatter.AdvancedStore
+	store    cliStore
 	dataDir  string
-	graph    *kg.Graph
-	readOnly bool // true when the store is in read-only mode
+	readOnly bool // true when the store is in read-only mode (--no-daemon only)
 
 	// layout
 	activeTab tabID
@@ -196,7 +194,7 @@ func (m tuiModel) loadFacts(agentID string) tea.Cmd {
 
 func (m tuiModel) loadSessions() tea.Cmd {
 	return func() tea.Msg {
-		sessions, err := harness.ListSessionsDB(m.store.DB())
+		sessions, err := m.store.SessionsList()
 		if err != nil {
 			return sessionsLoadedMsg{} // non-fatal
 		}
@@ -209,11 +207,8 @@ func (m tuiModel) loadSessions() tea.Cmd {
 }
 
 func (m tuiModel) loadNodes() tea.Cmd {
-	if m.graph == nil {
-		return nil
-	}
 	return func() tea.Msg {
-		nodes, err := m.graph.AllNodes()
+		nodes, err := m.store.KGNodes()
 		if err != nil {
 			return nodesLoadedMsg{}
 		}
@@ -388,7 +383,7 @@ func (m *tuiModel) updateSessionsKey(msg tea.KeyMsg) []tea.Cmd {
 			return nil
 		}
 		if sel, ok := m.sessionList.SelectedItem().(sessionItem); ok {
-			if err := harness.KillSession(sel.s.ID, m.dataDir); err != nil {
+			if err := m.store.SessionKill(sel.s.ID); err != nil {
 				m.status = "kill: " + err.Error()
 			} else {
 				m.status = "Killed " + sel.s.ID[:8]
@@ -561,9 +556,9 @@ func (m tuiModel) renderSessions(h int) string {
 // ── Graph tab ─────────────────────────────────────────────────────────────────
 
 func (m tuiModel) renderGraph(h int) string {
-	if m.graph == nil {
+	if len(m.nodeList.Items()) == 0 {
 		return styleBorderInactive.Width(m.width - 4).Height(h - 2).
-			Render(styleDimText.Render("\n  Knowledge graph not initialised.\n  Run `graymatter init` and store some memories first."))
+			Render(styleDimText.Render("\n  Knowledge graph empty.\n  Run `graymatter init` and store some memories first."))
 	}
 	leftW := m.width * 2 / 5
 	leftPane := styleBorderInactive.Width(leftW - 2).Height(h - 2).Render(m.nodeList.View())
@@ -642,31 +637,21 @@ Views (switch with 1-4 or tab/shift+tab):
   3. Graph    — browse knowledge graph nodes and edges
   4. Stats    — observability dashboard (KPIs, agent activity, weight distribution, 30d sparkline)
 
-If another process (e.g. opencode) holds the store write-lock, the TUI opens
-automatically in read-only mode. Use --read-only to force this from the start.`,
+By default the TUI connects to the store daemon, so it runs fine alongside an
+MCP server, opencode, or another TUI. --read-only applies only with --no-daemon
+(direct in-process open), where it forces a non-mutating open.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := graymatter.DefaultConfig()
-			cfg.DataDir = dataDir
-			cfg.ReadOnly = forceReadOnly
+			// --read-only only makes sense for the direct (--no-daemon) path;
+			// through the daemon every client is a full read/write peer.
+			if forceReadOnly {
+				noDaemon = true
+			}
 
-			mem, err := graymatter.NewWithConfig(cfg)
+			store, err := openStore()
 			if err != nil {
 				return err
 			}
-			defer mem.Close()
-
-			store := mem.Advanced()
-			if store == nil {
-				return fmt.Errorf("store not initialised")
-			}
-
-			// Optional: open KG graph if db is available.
-			var graph *kg.Graph
-			if db := store.DB(); db != nil {
-				if g, err := kg.Open(db); err == nil {
-					graph = g
-				}
-			}
+			defer func() { _ = store.Close() }()
 
 			newList := func(title string) list.Model {
 				l := list.New(nil, list.NewDefaultDelegate(), 40, 20)
@@ -679,7 +664,6 @@ automatically in read-only mode. Use --read-only to force this from the start.`,
 			m := tuiModel{
 				store:       store,
 				dataDir:     dataDir,
-				graph:       graph,
 				readOnly:    store.IsReadOnly(),
 				agentList:   newList("Agents"),
 				factList:    newList("Facts"),
@@ -696,6 +680,6 @@ automatically in read-only mode. Use --read-only to force this from the start.`,
 	}
 
 	cmd.Flags().BoolVar(&forceReadOnly, "read-only", false,
-		"open store in read-only mode (skips all mutating operations)")
+		"with --no-daemon: open the store read-only (skips all mutating operations)")
 	return cmd
 }

--- a/cmd/graymatter/internal/audit/audit.go
+++ b/cmd/graymatter/internal/audit/audit.go
@@ -1,0 +1,43 @@
+// Package audit persists the agent self-edit trail (memory_reflect actions)
+// to the kg_audit bbolt bucket. It is shared by the MCP server (direct mode)
+// and the daemon host service (client mode) so both write the same format.
+package audit
+
+import (
+	"encoding/json"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+var bucketAudit = []byte("kg_audit")
+
+// Entry is one self-edit event. Timestamps are UTC.
+type Entry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Action    string    `json:"action"`
+	Agent     string    `json:"agent"`
+	OldText   string    `json:"old_text,omitempty"`
+	NewText   string    `json:"new_text"`
+	Source    string    `json:"source"`
+}
+
+// Write persists entry best-effort: audit must never fail the operation it
+// records, so errors are deliberately swallowed.
+func Write(db *bolt.DB, entry Entry) {
+	if db == nil {
+		return
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	key := []byte(entry.Timestamp.Format(time.RFC3339Nano) + "_" + entry.Action + "_" + entry.Agent)
+	_ = db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(bucketAudit)
+		if err != nil {
+			return err
+		}
+		return b.Put(key, data)
+	})
+}

--- a/cmd/graymatter/internal/daemon/client.go
+++ b/cmd/graymatter/internal/daemon/client.go
@@ -1,0 +1,272 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
+)
+
+// Client is a connection to the daemon: the embedded rpc.Client provides the
+// core store surface (Put/Recall/List/Stats/...), and the typed methods here
+// cover the host-level service (checkpoints, sessions, KG, audit, tokens).
+type Client struct {
+	*rpc.Client
+	dataDir string
+}
+
+const hostCallTimeout = 30 * time.Second
+
+// connectBudget bounds the total dial+spawn+retry sequence. Daemon cold
+// start is dominated by bbolt open + listen — well under a second on local
+// disks — so this is generous headroom, not expected latency.
+const connectBudget = 10 * time.Second
+
+// Connect dials the daemon for dataDir, starting one if none is running.
+//
+// The spawn race is benign by construction: any number of clients may spawn
+// daemons concurrently, but only the bbolt lock winner survives to write the
+// discovery file; every loser exits and every client converges on the winner
+// through the retry loop.
+func Connect(dataDir string) (*Client, error) {
+	return connect(dataDir, true)
+}
+
+// ConnectNoSpawn dials the daemon for dataDir but never starts one. For
+// `daemon status` / `daemon stop`, where spawning would defeat the point.
+func ConnectNoSpawn(dataDir string) (*Client, error) {
+	return connect(dataDir, false)
+}
+
+func connect(dataDir string, allowSpawn bool) (*Client, error) {
+	absDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("daemon: resolve data dir: %w", err)
+	}
+
+	dial := func() (*rpc.Client, error) {
+		return rpc.Dial(rpc.DialOptions{DataDir: absDir, PingOnDial: true})
+	}
+
+	// Fast path: daemon already up.
+	if c, err := dial(); err == nil {
+		return &Client{Client: c, dataDir: absDir}, nil
+	} else if !allowSpawn {
+		return nil, fmt.Errorf("daemon not reachable at %s: %w", absDir, err)
+	}
+
+	if err := spawnDaemon(absDir); err != nil {
+		return nil, fmt.Errorf("daemon not running and auto-start failed: %w", err)
+	}
+
+	// Retry with backoff while the daemon cold-starts (or a racing winner
+	// finishes writing its discovery file).
+	deadline := time.Now().Add(connectBudget)
+	wait := 25 * time.Millisecond
+	var lastErr error
+	for time.Now().Before(deadline) {
+		time.Sleep(wait)
+		if wait < 400*time.Millisecond {
+			wait = wait * 8 / 5
+		}
+		c, err := dial()
+		if err == nil {
+			return &Client{Client: c, dataDir: absDir}, nil
+		}
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf(
+		"daemon did not come up within %s: %w%s\nhint: another process may hold %s open (a Go program embedding the graymatter library?); `graymatter doctor` can diagnose this",
+		connectBudget, lastErr, daemonLogTail(absDir), filepath.Join(absDir, "gray.db"))
+}
+
+// DataDir returns the absolute data directory this client is bound to.
+func (c *Client) DataDir() string { return c.dataDir }
+
+// resolveExecutable returns the path of the binary to spawn as the daemon.
+// Overridable in tests so they can point at a freshly built graymatter
+// binary instead of the test runner.
+var resolveExecutable = os.Executable
+
+// spawnDaemon launches `graymatter daemon run` detached, with stdout/stderr
+// appended to <dataDir>/daemon.log.
+func spawnDaemon(absDir string) error {
+	exe, err := resolveExecutable()
+	if err != nil {
+		return fmt.Errorf("locate own binary: %w", err)
+	}
+	if err := os.MkdirAll(absDir, 0o755); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+	logFile, err := os.OpenFile(filepath.Join(absDir, "daemon.log"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open daemon.log: %w", err)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	cmd := exec.Command(exe, "daemon", "run",
+		"--dir", absDir,
+		"--idle-exit", DefaultIdleExit.String())
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = detachSysProcAttr()
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s daemon run: %w", exe, err)
+	}
+	// Detach fully: the daemon outlives us and we must not leave a zombie
+	// behind when it exits first.
+	return cmd.Process.Release()
+}
+
+// daemonLogTail returns the last few lines of daemon.log formatted for
+// appending to an error message, or "" if the log is unreadable.
+func daemonLogTail(absDir string) string {
+	data, err := os.ReadFile(filepath.Join(absDir, "daemon.log"))
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > 6 {
+		lines = lines[len(lines)-6:]
+	}
+	return "\ndaemon.log (tail):\n  " + strings.Join(lines, "\n  ")
+}
+
+// --- typed host-service methods ----------------------------------------------
+
+func (c *Client) hostCall(method string, req, resp any) error {
+	return c.CallService(HostServiceName, method, req, resp, hostCallTimeout)
+}
+
+// CheckpointSave persists cp on the daemon and returns it with ID assigned.
+func (c *Client) CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error) {
+	var resp CheckpointSaveResponse
+	if err := c.hostCall("CheckpointSave", &CheckpointSaveRequest{CP: cp}, &resp); err != nil {
+		return session.Checkpoint{}, err
+	}
+	return resp.CP, nil
+}
+
+// CheckpointLoad retrieves one checkpoint by ID.
+func (c *Client) CheckpointLoad(agentID, checkpointID string) (*session.Checkpoint, error) {
+	var resp CheckpointLoadResponse
+	if err := c.hostCall("CheckpointLoad", &CheckpointLoadRequest{AgentID: agentID, CheckpointID: checkpointID}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.CP, nil
+}
+
+// CheckpointResume retrieves the most recent checkpoint for agentID.
+func (c *Client) CheckpointResume(agentID string) (*session.Checkpoint, error) {
+	var resp CheckpointResumeResponse
+	if err := c.hostCall("CheckpointResume", &CheckpointResumeRequest{AgentID: agentID}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.CP, nil
+}
+
+// CheckpointList returns all checkpoints for agentID, newest first.
+func (c *Client) CheckpointList(agentID string) ([]session.Checkpoint, error) {
+	var resp CheckpointListResponse
+	if err := c.hostCall("CheckpointList", &CheckpointListRequest{AgentID: agentID}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.CPs, nil
+}
+
+// SessionsList returns all harness session records, newest first.
+func (c *Client) SessionsList() ([]harness.HarnessSession, error) {
+	var resp SessionListResponse
+	if err := c.hostCall("SessionList", &SessionListRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Sessions, nil
+}
+
+// SessionSave persists a harness session record.
+func (c *Client) SessionSave(hs harness.HarnessSession) error {
+	return c.hostCall("SessionSave", &SessionSaveRequest{S: hs}, &SessionSaveResponse{})
+}
+
+// SessionKill terminates a running background session by ID.
+func (c *Client) SessionKill(id string) error {
+	return c.hostCall("SessionKill", &SessionKillRequest{ID: id}, &SessionKillResponse{})
+}
+
+// SessionResolve resolves "latest" (optionally per-agent) to a concrete ID.
+func (c *Client) SessionResolve(agentID, sessionID string) (string, error) {
+	var resp SessionResolveResponse
+	if err := c.hostCall("SessionResolve", &SessionResolveRequest{AgentID: agentID, SessionID: sessionID}, &resp); err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// KGNodes returns every knowledge-graph node (empty when no graph exists).
+func (c *Client) KGNodes() ([]kg.Node, error) {
+	var resp KGNodesResponse
+	if err := c.hostCall("KGNodes", &KGNodesRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Nodes, nil
+}
+
+// KGLink creates an edge between two nodes on the daemon's graph.
+func (c *Client) KGLink(from, to, relation string) error {
+	return c.hostCall("KGLink", &KGLinkRequest{From: from, To: to, Relation: relation}, &KGLinkResponse{})
+}
+
+// KGUpsert inserts or updates a node on the daemon's graph.
+func (c *Client) KGUpsert(id, label, entityType string) error {
+	return c.hostCall("KGUpsert", &KGUpsertRequest{ID: id, Label: label, EntityType: entityType}, &KGUpsertResponse{})
+}
+
+// AuditWrite records an agent self-edit event.
+func (c *Client) AuditWrite(e audit.Entry) error {
+	return c.hostCall("AuditWrite", &AuditWriteRequest{E: e}, &AuditWriteResponse{})
+}
+
+// TokenRecord adds token usage to the daemon's pre-aggregated ledger.
+func (c *Client) TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error {
+	return c.hostCall("TokenRecord", &TokenRecordRequest{
+		Agent: agent, Model: model,
+		Input: input, Output: output, CacheRead: cacheRead, CacheWrite: cacheWrite,
+	}, &TokenRecordResponse{})
+}
+
+// TokenSummary aggregates the token ledger over the trailing N days.
+func (c *Client) TokenSummary(days int) (harness.TokenUsageSummary, error) {
+	var resp TokenSummaryResponse
+	if err := c.hostCall("TokenSummary", &TokenSummaryRequest{Days: days}, &resp); err != nil {
+		return harness.TokenUsageSummary{}, err
+	}
+	return resp.S, nil
+}
+
+// Shutdown asks the daemon to stop gracefully.
+func (c *Client) Shutdown() error {
+	return c.CallService(HostServiceName, "Shutdown", &ShutdownRequest{}, &ShutdownResponse{}, 5*time.Second)
+}
+
+// Remember stores a fact with full Remember semantics (the daemon backend
+// routes Put through Memory.Remember, async consolidation included).
+func (c *Client) Remember(ctx context.Context, agentID, text string) error {
+	return c.Put(ctx, agentID, text)
+}
+
+// RecallDefault recalls with the daemon's configured TopK.
+func (c *Client) RecallDefault(ctx context.Context, agentID, query string) ([]string, error) {
+	return c.Recall(ctx, agentID, query, 0)
+}

--- a/cmd/graymatter/internal/daemon/daemon.go
+++ b/cmd/graymatter/internal/daemon/daemon.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
+)
+
+// DefaultIdleExit is how long a client-spawned daemon survives with no
+// connected clients and no traffic before exiting on its own. One-shot CLI
+// bursts (remember → recall → export) reuse the warm daemon; an abandoned
+// one reaps itself.
+const DefaultIdleExit = 2 * time.Minute
+
+// RunOptions configures a daemon run.
+type RunOptions struct {
+	// DataDir is the .graymatter directory to own. Made absolute internally
+	// so the daemon is immune to client cwd differences.
+	DataDir string
+
+	// IdleExit shuts the daemon down after this long with zero connected
+	// clients and no RPC traffic. 0 disables idle-exit (for service-manager
+	// setups where systemd/launchd owns the lifecycle).
+	IdleExit time.Duration
+
+	// Logf receives lifecycle log lines. Defaults to a stderr printer.
+	Logf func(format string, v ...any)
+}
+
+// Run starts the daemon in the foreground and blocks until shutdown
+// (signal, Shutdown RPC, idle-exit, or listener error).
+//
+// Ordering is load-bearing for the concurrent-start race: the bbolt lock is
+// acquired FIRST (strict write — a daemon that cannot own the store must
+// die loudly, not degrade to read-only), and only the lock winner writes
+// the discovery file. A second daemon racing here fails its open within the
+// lock timeout and exits; the spawning client just retries the dial and
+// reaches the winner.
+func Run(opts RunOptions) error {
+	logf := opts.Logf
+	if logf == nil {
+		logf = func(format string, v ...any) { fmt.Fprintf(os.Stderr, format+"\n", v...) }
+	}
+
+	absDir, err := filepath.Abs(opts.DataDir)
+	if err != nil {
+		return fmt.Errorf("daemon: resolve data dir: %w", err)
+	}
+
+	cfg := graymatter.DefaultConfig()
+	cfg.DataDir = absDir
+	cfg.StrictWrite = true
+
+	mem, err := graymatter.NewWithConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("daemon: %w", err)
+	}
+	defer func() { _ = mem.Close() }()
+
+	adv := mem.Advanced()
+	db := adv.DB()
+
+	var graph *kg.Graph
+	var adapter *kg.GraphAdapter
+	if g, err := kg.Open(db); err == nil {
+		graph = g
+		adapter = kg.NewGraphAdapter(g)
+	}
+
+	token, err := rpc.GenerateToken()
+	if err != nil {
+		return fmt.Errorf("daemon: %w", err)
+	}
+
+	srv := rpc.NewServer(rememberBackend{AdvancedStore: adv, mem: mem}, cfg)
+	srv.SetAuthToken(token)
+	srv.RegisterExtra(HostServiceName, &Host{
+		mem:     mem,
+		db:      db,
+		graph:   graph,
+		adapter: adapter,
+		stop:    srv.Stop,
+	})
+
+	ln, cleanup, err := rpc.Listen(absDir, token)
+	if err != nil {
+		return fmt.Errorf("daemon: %w", err)
+	}
+	defer cleanup()
+
+	if err := writePIDFile(absDir); err != nil {
+		logf("daemon: write pid file: %v (continuing)", err)
+	}
+	defer removePIDFile(absDir)
+
+	// Signal-driven shutdown.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		if _, ok := <-sigCh; ok {
+			logf("daemon: signal received, shutting down")
+			srv.Stop()
+		}
+	}()
+
+	// Idle-exit loop.
+	if opts.IdleExit > 0 {
+		go func() {
+			t := time.NewTicker(5 * time.Second)
+			defer t.Stop()
+			for range t.C {
+				if srv.ActiveConns() == 0 && time.Since(srv.LastActivity()) >= opts.IdleExit {
+					logf("daemon: idle for %s with no clients, exiting", opts.IdleExit)
+					srv.Stop()
+					return
+				}
+			}
+		}()
+	}
+
+	addr, _ := rpc.DiscoveryAddr(absDir)
+	logf("graymatter daemon ready: dir=%s addr=%s pid=%d idle-exit=%s",
+		absDir, addr, os.Getpid(), idleExitLabel(opts.IdleExit))
+
+	err = srv.Serve(ln)
+	logf("daemon: stopped")
+	return err
+}
+
+func idleExitLabel(d time.Duration) string {
+	if d <= 0 {
+		return "disabled"
+	}
+	return d.String()
+}
+
+func writePIDFile(dataDir string) error {
+	return os.WriteFile(rpc.PIDFilePath(dataDir), []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600)
+}
+
+func removePIDFile(dataDir string) {
+	_ = os.Remove(rpc.PIDFilePath(dataDir))
+}
+
+// ReadPIDFile returns the daemon PID recorded in dataDir, or 0 if absent.
+func ReadPIDFile(dataDir string) int {
+	data, err := os.ReadFile(rpc.PIDFilePath(dataDir))
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}

--- a/cmd/graymatter/internal/daemon/daemon_integration_test.go
+++ b/cmd/graymatter/internal/daemon/daemon_integration_test.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
+)
+
+// buildBinary compiles the graymatter binary once per test run and returns
+// its path. Spawn-on-connect re-invokes this binary as `daemon run`.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "graymatter")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", out,
+		"github.com/angelnicolasc/graymatter/cmd/graymatter")
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build graymatter: %v\n%s", err, combined)
+	}
+	return out
+}
+
+// withBuiltDaemon points spawn-on-connect at a freshly built binary for the
+// duration of the test.
+func withBuiltDaemon(t *testing.T) {
+	t.Helper()
+	bin := buildBinary(t)
+	prev := resolveExecutable
+	resolveExecutable = func() (string, error) { return bin, nil }
+	t.Cleanup(func() { resolveExecutable = prev })
+}
+
+// TestConnect_SpawnsDaemonAndWrites is the end-to-end issue #8 acceptance
+// test: with no daemon running, Connect must start one and a write must
+// round-trip through it.
+func TestConnect_SpawnsDaemonAndWrites(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary; skipped in -short")
+	}
+	withBuiltDaemon(t)
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	c, err := Connect(dir)
+	if err != nil {
+		t.Fatalf("Connect (should auto-spawn): %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if err := c.Remember(ctx, "agent-a", "first fact through the daemon"); err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	facts, err := c.List("agent-a")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("got %d facts, want 1", len(facts))
+	}
+
+	// A daemon must be reachable now without spawning.
+	if pid := ReadPIDFile(dir); pid == 0 {
+		t.Error("expected a daemon pid file after spawn")
+	}
+
+	if err := c.Shutdown(); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+}
+
+// TestConcurrentClients_ThroughDaemon mirrors the real #4 / #9 scenario:
+// several independent clients (think TUI + MCP server + a CLI command) all
+// writing to the same data dir at once, which the single-writer bbolt lock
+// would otherwise forbid.
+func TestConcurrentClients_ThroughDaemon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary; skipped in -short")
+	}
+	withBuiltDaemon(t)
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// First connection spawns the daemon; keep it open so the daemon stays
+	// up for the whole test.
+	lead, err := Connect(dir)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = lead.Close() }()
+
+	const clients = 4
+	const writes = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, clients)
+	for i := 0; i < clients; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			c, err := Connect(dir) // existing daemon: no second spawn
+			if err != nil {
+				errCh <- fmt.Errorf("client %d connect: %w", id, err)
+				return
+			}
+			defer func() { _ = c.Close() }()
+			for j := 0; j < writes; j++ {
+				if err := c.Remember(ctx, "swarm", fmt.Sprintf("c%d-%d", id, j)); err != nil {
+					errCh <- fmt.Errorf("client %d remember %d: %w", id, j, err)
+					return
+				}
+			}
+			errCh <- nil
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	facts, err := lead.List("swarm")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) != clients*writes {
+		t.Fatalf("got %d facts, want %d (lost writes = lock contention)", len(facts), clients*writes)
+	}
+
+	_ = lead.Shutdown()
+}
+
+// TestIdleExit verifies a client-spawned daemon reaps itself after the idle
+// window once every client disconnects.
+func TestIdleExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a daemon; skipped in -short")
+	}
+	dir := t.TempDir()
+
+	// Run the daemon directly with a tiny idle window in a goroutine.
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(RunOptions{
+			DataDir:  dir,
+			IdleExit: 1 * time.Second,
+			Logf:     func(string, ...any) {},
+		})
+	}()
+
+	// Wait for it to come up.
+	deadline := time.Now().Add(5 * time.Second)
+	var c *Client
+	for time.Now().Before(deadline) {
+		if cl, err := rpc.Dial(rpc.DialOptions{DataDir: dir}); err == nil {
+			c = &Client{Client: cl, dataDir: dir}
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if c == nil {
+		t.Fatal("daemon did not come up")
+	}
+	// Disconnect so the idle clock can start.
+	_ = c.Close()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("daemon exited with error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("daemon did not idle-exit within 15s")
+	}
+}

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -1,0 +1,276 @@
+// Package daemon implements GrayMatter daemon mode (issue #8): one process
+// owns the bbolt store and serves it over the local RPC endpoint from
+// pkg/memory/rpc; every other process — TUI, MCP server, one-shot CLI
+// commands, the run harness — connects as a client. This removes the
+// single-writer lock fights between concurrent graymatter processes.
+//
+// The package has three parts:
+//
+//   - Host: the daemon-side RPC service exposing binary-level subsystems
+//     (checkpoints, harness sessions, knowledge graph, audit, token ledger)
+//     that the core store service in pkg/memory/rpc deliberately knows
+//     nothing about.
+//   - Run: the daemon lifecycle — strict-write store open, listener +
+//     discovery file, pidfile, idle-exit, signal handling.
+//   - Connect: the client side — dial, spawn-on-absent with backoff, and
+//     typed wrappers for every host method.
+package daemon
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+)
+
+// HostServiceName is the net/rpc service name for the host-level service,
+// registered next to the core store service on the same listener.
+const HostServiceName = "GrayMatterHost"
+
+// Host is the daemon-side receiver for host-level RPCs.
+type Host struct {
+	mem     *graymatter.Memory
+	db      *bolt.DB
+	graph   *kg.Graph
+	adapter *kg.GraphAdapter
+	stop    func() // initiates graceful daemon shutdown
+}
+
+// --- wire types -------------------------------------------------------------
+
+type CheckpointSaveRequest struct{ CP session.Checkpoint }
+type CheckpointSaveResponse struct{ CP session.Checkpoint }
+
+type CheckpointLoadRequest struct{ AgentID, CheckpointID string }
+type CheckpointLoadResponse struct{ CP session.Checkpoint }
+
+type CheckpointResumeRequest struct{ AgentID string }
+type CheckpointResumeResponse struct{ CP session.Checkpoint }
+
+type CheckpointListRequest struct{ AgentID string }
+type CheckpointListResponse struct{ CPs []session.Checkpoint }
+
+type SessionListRequest struct{}
+type SessionListResponse struct{ Sessions []harness.HarnessSession }
+
+type SessionSaveRequest struct{ S harness.HarnessSession }
+type SessionSaveResponse struct{}
+
+type SessionKillRequest struct{ ID string }
+type SessionKillResponse struct{}
+
+type SessionResolveRequest struct{ AgentID, SessionID string }
+type SessionResolveResponse struct{ ID string }
+
+type KGNodesRequest struct{}
+type KGNodesResponse struct{ Nodes []kg.Node }
+
+type KGLinkRequest struct{ From, To, Relation string }
+type KGLinkResponse struct{}
+
+type KGUpsertRequest struct{ ID, Label, EntityType string }
+type KGUpsertResponse struct{}
+
+type AuditWriteRequest struct{ E audit.Entry }
+type AuditWriteResponse struct{}
+
+type TokenRecordRequest struct {
+	Agent, Model                         string
+	Input, Output, CacheRead, CacheWrite uint64
+}
+type TokenRecordResponse struct{}
+
+type TokenSummaryRequest struct{ Days int }
+type TokenSummaryResponse struct{ S harness.TokenUsageSummary }
+
+type ShutdownRequest struct{}
+type ShutdownResponse struct{}
+
+// --- handlers ---------------------------------------------------------------
+
+var errNoKG = errors.New("knowledge graph not available on the daemon")
+
+// CheckpointSave persists a checkpoint and returns it with ID/timestamps set.
+func (h *Host) CheckpointSave(req *CheckpointSaveRequest, resp *CheckpointSaveResponse) error {
+	saved, err := session.Save(h.db, req.CP)
+	if err != nil {
+		return err
+	}
+	resp.CP = saved
+	return nil
+}
+
+// CheckpointLoad retrieves one checkpoint by ID.
+func (h *Host) CheckpointLoad(req *CheckpointLoadRequest, resp *CheckpointLoadResponse) error {
+	cp, err := session.Load(h.db, req.AgentID, req.CheckpointID)
+	if err != nil {
+		return err
+	}
+	resp.CP = *cp
+	return nil
+}
+
+// CheckpointResume retrieves the most recent checkpoint for an agent.
+func (h *Host) CheckpointResume(req *CheckpointResumeRequest, resp *CheckpointResumeResponse) error {
+	cp, err := session.Resume(h.db, req.AgentID)
+	if err != nil {
+		return err
+	}
+	resp.CP = *cp
+	return nil
+}
+
+// CheckpointList returns all checkpoints for an agent, newest first.
+func (h *Host) CheckpointList(req *CheckpointListRequest, resp *CheckpointListResponse) error {
+	cps, err := session.List(h.db, req.AgentID)
+	if err != nil {
+		return err
+	}
+	resp.CPs = cps
+	return nil
+}
+
+// SessionList returns all harness session records, newest first.
+func (h *Host) SessionList(req *SessionListRequest, resp *SessionListResponse) error {
+	sessions, err := harness.ListSessionsDB(h.db)
+	if err != nil {
+		return err
+	}
+	resp.Sessions = sessions
+	return nil
+}
+
+// SessionSave persists a harness session record.
+func (h *Host) SessionSave(req *SessionSaveRequest, resp *SessionSaveResponse) error {
+	return harness.SaveSessionDB(h.db, req.S)
+}
+
+// SessionKill signals the recorded PID for a running session and marks it killed.
+func (h *Host) SessionKill(req *SessionKillRequest, resp *SessionKillResponse) error {
+	return harness.KillSessionDB(h.db, req.ID)
+}
+
+// SessionResolve resolves "latest" (optionally per-agent) to a concrete session ID.
+func (h *Host) SessionResolve(req *SessionResolveRequest, resp *SessionResolveResponse) error {
+	id, err := harness.ResolveSessionIDDB(h.db, req.AgentID, req.SessionID)
+	if err != nil {
+		return err
+	}
+	resp.ID = id
+	return nil
+}
+
+// KGNodes returns every knowledge-graph node.
+func (h *Host) KGNodes(req *KGNodesRequest, resp *KGNodesResponse) error {
+	if h.graph == nil {
+		resp.Nodes = nil
+		return nil
+	}
+	nodes, err := h.graph.AllNodes()
+	if err != nil {
+		return err
+	}
+	resp.Nodes = nodes
+	return nil
+}
+
+// KGLink creates an edge between two nodes.
+func (h *Host) KGLink(req *KGLinkRequest, resp *KGLinkResponse) error {
+	if h.adapter == nil {
+		return errNoKG
+	}
+	return h.adapter.LinkNodes(req.From, req.To, req.Relation)
+}
+
+// KGUpsert inserts or updates a node.
+func (h *Host) KGUpsert(req *KGUpsertRequest, resp *KGUpsertResponse) error {
+	if h.adapter == nil {
+		return errNoKG
+	}
+	return h.adapter.UpsertNode(req.ID, req.Label, req.EntityType)
+}
+
+// AuditWrite records an agent self-edit event. Best-effort by design.
+func (h *Host) AuditWrite(req *AuditWriteRequest, resp *AuditWriteResponse) error {
+	audit.Write(h.db, req.E)
+	return nil
+}
+
+// TokenRecord adds token usage to the pre-aggregated ledger.
+func (h *Host) TokenRecord(req *TokenRecordRequest, resp *TokenRecordResponse) error {
+	return harness.RecordTokenUsage(h.db, req.Agent, req.Model, req.Input, req.Output, req.CacheRead, req.CacheWrite)
+}
+
+// TokenSummary aggregates the token ledger over the trailing N days.
+func (h *Host) TokenSummary(req *TokenSummaryRequest, resp *TokenSummaryResponse) error {
+	s, err := harness.LoadTokenUsageSummary(h.db, req.Days)
+	if err != nil {
+		return err
+	}
+	resp.S = s
+	return nil
+}
+
+// Shutdown asks the daemon to stop gracefully. The stop is deferred a beat so
+// the RPC reply reaches the client before connections are torn down.
+func (h *Host) Shutdown(req *ShutdownRequest, resp *ShutdownResponse) error {
+	if h.stop != nil {
+		go func() {
+			time.Sleep(150 * time.Millisecond)
+			h.stop()
+		}()
+	}
+	return nil
+}
+
+// --- daemon-side core backend ----------------------------------------------
+
+// rememberBackend adapts *graymatter.Memory to the core rpc.Backend so that
+// remote Puts get full Remember semantics (async consolidation included) and
+// remote Recalls with TopK<=0 use the daemon's configured TopK.
+type rememberBackend struct {
+	graymatter.AdvancedStore
+	mem *graymatter.Memory
+}
+
+func (b rememberBackend) Put(ctx context.Context, agentID, text string) error {
+	return b.mem.Remember(ctx, agentID, text)
+}
+
+func (b rememberBackend) PutShared(ctx context.Context, text string) error {
+	return b.mem.RememberShared(ctx, text)
+}
+
+func (b rememberBackend) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return b.mem.Recall(ctx, agentID, query)
+	}
+	return b.AdvancedStore.Recall(ctx, agentID, query, topK)
+}
+
+func (b rememberBackend) RecallShared(ctx context.Context, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return b.mem.RecallShared(ctx, query)
+	}
+	return b.AdvancedStore.RecallShared(ctx, query, topK)
+}
+
+func (b rememberBackend) RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return b.mem.RecallAll(ctx, agentID, query)
+	}
+	// AdvancedStore does not expose RecallAll; the concrete store does.
+	if ra, ok := b.AdvancedStore.(interface {
+		RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	}); ok {
+		return ra.RecallAll(ctx, agentID, query, topK)
+	}
+	return b.mem.RecallAll(ctx, agentID, query)
+}

--- a/cmd/graymatter/internal/daemon/host_test.go
+++ b/cmd/graymatter/internal/daemon/host_test.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+)
+
+// connectFresh spawns a daemon for a temp dir and returns a connected client.
+func connectFresh(t *testing.T) *Client {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("builds a binary; skipped in -short")
+	}
+	withBuiltDaemon(t)
+	dir := t.TempDir()
+	c, err := Connect(dir)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Shutdown(); _ = c.Close() })
+	return c
+}
+
+// TestHostService_CoreSurface drives the full client surface against a real
+// daemon: the memory operations plus every host-service method (checkpoints,
+// sessions, KG, audit, tokens). This is the contract the TUI, MCP server, and
+// CLI all depend on.
+func TestHostService_CoreSurface(t *testing.T) {
+	c := connectFresh(t)
+	ctx := context.Background()
+
+	// --- memory surface ---
+	if err := c.Remember(ctx, "agent-a", "alpha fact"); err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	if err := c.PutShared(ctx, "shared fact"); err != nil {
+		t.Fatalf("PutShared: %v", err)
+	}
+	if got, err := c.RecallDefault(ctx, "agent-a", "alpha"); err != nil || len(got) == 0 {
+		t.Fatalf("RecallDefault = %v, %v", got, err)
+	}
+	if got, err := c.RecallShared(ctx, "shared", 5); err != nil || len(got) == 0 {
+		t.Fatalf("RecallShared = %v, %v", got, err)
+	}
+	if got, err := c.RecallAll(ctx, "agent-a", "fact", 0); err != nil || len(got) == 0 {
+		t.Fatalf("RecallAll = %v, %v", got, err)
+	}
+	agents, err := c.ListAgents()
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) == 0 {
+		t.Fatal("ListAgents empty")
+	}
+	facts, err := c.List("agent-a")
+	if err != nil || len(facts) != 1 {
+		t.Fatalf("List = %v, %v", facts, err)
+	}
+	if st, err := c.Stats("agent-a"); err != nil || st.FactCount != 1 {
+		t.Fatalf("Stats = %+v, %v", st, err)
+	}
+	// UpdateFact (weight to 0), then Delete.
+	f := facts[0]
+	f.Weight = 0.5
+	if err := c.UpdateFact("agent-a", f); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+	if err := c.Delete("agent-a", f.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if n, err := c.PendingVectorCount(); err != nil || n != 0 {
+		t.Fatalf("PendingVectorCount = %d, %v", n, err)
+	}
+
+	// --- checkpoints ---
+	saved, err := c.CheckpointSave(session.Checkpoint{
+		AgentID:  "agent-a",
+		State:    map[string]any{"k": "v"},
+		Messages: []session.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil || saved.ID == "" {
+		t.Fatalf("CheckpointSave = %+v, %v", saved, err)
+	}
+	if got, err := c.CheckpointResume("agent-a"); err != nil || got.ID != saved.ID {
+		t.Fatalf("CheckpointResume = %+v, %v", got, err)
+	}
+	if got, err := c.CheckpointLoad("agent-a", saved.ID); err != nil || got.ID != saved.ID {
+		t.Fatalf("CheckpointLoad = %+v, %v", got, err)
+	}
+	if cps, err := c.CheckpointList("agent-a"); err != nil || len(cps) != 1 {
+		t.Fatalf("CheckpointList = %v, %v", cps, err)
+	}
+
+	// --- sessions ---
+	hs := harness.HarnessSession{ID: "sess-1", AgentID: "agent-a", AgentFile: "a.md", Status: "done"}
+	if err := c.SessionSave(hs); err != nil {
+		t.Fatalf("SessionSave: %v", err)
+	}
+	sessions, err := c.SessionsList()
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("SessionsList = %v, %v", sessions, err)
+	}
+	if id, err := c.SessionResolve("agent-a", "latest"); err != nil || id != "sess-1" {
+		t.Fatalf("SessionResolve = %q, %v", id, err)
+	}
+	// Kill a non-running session: must error clearly, not panic.
+	if err := c.SessionKill("sess-1"); err == nil {
+		t.Error("SessionKill on a non-running session should error")
+	}
+
+	// --- knowledge graph ---
+	if err := c.KGUpsert("node-a", "Node A", "concept"); err != nil {
+		t.Fatalf("KGUpsert a: %v", err)
+	}
+	if err := c.KGUpsert("node-b", "Node B", "concept"); err != nil {
+		t.Fatalf("KGUpsert b: %v", err)
+	}
+	if err := c.KGLink("node-a", "node-b", "relates_to"); err != nil {
+		t.Fatalf("KGLink: %v", err)
+	}
+	nodes, err := c.KGNodes()
+	if err != nil {
+		t.Fatalf("KGNodes: %v", err)
+	}
+	if len(nodes) < 2 {
+		t.Fatalf("KGNodes = %d, want >= 2", len(nodes))
+	}
+
+	// --- audit ---
+	if err := c.AuditWrite(audit.Entry{Action: "forget", Agent: "agent-a", NewText: "x", Source: "test"}); err != nil {
+		t.Fatalf("AuditWrite: %v", err)
+	}
+
+	// --- token ledger ---
+	if err := c.TokenRecord("agent-a", "claude-sonnet-4-6", 100, 50, 10, 5); err != nil {
+		t.Fatalf("TokenRecord: %v", err)
+	}
+	sum, err := c.TokenSummary(30)
+	if err != nil {
+		t.Fatalf("TokenSummary: %v", err)
+	}
+	if !sum.Loaded || sum.Requests != 1 {
+		t.Fatalf("TokenSummary = %+v, want Loaded with 1 request", sum)
+	}
+}
+
+// TestConnect_NoSpawnWhenAbsent verifies ConnectNoSpawn does not start a
+// daemon and reports a clear error.
+func TestConnect_NoSpawnWhenAbsent(t *testing.T) {
+	_, err := ConnectNoSpawn(t.TempDir())
+	if err == nil {
+		t.Fatal("ConnectNoSpawn should fail when no daemon is running")
+	}
+	if !strings.Contains(err.Error(), "not reachable") {
+		t.Errorf("error %q should say the daemon is not reachable", err)
+	}
+}

--- a/cmd/graymatter/internal/daemon/spawn_unix.go
+++ b/cmd/graymatter/internal/daemon/spawn_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package daemon
+
+import "syscall"
+
+// detachSysProcAttr starts the daemon in a new session (Setsid), detached
+// from the spawning client's controlling terminal so it survives the client.
+func detachSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/graymatter/internal/daemon/spawn_windows.go
+++ b/cmd/graymatter/internal/daemon/spawn_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package daemon
+
+import "syscall"
+
+const (
+	detachedProcess    = 0x00000008
+	createNewProcGroup = 0x00000200
+)
+
+// detachSysProcAttr starts the daemon detached from the spawning client's
+// console (DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP) so it survives the
+// client and never pops a window.
+func detachSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: detachedProcess | createNewProcGroup,
+		HideWindow:    true,
+	}
+}

--- a/cmd/graymatter/internal/daemon/unit_test.go
+++ b/cmd/graymatter/internal/daemon/unit_test.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
+)
+
+func TestReadPIDFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if pid := ReadPIDFile(dir); pid != 0 {
+		t.Errorf("ReadPIDFile on empty dir = %d, want 0", pid)
+	}
+
+	if err := os.WriteFile(rpc.PIDFilePath(dir), []byte("4321\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if pid := ReadPIDFile(dir); pid != 4321 {
+		t.Errorf("ReadPIDFile = %d, want 4321", pid)
+	}
+
+	// Garbage pid file reads as 0, not a panic.
+	if err := os.WriteFile(rpc.PIDFilePath(dir), []byte("not-a-number"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if pid := ReadPIDFile(dir); pid != 0 {
+		t.Errorf("ReadPIDFile on garbage = %d, want 0", pid)
+	}
+}
+
+func TestIdleExitLabel(t *testing.T) {
+	if got := idleExitLabel(0); got != "disabled" {
+		t.Errorf("idleExitLabel(0) = %q, want disabled", got)
+	}
+	if got := idleExitLabel(0 - 1); got != "disabled" {
+		t.Errorf("idleExitLabel(negative) = %q, want disabled", got)
+	}
+	if got := idleExitLabel(2_000_000_000); got == "" || got == "disabled" {
+		t.Errorf("idleExitLabel(2s) = %q, want a duration", got)
+	}
+}
+
+func TestDaemonLogTail(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing log → empty tail.
+	if got := daemonLogTail(dir); got != "" {
+		t.Errorf("daemonLogTail on missing log = %q, want empty", got)
+	}
+
+	lines := "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\n"
+	if err := os.WriteFile(filepath.Join(dir, "daemon.log"), []byte(lines), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := daemonLogTail(dir)
+	if got == "" {
+		t.Fatal("daemonLogTail returned empty for a non-empty log")
+	}
+	// Keeps only the last few lines.
+	if want := "l8"; !strings.Contains(got, want) {
+		t.Errorf("tail %q missing last line %q", got, want)
+	}
+	if notWant := "l1"; strings.Contains(got, notWant) {
+		t.Errorf("tail %q should not include the oldest line %q", got, notWant)
+	}
+}

--- a/cmd/graymatter/internal/harness/recovery.go
+++ b/cmd/graymatter/internal/harness/recovery.go
@@ -37,6 +37,8 @@ func ListSessionsDB(db *bolt.DB) ([]HarnessSession, error) {
 
 // KillSession sends a termination signal to the background process recorded
 // in the HarnessSession for sessionID, then marks its status as "killed".
+// It opens its own write handle on the store; processes that already hold
+// one (the daemon) must use KillSessionDB instead.
 //
 // Returns an error if:
 //   - the session does not exist
@@ -49,7 +51,11 @@ func KillSession(sessionID, dataDir string) error {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+	return KillSessionDB(db, sessionID)
+}
 
+// KillSessionDB is KillSession against an already-open db handle.
+func KillSessionDB(db *bolt.DB, sessionID string) error {
 	if err := initHarnessBucket(db); err != nil {
 		return fmt.Errorf("init harness bucket: %w", err)
 	}
@@ -74,6 +80,21 @@ func KillSession(sessionID, dataDir string) error {
 	hs.Status = "killed"
 	hs.FinishedAt = &now
 	return saveHarnessSession(db, *hs)
+}
+
+// SaveSessionDB persists a HarnessSession record against an already-open db
+// handle, creating the harness bucket if needed. Used by the daemon host
+// service; in-process callers go through Run's own bookkeeping.
+func SaveSessionDB(db *bolt.DB, hs HarnessSession) error {
+	if err := initHarnessBucket(db); err != nil {
+		return fmt.Errorf("init harness bucket: %w", err)
+	}
+	return saveHarnessSession(db, hs)
+}
+
+// ResolveSessionIDDB is ResolveSessionID against an already-open db handle.
+func ResolveSessionIDDB(db *bolt.DB, agentID, sessionID string) (string, error) {
+	return resolveSessionID(db, agentID, sessionID)
 }
 
 // Resume looks up the HarnessSession for sessionID (or "latest" for the most

--- a/cmd/graymatter/internal/harness/runner.go
+++ b/cmd/graymatter/internal/harness/runner.go
@@ -17,7 +17,6 @@ import (
 	"github.com/oklog/ulid/v2"
 	bolt "go.etcd.io/bbolt"
 
-	graymatter "github.com/angelnicolasc/graymatter"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
 )
 
@@ -67,6 +66,11 @@ type RunConfig struct {
 	// APIKey overrides ANTHROPIC_API_KEY. If empty, env var is used.
 	APIKey string
 
+	// Store, when non-nil, is the persistence backend the run uses (the
+	// daemon client in production). When nil, Run opens an in-process store
+	// at DataDir itself — the path tests and --no-daemon take.
+	Store Store
+
 	// llmDoer replaces the real Anthropic API call. Injected by tests only.
 	// Production code leaves this nil.
 	llmDoer func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error)
@@ -109,26 +113,18 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 		return nil, fmt.Errorf("parse agent file: %w", err)
 	}
 
-	// Open memory + bbolt store.
-	gmCfg := graymatter.DefaultConfig()
-	gmCfg.DataDir = cfg.DataDir
-	if cfg.APIKey != "" {
-		gmCfg.AnthropicAPIKey = cfg.APIKey
+	// Obtain a Store. In production the caller injects the daemon client so
+	// the run never fights the bbolt lock; tests and --no-daemon fall back to
+	// an in-process open here.
+	store := cfg.Store
+	if store == nil {
+		ls, err := OpenLocalStore(cfg.DataDir, cfg.APIKey)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = ls.Close() }()
+		store = ls
 	}
-	gm, err := graymatter.NewWithConfig(gmCfg)
-	if err != nil {
-		return nil, fmt.Errorf("open memory store: %w", err)
-	}
-	defer func() { _ = gm.Close() }()
-
-	db := gm.Advanced().DB()
-
-	// Ensure harness_sessions bucket exists.
-	if err := initHarnessBucket(db); err != nil {
-		return nil, fmt.Errorf("init harness bucket: %w", err)
-	}
-	// Ensure token_usage bucket exists (best-effort; accounting never breaks a run).
-	_ = initTokenUsageBucket(db)
 
 	// Allocate a new session ID for this run.
 	sessionID := ulid.Make().String()
@@ -136,7 +132,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 	// Load prior checkpoint message history when resuming.
 	var priorMessages []session.Message
 	if cfg.ResumeID != "" {
-		cp, cpErr := session.Resume(db, def.Name)
+		cp, cpErr := store.CheckpointResume(def.Name)
 		if cpErr == nil && cp != nil {
 			priorMessages = cp.Messages
 			fmt.Fprintf(cfg.Stderr, "Resuming from checkpoint %s...\n", cp.ID)
@@ -152,12 +148,12 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 		Status:    "running",
 		Inputs:    cfg.Inputs,
 	}
-	if err := saveHarnessSession(db, hs); err != nil {
+	if err := store.SessionSave(hs); err != nil {
 		return nil, fmt.Errorf("save harness session: %w", err)
 	}
 
 	// Recall relevant memory and inject into system prompt.
-	memFacts, _ := gm.Recall(ctx, def.Name, def.Task)
+	memFacts, _ := store.RecallDefault(ctx, def.Name, def.Task)
 	systemContent := def.SystemPrompt
 	if len(memFacts) > 0 {
 		systemContent += "\n\n## Memory\n" + strings.Join(memFacts, "\n")
@@ -185,7 +181,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 
 	for attempt := 1; attempt <= cfg.MaxRetries; attempt++ {
 		hs.Attempts = attempt
-		_ = saveHarnessSession(db, hs) // best-effort progress update
+		_ = store.SessionSave(hs) // best-effort progress update
 
 		params := anthropic.MessageNewParams{
 			Model:     anthropic.Model(def.Model),
@@ -219,7 +215,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 		}
 
 		// Record token usage (best-effort; accounting never breaks a run).
-		_ = RecordTokenUsage(db, def.Name, def.Model,
+		_ = store.TokenRecord(def.Name, def.Model,
 			uint64(msg.Usage.InputTokens),
 			uint64(msg.Usage.OutputTokens),
 			uint64(msg.Usage.CacheReadInputTokens),
@@ -234,10 +230,10 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 
 		// Store observation in memory (best-effort).
 		if finalReply != "" {
-			_ = gm.Remember(ctx, def.Name, finalReply)
+			_ = store.Remember(ctx, def.Name, finalReply)
 		}
 
-		// Checkpoint: persist full message history to bbolt.
+		// Checkpoint: persist full message history.
 		cp := session.Checkpoint{
 			AgentID: def.Name,
 			State: map[string]any{
@@ -248,7 +244,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 			Messages: sessionMessages,
 			Metadata: map[string]string{"harness_session_id": sessionID},
 		}
-		saved, saveErr := session.Save(db, cp)
+		saved, saveErr := store.CheckpointSave(cp)
 		if saveErr == nil {
 			hs.LastCPID = saved.ID
 		}
@@ -258,7 +254,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 		hs.FinishedAt = &now
 		hs.Status = "done"
 		hs.Attempts = attempt
-		_ = saveHarnessSession(db, hs)
+		_ = store.SessionSave(hs)
 
 		fmt.Fprintln(cfg.Stdout, finalReply)
 
@@ -275,7 +271,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 	hs.FinishedAt = &now
 	hs.Status = "failed"
 	hs.ErrorMsg = lastErr.Error()
-	_ = saveHarnessSession(db, hs)
+	_ = store.SessionSave(hs)
 	writeFailedRun(cfg.DataDir, sessionID, hs, lastErr)
 
 	return nil, fmt.Errorf("run %q failed after %d attempt(s): %w", def.Name, cfg.MaxRetries, lastErr)

--- a/cmd/graymatter/internal/harness/store.go
+++ b/cmd/graymatter/internal/harness/store.go
@@ -1,0 +1,80 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+)
+
+// Store is the persistence surface Run needs. It is deliberately the subset
+// of operations a run performs, so the runner has exactly one code path
+// regardless of whether the store is owned by the daemon (production) or
+// opened in-process (tests, --no-daemon).
+//
+// The daemon client in package daemon satisfies this interface directly;
+// LocalStore provides the in-process implementation.
+type Store interface {
+	Remember(ctx context.Context, agentID, text string) error
+	RecallDefault(ctx context.Context, agentID, query string) ([]string, error)
+	CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error)
+	CheckpointResume(agentID string) (*session.Checkpoint, error)
+	SessionSave(hs HarnessSession) error
+	TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error
+	Close() error
+}
+
+// LocalStore is the in-process Store backed by a graymatter.Memory and its
+// bbolt handle. Used by tests and the --no-daemon path; the daemon owns the
+// store in normal operation.
+type LocalStore struct {
+	mem *graymatter.Memory
+}
+
+// OpenLocalStore opens an in-process store at dataDir for a run. apiKey, when
+// non-empty, overrides ANTHROPIC_API_KEY for embedding/consolidation.
+func OpenLocalStore(dataDir, apiKey string) (*LocalStore, error) {
+	cfg := graymatter.DefaultConfig()
+	cfg.DataDir = dataDir
+	if apiKey != "" {
+		cfg.AnthropicAPIKey = apiKey
+	}
+	mem, err := graymatter.NewWithConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("open memory store: %w", err)
+	}
+	db := mem.Advanced().DB()
+	if err := initHarnessBucket(db); err != nil {
+		_ = mem.Close()
+		return nil, fmt.Errorf("init harness bucket: %w", err)
+	}
+	_ = initTokenUsageBucket(db) // best-effort; accounting never breaks a run
+	return &LocalStore{mem: mem}, nil
+}
+
+func (s *LocalStore) Remember(ctx context.Context, agentID, text string) error {
+	return s.mem.Remember(ctx, agentID, text)
+}
+
+func (s *LocalStore) RecallDefault(ctx context.Context, agentID, query string) ([]string, error) {
+	return s.mem.Recall(ctx, agentID, query)
+}
+
+func (s *LocalStore) CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error) {
+	return session.Save(s.mem.Advanced().DB(), cp)
+}
+
+func (s *LocalStore) CheckpointResume(agentID string) (*session.Checkpoint, error) {
+	return session.Resume(s.mem.Advanced().DB(), agentID)
+}
+
+func (s *LocalStore) SessionSave(hs HarnessSession) error {
+	return saveHarnessSession(s.mem.Advanced().DB(), hs)
+}
+
+func (s *LocalStore) TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error {
+	return RecordTokenUsage(s.mem.Advanced().DB(), agent, model, input, output, cacheRead, cacheWrite)
+}
+
+func (s *LocalStore) Close() error { return s.mem.Close() }

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -8,12 +8,10 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	bolt "go.etcd.io/bbolt"
 
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
 )
-
-var bucketAudit = []byte("kg_audit")
 
 func (s *Server) handleMemorySearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
@@ -25,14 +23,14 @@ func (s *Server) handleMemorySearch(ctx context.Context, req mcp.CallToolRequest
 	if !ok || query == "" {
 		return toolError("query is required")
 	}
-	topK := getInt(args, "top_k", s.mem.Config().TopK)
+	topK := getInt(args, "top_k", 0) // 0 = store default
 
-	facts, err := s.mem.Recall(ctx, agentID, query)
+	facts, err := s.backend.Recall(ctx, agentID, query, topK)
 	if err != nil {
 		return toolError(fmt.Sprintf("recall error: %v", err))
 	}
 
-	if topK < len(facts) {
+	if topK > 0 && topK < len(facts) {
 		facts = facts[:topK]
 	}
 
@@ -59,7 +57,7 @@ func (s *Server) handleMemoryAdd(ctx context.Context, req mcp.CallToolRequest) (
 		return toolError("text is required")
 	}
 
-	if err := s.mem.Remember(ctx, agentID, text); err != nil {
+	if err := s.backend.Remember(ctx, agentID, text); err != nil {
 		return toolError(fmt.Sprintf("remember error: %v", err))
 	}
 
@@ -80,18 +78,13 @@ func (s *Server) handleCheckpointSave(ctx context.Context, req mcp.CallToolReque
 		}
 	}
 
-	store := s.mem.Advanced()
-	if store == nil {
-		return toolError("memory store not initialised")
-	}
-
 	cp := session.Checkpoint{
 		AgentID:   agentID,
 		CreatedAt: time.Now().UTC(),
 		State:     state,
 		Metadata:  map[string]string{"source": "mcp"},
 	}
-	saved, err := session.Save(store.DB(), cp)
+	saved, err := s.backend.CheckpointSave(cp)
 	if err != nil {
 		return toolError(fmt.Sprintf("checkpoint save error: %v", err))
 	}
@@ -106,12 +99,7 @@ func (s *Server) handleCheckpointResume(ctx context.Context, req mcp.CallToolReq
 		return toolError("agent_id is required")
 	}
 
-	store := s.mem.Advanced()
-	if store == nil {
-		return toolError("memory store not initialised")
-	}
-
-	cp, err := session.Resume(store.DB(), agentID)
+	cp, err := s.backend.CheckpointResume(agentID)
 	if err != nil {
 		return toolError(fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err))
 	}
@@ -145,11 +133,6 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 	text, _ := getString(args, "text")
 	target, _ := getString(args, "target")
 
-	store := s.mem.Advanced()
-	if store == nil {
-		return toolError("memory store not initialised")
-	}
-
 	var oldText string
 	var resultMsg string
 
@@ -158,7 +141,7 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if text == "" {
 			return toolError("text (the fact to add) is required for add")
 		}
-		if err := s.mem.Remember(ctx, agentID, text); err != nil {
+		if err := s.backend.Remember(ctx, agentID, text); err != nil {
 			return toolError(fmt.Sprintf("add failed: %v", err))
 		}
 		resultMsg = fmt.Sprintf("Added fact for agent %q.", agentID)
@@ -170,7 +153,7 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if text == "" {
 			return toolError("text (the corrected fact) is required for update")
 		}
-		facts, err := store.List(agentID)
+		facts, err := s.backend.List(agentID)
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
@@ -178,14 +161,14 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 			if f.Text == target {
 				oldText = f.Text
 				f.Weight = 0
-				_ = store.UpdateFact(agentID, f)
+				_ = s.backend.UpdateFact(agentID, f)
 				break
 			}
 		}
 		if oldText == "" {
 			return toolError(fmt.Sprintf("target fact not found: %q", target))
 		}
-		if err := s.mem.Remember(ctx, agentID, text); err != nil {
+		if err := s.backend.Remember(ctx, agentID, text); err != nil {
 			return toolError(fmt.Sprintf("add updated fact: %v", err))
 		}
 		resultMsg = fmt.Sprintf("Updated fact for agent %q.", agentID)
@@ -200,7 +183,7 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if victim == "" {
 			return toolError("the fact to forget is required: pass it in target (or text)")
 		}
-		facts, err := store.List(agentID)
+		facts, err := s.backend.List(agentID)
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
@@ -208,7 +191,7 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 			if f.Text == victim {
 				oldText = f.Text
 				f.Weight = 0
-				_ = store.UpdateFact(agentID, f)
+				_ = s.backend.UpdateFact(agentID, f)
 				break
 			}
 		}
@@ -224,12 +207,9 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if text == "" {
 			return toolError("text (the source node ID) is required for link")
 		}
-		if s.kgLinker == nil {
-			return toolError("knowledge graph not available in this server instance")
-		}
 		fromID := strings.ToLower(strings.TrimSpace(text))
 		toID := strings.ToLower(strings.TrimSpace(target))
-		if err := s.kgLinker.LinkNodes(fromID, toID, "agent_link"); err != nil {
+		if err := s.backend.KGLink(fromID, toID, "agent_link"); err != nil {
 			return toolError(fmt.Sprintf("link nodes: %v", err))
 		}
 		resultMsg = fmt.Sprintf("Linked %q → %q.", fromID, toID)
@@ -238,7 +218,7 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		return toolError(fmt.Sprintf("unknown action %q", action))
 	}
 
-	writeAuditEntry(store.DB(), auditEntry{
+	_ = s.backend.AuditWrite(audit.Entry{
 		Timestamp: time.Now().UTC(),
 		Action:    action,
 		Agent:     agentID,
@@ -248,28 +228,4 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 	})
 
 	return toolText(resultMsg)
-}
-
-type auditEntry struct {
-	Timestamp time.Time `json:"timestamp"`
-	Action    string    `json:"action"`
-	Agent     string    `json:"agent"`
-	OldText   string    `json:"old_text,omitempty"`
-	NewText   string    `json:"new_text"`
-	Source    string    `json:"source"`
-}
-
-func writeAuditEntry(db *bolt.DB, entry auditEntry) {
-	data, err := json.Marshal(entry)
-	if err != nil {
-		return
-	}
-	key := []byte(entry.Timestamp.Format(time.RFC3339Nano) + "_" + entry.Action + "_" + entry.Agent)
-	_ = db.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists(bucketAudit)
-		if err != nil {
-			return err
-		}
-		return b.Put(key, data)
-	})
 }

--- a/cmd/graymatter/internal/mcp/handlers_test.go
+++ b/cmd/graymatter/internal/mcp/handlers_test.go
@@ -28,6 +28,99 @@ func reflectReq(args map[string]any) mcp.CallToolRequest {
 	return mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: args}}
 }
 
+func TestMemoryAdd_AndSearch(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	// add requires agent_id and text
+	if res, _ := s.handleMemoryAdd(ctx, reflectReq(map[string]any{"text": "x"})); !res.IsError {
+		t.Error("memory_add without agent_id should error")
+	}
+	if res, _ := s.handleMemoryAdd(ctx, reflectReq(map[string]any{"agent_id": "a1"})); !res.IsError {
+		t.Error("memory_add without text should error")
+	}
+
+	res, err := s.handleMemoryAdd(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "text": "the sky is blue",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("memory_add failed: %v / %s", err, resultText(t, res))
+	}
+
+	// search finds it
+	res, err = s.handleMemorySearch(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "query": "sky", "top_k": float64(5),
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("memory_search failed: %v / %s", err, resultText(t, res))
+	}
+	if !strings.Contains(resultText(t, res), "sky is blue") {
+		t.Errorf("search result missing the fact: %s", resultText(t, res))
+	}
+
+	// search validation
+	if res, _ := s.handleMemorySearch(ctx, reflectReq(map[string]any{"query": "x"})); !res.IsError {
+		t.Error("memory_search without agent_id should error")
+	}
+	if res, _ := s.handleMemorySearch(ctx, reflectReq(map[string]any{"agent_id": "a1"})); !res.IsError {
+		t.Error("memory_search without query should error")
+	}
+
+	// empty result is a clean message, not an error
+	res, _ = s.handleMemorySearch(ctx, reflectReq(map[string]any{
+		"agent_id": "nobody", "query": "nothing here",
+	}))
+	if res.IsError || !strings.Contains(resultText(t, res), "No memories found") {
+		t.Errorf("expected clean empty-state, got: %s", resultText(t, res))
+	}
+}
+
+func TestCheckpoint_SaveResume(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	if res, _ := s.handleCheckpointSave(ctx, reflectReq(map[string]any{})); !res.IsError {
+		t.Error("checkpoint_save without agent_id should error")
+	}
+	// bad JSON state is rejected
+	if res, _ := s.handleCheckpointSave(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "state": "{not json",
+	})); !res.IsError {
+		t.Error("checkpoint_save with invalid JSON state should error")
+	}
+
+	res, err := s.handleCheckpointSave(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "state": `{"step":3}`,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("checkpoint_save failed: %v / %s", err, resultText(t, res))
+	}
+
+	res, err = s.handleCheckpointResume(ctx, reflectReq(map[string]any{"agent_id": "a1"}))
+	if err != nil || res.IsError {
+		t.Fatalf("checkpoint_resume failed: %v / %s", err, resultText(t, res))
+	}
+	if !strings.Contains(resultText(t, res), "restored") {
+		t.Errorf("resume result unexpected: %s", resultText(t, res))
+	}
+
+	// resume for an unknown agent errors
+	if res, _ := s.handleCheckpointResume(ctx, reflectReq(map[string]any{"agent_id": "ghost"})); !res.IsError {
+		t.Error("checkpoint_resume for unknown agent should error")
+	}
+}
+
+func TestMemoryReflect_LinkRequiresKG(t *testing.T) {
+	// DirectBackend with no KG linker: link must report unavailability.
+	s, _ := newTestServer(t)
+	res, _ := s.handleMemoryReflect(context.Background(), reflectReq(map[string]any{
+		"action": "link", "agent": "a1", "text": "node-a", "target": "node-b",
+	}))
+	if !res.IsError || !strings.Contains(resultText(t, res), "knowledge graph") {
+		t.Errorf("expected KG-unavailable error, got: %s", resultText(t, res))
+	}
+}
+
 func resultText(t *testing.T, res *mcp.CallToolResult) string {
 	t.Helper()
 	if len(res.Content) == 0 {

--- a/cmd/graymatter/internal/mcp/handlers_test.go
+++ b/cmd/graymatter/internal/mcp/handlers_test.go
@@ -10,8 +10,9 @@ import (
 	graymatter "github.com/angelnicolasc/graymatter"
 )
 
-// newTestServer returns an MCP Server backed by a real Memory in a temp dir.
-func newTestServer(t *testing.T) *Server {
+// newTestServer returns an MCP Server backed by a real Memory in a temp dir,
+// through the DirectBackend (the same code path --no-daemon uses).
+func newTestServer(t *testing.T) (*Server, *graymatter.Memory) {
 	t.Helper()
 	cfg := graymatter.DefaultConfig()
 	cfg.DataDir = t.TempDir()
@@ -20,7 +21,7 @@ func newTestServer(t *testing.T) *Server {
 		t.Fatalf("NewWithConfig: %v", err)
 	}
 	t.Cleanup(func() { _ = mem.Close() })
-	return New(mem)
+	return New(NewDirectBackend(mem, nil)), mem
 }
 
 func reflectReq(args map[string]any) mcp.CallToolRequest {
@@ -40,9 +41,9 @@ func resultText(t *testing.T, res *mcp.CallToolResult) string {
 }
 
 // factWeight returns the weight of the fact with the given text, or -1 if absent.
-func factWeight(t *testing.T, s *Server, agentID, text string) float64 {
+func factWeight(t *testing.T, mem *graymatter.Memory, agentID, text string) float64 {
 	t.Helper()
-	facts, err := s.mem.Advanced().List(agentID)
+	facts, err := mem.Advanced().List(agentID)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -55,11 +56,11 @@ func factWeight(t *testing.T, s *Server, agentID, text string) float64 {
 }
 
 func TestMemoryReflect_ForgetViaText(t *testing.T) {
-	s := newTestServer(t)
+	s, mem := newTestServer(t)
 	ctx := context.Background()
 	const fact = "Workaround for Node 14 bug (project now on Node 18)"
 
-	if err := s.mem.Remember(ctx, "a1", fact); err != nil {
+	if err := mem.Remember(ctx, "a1", fact); err != nil {
 		t.Fatalf("Remember: %v", err)
 	}
 
@@ -76,17 +77,17 @@ func TestMemoryReflect_ForgetViaText(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("forget via text should succeed, got error: %s", resultText(t, res))
 	}
-	if w := factWeight(t, s, "a1", fact); w != 0 {
+	if w := factWeight(t, mem, "a1", fact); w != 0 {
 		t.Errorf("fact weight after forget = %v, want 0", w)
 	}
 }
 
 func TestMemoryReflect_ForgetViaTarget(t *testing.T) {
-	s := newTestServer(t)
+	s, mem := newTestServer(t)
 	ctx := context.Background()
 	const fact = "stale fact"
 
-	if err := s.mem.Remember(ctx, "a1", fact); err != nil {
+	if err := mem.Remember(ctx, "a1", fact); err != nil {
 		t.Fatalf("Remember: %v", err)
 	}
 
@@ -101,19 +102,19 @@ func TestMemoryReflect_ForgetViaTarget(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("forget via target should succeed, got error: %s", resultText(t, res))
 	}
-	if w := factWeight(t, s, "a1", fact); w != 0 {
+	if w := factWeight(t, mem, "a1", fact); w != 0 {
 		t.Errorf("fact weight after forget = %v, want 0", w)
 	}
 }
 
 func TestMemoryReflect_ForgetTargetWinsOverText(t *testing.T) {
-	s := newTestServer(t)
+	s, mem := newTestServer(t)
 	ctx := context.Background()
 
-	if err := s.mem.Remember(ctx, "a1", "fact A"); err != nil {
+	if err := mem.Remember(ctx, "a1", "fact A"); err != nil {
 		t.Fatalf("Remember: %v", err)
 	}
-	if err := s.mem.Remember(ctx, "a1", "fact B"); err != nil {
+	if err := mem.Remember(ctx, "a1", "fact B"); err != nil {
 		t.Fatalf("Remember: %v", err)
 	}
 
@@ -129,16 +130,16 @@ func TestMemoryReflect_ForgetTargetWinsOverText(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("forget should succeed, got error: %s", resultText(t, res))
 	}
-	if w := factWeight(t, s, "a1", "fact B"); w != 0 {
+	if w := factWeight(t, mem, "a1", "fact B"); w != 0 {
 		t.Errorf("target fact B weight = %v, want 0 (target must win)", w)
 	}
-	if w := factWeight(t, s, "a1", "fact A"); w == 0 {
+	if w := factWeight(t, mem, "a1", "fact A"); w == 0 {
 		t.Errorf("text fact A was forgotten, but target should have won")
 	}
 }
 
 func TestMemoryReflect_Validation(t *testing.T) {
-	s := newTestServer(t)
+	s, _ := newTestServer(t)
 	ctx := context.Background()
 
 	cases := []struct {
@@ -200,12 +201,12 @@ func TestMemoryReflect_Validation(t *testing.T) {
 }
 
 func TestMemoryReflect_UpdateSupersedes(t *testing.T) {
-	s := newTestServer(t)
+	s, mem := newTestServer(t)
 	ctx := context.Background()
 	const oldFact = "API base URL is https://api.v1.example.com"
 	const newFact = "API base URL is https://api.v2.example.com"
 
-	if err := s.mem.Remember(ctx, "a1", oldFact); err != nil {
+	if err := mem.Remember(ctx, "a1", oldFact); err != nil {
 		t.Fatalf("Remember: %v", err)
 	}
 
@@ -221,10 +222,10 @@ func TestMemoryReflect_UpdateSupersedes(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("update should succeed, got error: %s", resultText(t, res))
 	}
-	if w := factWeight(t, s, "a1", oldFact); w != 0 {
+	if w := factWeight(t, mem, "a1", oldFact); w != 0 {
 		t.Errorf("old fact weight = %v, want 0", w)
 	}
-	if w := factWeight(t, s, "a1", newFact); w <= 0 {
+	if w := factWeight(t, mem, "a1", newFact); w <= 0 {
 		t.Errorf("new fact weight = %v, want > 0", w)
 	}
 }

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -14,6 +14,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -21,12 +22,31 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 const (
 	serverName    = "graymatter"
 	serverVersion = "0.1.0"
 )
+
+// Backend is the persistence surface the MCP handlers need. Two
+// implementations exist: the daemon client (default — lets several MCP
+// hosts and the TUI share one store, issue #8) and DirectBackend
+// (in-process, for --no-daemon and tests).
+type Backend interface {
+	Remember(ctx context.Context, agentID, text string) error
+	// Recall with topK<=0 uses the store's configured default.
+	Recall(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	List(agentID string) ([]memory.Fact, error)
+	UpdateFact(agentID string, f memory.Fact) error
+	CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error)
+	CheckpointResume(agentID string) (*session.Checkpoint, error)
+	AuditWrite(e audit.Entry) error
+	KGLink(from, to, relation string) error
+}
 
 // KGLinker is a narrow interface for creating knowledge-graph edges.
 // Implemented by *kg.GraphAdapter in production.
@@ -37,14 +57,13 @@ type KGLinker interface {
 
 // Server wraps mcp-go with GrayMatter memory handlers.
 type Server struct {
-	mem      *graymatter.Memory
-	mcpSrv   *server.MCPServer
-	kgLinker KGLinker // optional; enables memory_reflect "link" action
+	backend Backend
+	mcpSrv  *server.MCPServer
 }
 
-// New creates a configured MCP server backed by mem.
-func New(mem *graymatter.Memory) *Server {
-	s := &Server{mem: mem}
+// New creates a configured MCP server on top of backend.
+func New(backend Backend) *Server {
+	s := &Server{backend: backend}
 	s.mcpSrv = server.NewMCPServer(serverName, serverVersion,
 		server.WithToolCapabilities(true),
 	)
@@ -52,9 +71,80 @@ func New(mem *graymatter.Memory) *Server {
 	return s
 }
 
-// SetKGLinker wires an optional knowledge-graph linker so that the
-// memory_reflect tool can create graph edges. Call after New().
-func (s *Server) SetKGLinker(l KGLinker) { s.kgLinker = l }
+// DirectBackend implements Backend against an in-process Memory. The KG
+// linker is optional; without it the link action reports unavailability.
+type DirectBackend struct {
+	mem      *graymatter.Memory
+	kgLinker KGLinker
+}
+
+// NewDirectBackend wraps mem (and an optional kg linker) as a Backend.
+func NewDirectBackend(mem *graymatter.Memory, kgLinker KGLinker) *DirectBackend {
+	return &DirectBackend{mem: mem, kgLinker: kgLinker}
+}
+
+func (b *DirectBackend) Remember(ctx context.Context, agentID, text string) error {
+	return b.mem.Remember(ctx, agentID, text)
+}
+
+func (b *DirectBackend) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return b.mem.Recall(ctx, agentID, query)
+	}
+	store := b.mem.Advanced()
+	if store == nil {
+		return nil, errors.New("memory store not initialised")
+	}
+	return store.Recall(ctx, agentID, query, topK)
+}
+
+func (b *DirectBackend) List(agentID string) ([]memory.Fact, error) {
+	store := b.mem.Advanced()
+	if store == nil {
+		return nil, errors.New("memory store not initialised")
+	}
+	return store.List(agentID)
+}
+
+func (b *DirectBackend) UpdateFact(agentID string, f memory.Fact) error {
+	store := b.mem.Advanced()
+	if store == nil {
+		return errors.New("memory store not initialised")
+	}
+	return store.UpdateFact(agentID, f)
+}
+
+func (b *DirectBackend) CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error) {
+	store := b.mem.Advanced()
+	if store == nil {
+		return session.Checkpoint{}, errors.New("memory store not initialised")
+	}
+	return session.Save(store.DB(), cp)
+}
+
+func (b *DirectBackend) CheckpointResume(agentID string) (*session.Checkpoint, error) {
+	store := b.mem.Advanced()
+	if store == nil {
+		return nil, errors.New("memory store not initialised")
+	}
+	return session.Resume(store.DB(), agentID)
+}
+
+func (b *DirectBackend) AuditWrite(e audit.Entry) error {
+	store := b.mem.Advanced()
+	if store == nil {
+		return nil
+	}
+	audit.Write(store.DB(), e)
+	return nil
+}
+
+func (b *DirectBackend) KGLink(from, to, relation string) error {
+	if b.kgLinker == nil {
+		return errors.New("knowledge graph not available in this server instance")
+	}
+	return b.kgLinker.LinkNodes(from, to, relation)
+}
 
 // ServeStdio starts the MCP server over stdin/stdout (used by Claude Code).
 // Blocks until the client disconnects.

--- a/cmd/graymatter/main.go
+++ b/cmd/graymatter/main.go
@@ -11,9 +11,10 @@ import (
 var version = "dev"
 
 var (
-	dataDir string
-	quiet   bool
-	jsonOut bool
+	dataDir  string
+	quiet    bool
+	jsonOut  bool
+	noDaemon bool
 )
 
 var rootCmd = &cobra.Command{
@@ -27,10 +28,13 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&dataDir, "dir", ".graymatter", "data directory")
 	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "suppress non-essential output")
 	rootCmd.PersistentFlags().BoolVar(&jsonOut, "json", false, "output in JSON format")
+	rootCmd.PersistentFlags().BoolVar(&noDaemon, "no-daemon", false,
+		"open the store in-process instead of through the daemon (debugging; fights the single-writer lock)")
 
 	rootCmd.AddCommand(
 		initCmd(),
 		doctorCmd(),
+		daemonCmd(),
 		rememberCmd(),
 		recallCmd(),
 		checkpointCmd(),

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// cliStore is the persistence surface CLI commands and the TUI consume.
+//
+// There are exactly two implementations and one place that picks between
+// them (openStore): the daemon client (default — concurrent-safe, issue #8)
+// and the in-process direct store (--no-daemon / GRAYMATTER_NO_DAEMON=1,
+// for debugging and air-gapped inspection). Commands never open bbolt
+// themselves and never branch on the mode.
+type cliStore interface {
+	// Core memory surface.
+	Remember(ctx context.Context, agentID, text string) error
+	PutShared(ctx context.Context, text string) error
+	RecallDefault(ctx context.Context, agentID, query string) ([]string, error)
+	Recall(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	RecallShared(ctx context.Context, query string, topK int) ([]string, error)
+	RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	List(agentID string) ([]memory.Fact, error)
+	ListAgents() ([]string, error)
+	Stats(agentID string) (memory.MemoryStats, error)
+	Delete(agentID, factID string) error
+	UpdateFact(agentID string, f memory.Fact) error
+
+	// Host-level surface (checkpoints, sessions, KG, audit, tokens).
+	CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error)
+	CheckpointLoad(agentID, checkpointID string) (*session.Checkpoint, error)
+	CheckpointResume(agentID string) (*session.Checkpoint, error)
+	CheckpointList(agentID string) ([]session.Checkpoint, error)
+	SessionsList() ([]harness.HarnessSession, error)
+	SessionKill(id string) error
+	SessionResolve(agentID, sessionID string) (string, error)
+	KGNodes() ([]kg.Node, error)
+	KGLink(from, to, relation string) error
+	AuditWrite(e audit.Entry) error
+	TokenSummary(days int) (harness.TokenUsageSummary, error)
+	TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error
+	SessionSave(hs harness.HarnessSession) error
+
+	// IsReadOnly reports a degraded direct open (--no-daemon while another
+	// process holds the write lock). Always false through the daemon.
+	IsReadOnly() bool
+
+	Close() error
+}
+
+// daemonStore adapts *daemon.Client to cliStore (only the bits the client
+// doesn't already satisfy structurally).
+type daemonStore struct {
+	*daemon.Client
+}
+
+func (d daemonStore) IsReadOnly() bool { return false }
+
+// compile-time checks: both implementations satisfy cliStore.
+var (
+	_ cliStore = daemonStore{}
+	_ cliStore = (*directStore)(nil)
+)
+
+// openStore is the single entry point commands use to reach the store.
+func openStore() (cliStore, error) {
+	if noDaemon || os.Getenv("GRAYMATTER_NO_DAEMON") == "1" {
+		return openDirectStore()
+	}
+	c, err := daemon.Connect(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	return daemonStore{Client: c}, nil
+}
+
+// --- direct (in-process) implementation --------------------------------------
+
+// directStore wraps a Memory + raw db for --no-daemon operation. It is also
+// what unit tests construct to exercise command logic without a daemon.
+type directStore struct {
+	mem   *graymatter.Memory
+	store graymatter.AdvancedStore
+}
+
+func openDirectStore() (*directStore, error) {
+	cfg := graymatter.DefaultConfig()
+	cfg.DataDir = dataDir
+	mem, err := graymatter.NewWithConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	store := mem.Advanced()
+	if store == nil {
+		_ = mem.Close()
+		return nil, fmt.Errorf("store not initialised")
+	}
+	return &directStore{mem: mem, store: store}, nil
+}
+
+func (d *directStore) Remember(ctx context.Context, agentID, text string) error {
+	return d.mem.Remember(ctx, agentID, text)
+}
+
+func (d *directStore) PutShared(ctx context.Context, text string) error {
+	return d.mem.RememberShared(ctx, text)
+}
+
+func (d *directStore) RecallDefault(ctx context.Context, agentID, query string) ([]string, error) {
+	return d.mem.Recall(ctx, agentID, query)
+}
+
+func (d *directStore) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return d.mem.Recall(ctx, agentID, query)
+	}
+	return d.store.Recall(ctx, agentID, query, topK)
+}
+
+func (d *directStore) RecallShared(ctx context.Context, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return d.mem.RecallShared(ctx, query)
+	}
+	return d.store.RecallShared(ctx, query, topK)
+}
+
+func (d *directStore) RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	if topK <= 0 {
+		return d.mem.RecallAll(ctx, agentID, query)
+	}
+	if ra, ok := d.store.(interface {
+		RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	}); ok {
+		return ra.RecallAll(ctx, agentID, query, topK)
+	}
+	return d.mem.RecallAll(ctx, agentID, query)
+}
+
+func (d *directStore) List(agentID string) ([]memory.Fact, error) { return d.store.List(agentID) }
+func (d *directStore) ListAgents() ([]string, error)              { return d.store.ListAgents() }
+func (d *directStore) Stats(agentID string) (memory.MemoryStats, error) {
+	return d.store.Stats(agentID)
+}
+func (d *directStore) Delete(agentID, factID string) error { return d.store.Delete(agentID, factID) }
+func (d *directStore) UpdateFact(agentID string, f memory.Fact) error {
+	return d.store.UpdateFact(agentID, f)
+}
+
+func (d *directStore) CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error) {
+	return session.Save(d.store.DB(), cp)
+}
+
+func (d *directStore) CheckpointLoad(agentID, checkpointID string) (*session.Checkpoint, error) {
+	return session.Load(d.store.DB(), agentID, checkpointID)
+}
+
+func (d *directStore) CheckpointResume(agentID string) (*session.Checkpoint, error) {
+	return session.Resume(d.store.DB(), agentID)
+}
+
+func (d *directStore) CheckpointList(agentID string) ([]session.Checkpoint, error) {
+	return session.List(d.store.DB(), agentID)
+}
+
+func (d *directStore) SessionsList() ([]harness.HarnessSession, error) {
+	return harness.ListSessionsDB(d.store.DB())
+}
+
+func (d *directStore) SessionKill(id string) error {
+	return harness.KillSessionDB(d.store.DB(), id)
+}
+
+func (d *directStore) SessionResolve(agentID, sessionID string) (string, error) {
+	return harness.ResolveSessionIDDB(d.store.DB(), agentID, sessionID)
+}
+
+func (d *directStore) KGNodes() ([]kg.Node, error) {
+	g, err := kg.Open(d.store.DB())
+	if err != nil {
+		return nil, nil // no graph yet: empty, not an error
+	}
+	return g.AllNodes()
+}
+
+func (d *directStore) KGLink(from, to, relation string) error {
+	g, err := kg.Open(d.store.DB())
+	if err != nil {
+		return fmt.Errorf("knowledge graph not available: %w", err)
+	}
+	return kg.NewGraphAdapter(g).LinkNodes(from, to, relation)
+}
+
+func (d *directStore) AuditWrite(e audit.Entry) error {
+	audit.Write(d.store.DB(), e)
+	return nil
+}
+
+func (d *directStore) TokenSummary(days int) (harness.TokenUsageSummary, error) {
+	return harness.LoadTokenUsageSummary(d.store.DB(), days)
+}
+
+func (d *directStore) TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error {
+	return harness.RecordTokenUsage(d.store.DB(), agent, model, input, output, cacheRead, cacheWrite)
+}
+
+func (d *directStore) SessionSave(hs harness.HarnessSession) error {
+	return harness.SaveSessionDB(d.store.DB(), hs)
+}
+
+func (d *directStore) IsReadOnly() bool { return d.store.IsReadOnly() }
+
+func (d *directStore) Close() error { return d.mem.Close() }

--- a/cmd/graymatter/tui_dashboard.go
+++ b/cmd/graymatter/tui_dashboard.go
@@ -176,10 +176,8 @@ func (m tuiModel) loadDashboard() tea.Cmd {
 		// Token usage is a cheap bucket scan (≤ agents × models × days rows).
 		// Never block the dashboard on it — if the bucket is missing or the
 		// query fails, the panel degrades to an empty-state card.
-		if db := store.DB(); db != nil {
-			if ts, err := harness.LoadTokenUsageSummary(db, 30); err == nil {
-				d.Tokens = ts
-			}
+		if ts, err := store.TokenSummary(30); err == nil {
+			d.Tokens = ts
 		}
 
 		return dashboardLoadedMsg{d}

--- a/cmd/graymatter/tui_dashboard_test.go
+++ b/cmd/graymatter/tui_dashboard_test.go
@@ -27,7 +27,7 @@ func TestDashboardRender_Empty(t *testing.T) {
 		t.Fatal("nil advanced store")
 	}
 
-	m := tuiModel{store: store, width: 120, height: 32}
+	m := tuiModel{store: &directStore{mem: mem, store: store}, width: 120, height: 32}
 	// Execute the loader synchronously and dispatch the message.
 	msg := m.loadDashboard()()
 	loaded, ok := msg.(dashboardLoadedMsg)
@@ -83,7 +83,7 @@ func TestDashboardRender_WithFacts(t *testing.T) {
 		}
 	}
 
-	m := tuiModel{store: store, width: 140, height: 36}
+	m := tuiModel{store: &directStore{mem: mem, store: store}, width: 140, height: 36}
 	msg := m.loadDashboard()()
 	loaded, ok := msg.(dashboardLoadedMsg)
 	if !ok {
@@ -149,7 +149,7 @@ func TestDashboardRender_WithTokens(t *testing.T) {
 		t.Fatalf("record usage: %v", err)
 	}
 
-	m := tuiModel{store: store, width: 140, height: 36}
+	m := tuiModel{store: &directStore{mem: mem, store: store}, width: 140, height: 36}
 	msg := m.loadDashboard()()
 	loaded, ok := msg.(dashboardLoadedMsg)
 	if !ok {

--- a/config.go
+++ b/config.go
@@ -109,6 +109,13 @@ type Config struct {
 	// back to read-only if the write lock is held by another process (e.g.
 	// opencode running in the same directory).
 	ReadOnly bool
+
+	// StrictWrite disables the automatic read-only fallback: if the write
+	// lock cannot be acquired, Open fails immediately instead of degrading.
+	// The store daemon sets this — a store owner that silently came up
+	// read-only would break every connected client. StrictWrite wins over
+	// ReadOnly when both are set.
+	StrictWrite bool
 }
 
 // DefaultConfig returns a Config with all defaults applied from environment

--- a/graymatter.go
+++ b/graymatter.go
@@ -99,6 +99,7 @@ func NewWithConfig(cfg Config) (*Memory, error) {
 		OnVectorIndexError:      cfg.OnVectorIndexError,
 		VectorReconcileInterval: cfg.VectorReconcileInterval,
 		ReadOnly:                cfg.ReadOnly,
+		StrictWrite:             cfg.StrictWrite,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("graymatter: open store: %w", err)

--- a/pkg/memory/rpc/client.go
+++ b/pkg/memory/rpc/client.go
@@ -1,0 +1,268 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"sync"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// Client is a thin wrapper around a net/rpc client that speaks the
+// GrayMatter RPC service.
+//
+// Methods mirror Backend (which itself mirrors the in-process
+// AdvancedStore minus DB() and the ConsolidateConfig argument). All
+// methods are safe for concurrent use — net/rpc serialises requests on
+// a single connection, so callers do not need to add their own locking.
+//
+// Construct with Dial; release with Close.
+type Client struct {
+	rpc         *rpc.Client
+	conn        net.Conn
+	addr        string
+	callTimeout time.Duration
+	closeMu     sync.Mutex
+	closed      bool
+}
+
+// DialOptions tunes how Dial finds and connects to a daemon.
+type DialOptions struct {
+	// DataDir locates the daemon's discovery file (graymatter.addr).
+	// The default is ".graymatter".
+	DataDir string
+
+	// DialTimeout caps how long a single dial attempt may block.
+	// Defaults to 2 seconds.
+	DialTimeout time.Duration
+
+	// CallTimeout bounds each RPC round-trip. A hung daemon otherwise
+	// blocks net/rpc forever and with it every one-shot CLI command.
+	// Defaults to 30 seconds. Consolidate uses an independent, longer
+	// bound (it proxies an LLM call).
+	CallTimeout time.Duration
+
+	// PingOnDial, if true, sends a Ping RPC after connecting and verifies
+	// the server protocol matches Protocol. Defaults to true; turn off
+	// only for tests against a server you trust unconditionally.
+	PingOnDial bool
+}
+
+// consolidateTimeout bounds Consolidate calls; the daemon-side work may
+// include an LLM round-trip, so the regular CallTimeout is too tight.
+const consolidateTimeout = 5 * time.Minute
+
+// Dial opens a connection to a running daemon at dataDir, presenting the
+// auth token recorded in the discovery file.
+//
+// Dial does NOT spawn the daemon if none is running — that is the job of
+// higher-level callers. Dial returns net.ErrClosed-shaped errors if the
+// discovery file is missing or the listener refuses connections, so
+// spawn-on-connect logic can errors.Is for that case.
+func Dial(opts DialOptions) (*Client, error) {
+	if opts.DataDir == "" {
+		opts.DataDir = ".graymatter"
+	}
+	if opts.DialTimeout == 0 {
+		opts.DialTimeout = 2 * time.Second
+	}
+	if opts.CallTimeout == 0 {
+		opts.CallTimeout = 30 * time.Second
+	}
+
+	addr, token, err := readDiscovery(opts.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("rpc: read discovery: %w", err)
+	}
+
+	conn, err := dialAddr(addr, opts.DialTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("rpc: dial %s: %w", addr, err)
+	}
+
+	// Token preamble: one line before the JSON-RPC stream starts. The
+	// server drops the connection silently on mismatch — the subsequent
+	// Ping surfaces that as a useful error.
+	if token != "" {
+		if err := conn.SetWriteDeadline(time.Now().Add(opts.DialTimeout)); err == nil {
+			_, _ = conn.Write([]byte(token + "\n"))
+			_ = conn.SetWriteDeadline(time.Time{})
+		}
+	}
+
+	c := &Client{
+		rpc:         rpc.NewClientWithCodec(jsonrpc.NewClientCodec(conn)),
+		conn:        conn,
+		addr:        addr,
+		callTimeout: opts.CallTimeout,
+	}
+
+	if opts.PingOnDial {
+		if err := c.Ping(); err != nil {
+			_ = c.Close()
+			return nil, fmt.Errorf("rpc: ping after dial: %w", err)
+		}
+	}
+	return c, nil
+}
+
+// Close releases the underlying connection. Safe to call multiple times.
+func (c *Client) Close() error {
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	return c.rpc.Close()
+}
+
+// Addr returns the discovery address this client connected to. Useful
+// for logs and tests.
+func (c *Client) Addr() string { return c.addr }
+
+// call invokes a core-service method with the default timeout.
+func (c *Client) call(method string, req, resp any) error {
+	return c.CallService(ServiceName, method, req, resp, c.callTimeout)
+}
+
+// CallService invokes service.method with an explicit timeout. It exists so
+// the daemon's host-level services (registered via Server.RegisterExtra) can
+// reuse this client and its connection rather than maintaining a second one.
+//
+// net/rpc cannot cancel an in-flight call, so on timeout the connection is
+// closed — which fails all pending calls — and the client must be re-dialed.
+// A poisoned connection is strictly worse than a dropped one.
+func (c *Client) CallService(service, method string, req, resp any, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = c.callTimeout
+	}
+	done := c.rpc.Go(service+"."+method, req, resp, make(chan *rpc.Call, 1)).Done
+
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	select {
+	case call := <-done:
+		return call.Error
+	case <-t.C:
+		_ = c.Close()
+		return fmt.Errorf("rpc: %s.%s timed out after %s (connection closed)", service, method, timeout)
+	}
+}
+
+// Ping verifies the server is reachable and protocol-compatible.
+// Returns nil on success.
+func (c *Client) Ping() error {
+	var resp PingResponse
+	if err := c.call("Ping", &PingRequest{}, &resp); err != nil {
+		return err
+	}
+	if resp.Protocol != Protocol {
+		return fmt.Errorf("rpc: protocol mismatch: server=%q client=%q", resp.Protocol, Protocol)
+	}
+	return nil
+}
+
+// --- typed methods mirroring Backend ---
+
+// Put writes a fact for agentID.
+//
+// The ctx argument is currently retained for API symmetry; net/rpc does
+// not propagate cancellation across the wire, so a cancelled ctx will
+// not interrupt an in-flight server-side call. This is acceptable for
+// foundation-mode because individual operations complete in <50 ms;
+// a future revision may add per-call deadline forwarding.
+func (c *Client) Put(ctx context.Context, agentID, text string) error {
+	return c.call("Put", &PutRequest{AgentID: agentID, Text: text}, &PutResponse{})
+}
+
+// PutShared writes a fact to the __shared__ namespace.
+func (c *Client) PutShared(ctx context.Context, text string) error {
+	return c.call("PutShared", &PutSharedRequest{Text: text}, &PutSharedResponse{})
+}
+
+// Recall returns the top-k most relevant facts for agentID given query.
+func (c *Client) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	var resp RecallResponse
+	if err := c.call("Recall", &RecallRequest{AgentID: agentID, Query: query, TopK: topK}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Facts, nil
+}
+
+// RecallShared returns the top-k most relevant shared facts for query.
+func (c *Client) RecallShared(ctx context.Context, query string, topK int) ([]string, error) {
+	var resp RecallSharedResponse
+	if err := c.call("RecallShared", &RecallSharedRequest{Query: query, TopK: topK}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Facts, nil
+}
+
+// RecallAll returns the merged agent + shared facts for query. TopK<=0 uses
+// the daemon's configured default.
+func (c *Client) RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	var resp RecallAllResponse
+	if err := c.call("RecallAll", &RecallAllRequest{AgentID: agentID, Query: query, TopK: topK}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Facts, nil
+}
+
+// List returns every fact for agentID, newest first.
+func (c *Client) List(agentID string) ([]memory.Fact, error) {
+	var resp ListResponse
+	if err := c.call("List", &ListRequest{AgentID: agentID}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Facts, nil
+}
+
+// ListAgents returns every known agent ID.
+func (c *Client) ListAgents() ([]string, error) {
+	var resp ListAgentsResponse
+	if err := c.call("ListAgents", &ListAgentsRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.AgentIDs, nil
+}
+
+// Stats returns aggregate fact statistics for agentID.
+func (c *Client) Stats(agentID string) (memory.MemoryStats, error) {
+	var resp StatsResponse
+	if err := c.call("Stats", &StatsRequest{AgentID: agentID}, &resp); err != nil {
+		return memory.MemoryStats{}, err
+	}
+	return resp.Stats, nil
+}
+
+// Delete removes a fact by ID.
+func (c *Client) Delete(agentID, factID string) error {
+	return c.call("Delete", &DeleteRequest{AgentID: agentID, FactID: factID}, &DeleteResponse{})
+}
+
+// UpdateFact persists a modified fact.
+func (c *Client) UpdateFact(agentID string, f memory.Fact) error {
+	return c.call("UpdateFact", &UpdateFactRequest{AgentID: agentID, Fact: f}, &UpdateFactResponse{})
+}
+
+// Consolidate triggers server-side consolidation for agentID using the
+// daemon's own configuration. Clients cannot override the policy. Uses a
+// longer timeout than other calls because consolidation may proxy an LLM
+// round-trip.
+func (c *Client) Consolidate(ctx context.Context, agentID string) error {
+	return c.CallService(ServiceName, "Consolidate", &ConsolidateRequest{AgentID: agentID}, &ConsolidateResponse{}, consolidateTimeout)
+}
+
+// PendingVectorCount returns the number of facts waiting to be re-indexed.
+func (c *Client) PendingVectorCount() (int, error) {
+	var resp PendingVectorCountResponse
+	if err := c.call("PendingVectorCount", &PendingVectorCountRequest{}, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Count, nil
+}

--- a/pkg/memory/rpc/rpc_test.go
+++ b/pkg/memory/rpc/rpc_test.go
@@ -1,0 +1,303 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// startServer opens a real memory.Store in a temp dir, wraps it in a Server,
+// and serves it on the platform listener (unix socket / TCP loopback).
+// Returns the data dir for clients to Dial against.
+func startServer(t *testing.T, token string) (dataDir string, srv *Server) {
+	t.Helper()
+	dataDir = t.TempDir()
+
+	store, err := memory.Open(memory.StoreConfig{DataDir: dataDir, StrictWrite: true})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	srv = NewServer(store, nil)
+	srv.SetAuthToken(token)
+
+	ln, cleanup, err := Listen(dataDir, token)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(srv.Stop)
+
+	return dataDir, srv
+}
+
+func dialT(t *testing.T, dataDir string) *Client {
+	t.Helper()
+	c, err := Dial(DialOptions{DataDir: dataDir, PingOnDial: true})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestRoundTrip_CoreSurface(t *testing.T) {
+	dataDir, _ := startServer(t, mustToken(t))
+	c := dialT(t, dataDir)
+	ctx := context.Background()
+
+	// Put + List
+	if err := c.Put(ctx, "agent-a", "fact alpha"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := c.Put(ctx, "agent-a", "fact beta"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	facts, err := c.List("agent-a")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) != 2 {
+		t.Fatalf("List returned %d facts, want 2", len(facts))
+	}
+
+	// Recall
+	recalled, err := c.Recall(ctx, "agent-a", "alpha", 5)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(recalled) == 0 {
+		t.Fatal("Recall returned nothing")
+	}
+
+	// Shared namespace
+	if err := c.PutShared(ctx, "shared gamma"); err != nil {
+		t.Fatalf("PutShared: %v", err)
+	}
+	sharedFacts, err := c.RecallShared(ctx, "gamma", 5)
+	if err != nil {
+		t.Fatalf("RecallShared: %v", err)
+	}
+	if len(sharedFacts) == 0 {
+		t.Fatal("RecallShared returned nothing")
+	}
+
+	// ListAgents + Stats
+	agents, err := c.ListAgents()
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) == 0 {
+		t.Fatal("ListAgents returned nothing")
+	}
+	stats, err := c.Stats("agent-a")
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.FactCount != 2 {
+		t.Errorf("Stats.FactCount = %d, want 2", stats.FactCount)
+	}
+
+	// UpdateFact + Delete
+	f := facts[0]
+	f.Weight = 0.123
+	if err := c.UpdateFact("agent-a", f); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+	if err := c.Delete("agent-a", facts[1].ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	after, err := c.List("agent-a")
+	if err != nil {
+		t.Fatalf("List after delete: %v", err)
+	}
+	if len(after) != 1 {
+		t.Fatalf("after delete: %d facts, want 1", len(after))
+	}
+	if after[0].Weight != 0.123 {
+		t.Errorf("updated weight = %v, want 0.123", after[0].Weight)
+	}
+
+	// PendingVectorCount (keyword-only store: zero)
+	if n, err := c.PendingVectorCount(); err != nil || n != 0 {
+		t.Errorf("PendingVectorCount = %d, %v; want 0, nil", n, err)
+	}
+}
+
+// TestConcurrentClients is the issue #8 acceptance test at the RPC layer:
+// multiple processes' worth of clients writing simultaneously through one
+// store owner, with no bbolt lock fights.
+func TestConcurrentClients_WritesInterleave(t *testing.T) {
+	dataDir, _ := startServer(t, mustToken(t))
+	ctx := context.Background()
+
+	const clients = 4
+	const writesPerClient = 25
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, clients)
+	for i := 0; i < clients; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			c, err := Dial(DialOptions{DataDir: dataDir, PingOnDial: true})
+			if err != nil {
+				errCh <- fmt.Errorf("client %d dial: %w", id, err)
+				return
+			}
+			defer func() { _ = c.Close() }()
+			for j := 0; j < writesPerClient; j++ {
+				if err := c.Put(ctx, "swarm", fmt.Sprintf("client %d fact %d", id, j)); err != nil {
+					errCh <- fmt.Errorf("client %d put %d: %w", id, j, err)
+					return
+				}
+			}
+			errCh <- nil
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := dialT(t, dataDir)
+	facts, err := c.List("swarm")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) != clients*writesPerClient {
+		t.Fatalf("got %d facts, want %d", len(facts), clients*writesPerClient)
+	}
+}
+
+func TestAuth_WrongTokenRejected(t *testing.T) {
+	dataDir, _ := startServer(t, mustToken(t))
+
+	// Sabotage the token the client will read.
+	addr, _, err := readDiscovery(dataDir)
+	if err != nil {
+		t.Fatalf("readDiscovery: %v", err)
+	}
+	if err := writeDiscovery(dataDir, addr, "deadbeef"); err != nil {
+		t.Fatalf("writeDiscovery: %v", err)
+	}
+
+	_, err = Dial(DialOptions{DataDir: dataDir, PingOnDial: true})
+	if err == nil {
+		t.Fatal("Dial with wrong token should fail")
+	}
+}
+
+func TestAuth_MissingTokenRejected(t *testing.T) {
+	dataDir, _ := startServer(t, mustToken(t))
+
+	addr, _, err := readDiscovery(dataDir)
+	if err != nil {
+		t.Fatalf("readDiscovery: %v", err)
+	}
+
+	// Raw connection that never sends the preamble: the server must drop it
+	// within its 3s auth deadline; the client read then fails.
+	conn, err := dialAddr(addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dialAddr: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err == nil {
+		t.Fatal("server should close unauthenticated connections, but it answered")
+	}
+}
+
+func TestActiveConns_TracksClients(t *testing.T) {
+	dataDir, srv := startServer(t, mustToken(t))
+
+	if n := srv.ActiveConns(); n != 0 {
+		t.Fatalf("ActiveConns = %d before any client, want 0", n)
+	}
+
+	c1 := dialT(t, dataDir)
+	c2 := dialT(t, dataDir)
+	_ = c1.Ping()
+	_ = c2.Ping()
+	waitFor(t, func() bool { return srv.ActiveConns() == 2 }, "two active conns")
+
+	_ = c1.Close()
+	waitFor(t, func() bool { return srv.ActiveConns() == 1 }, "one active conn after close")
+
+	before := srv.LastActivity()
+	_ = c2.Close()
+	waitFor(t, func() bool { return srv.ActiveConns() == 0 }, "zero active conns")
+	if !srv.LastActivity().After(before) && srv.LastActivity() != before {
+		// Disconnect must refresh the idle clock (>= is fine on coarse clocks).
+		t.Error("LastActivity did not advance on disconnect")
+	}
+}
+
+func TestDial_NoDaemonReturnsErrClosed(t *testing.T) {
+	_, err := Dial(DialOptions{DataDir: t.TempDir()})
+	if err == nil {
+		t.Fatal("Dial without a daemon should fail")
+	}
+	// Spawn-on-connect logic keys off net.ErrClosed to mean "no daemon".
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("expected net.ErrClosed in chain, got: %v", err)
+	}
+}
+
+func TestServer_StopUnblocksServe(t *testing.T) {
+	dataDir, srv := startServer(t, mustToken(t))
+	c := dialT(t, dataDir)
+	if err := c.Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Stop did not return within 10s")
+	}
+}
+
+func mustToken(t *testing.T) string {
+	t.Helper()
+	tok, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if len(tok) != 64 {
+		t.Fatalf("token length = %d, want 64", len(tok))
+	}
+	return tok
+}
+
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/pkg/memory/rpc/rpc_test.go
+++ b/pkg/memory/rpc/rpc_test.go
@@ -239,13 +239,15 @@ func TestActiveConns_TracksClients(t *testing.T) {
 	_ = c1.Close()
 	waitFor(t, func() bool { return srv.ActiveConns() == 1 }, "one active conn after close")
 
+	// Disconnect must refresh the idle clock. Sleep a beat so the post-close
+	// touch lands at a strictly later instant even on a coarse clock, then
+	// poll: the server decrements ActiveConns *before* it calls touch(), so
+	// "0 conns" alone doesn't prove the touch has run yet.
 	before := srv.LastActivity()
+	time.Sleep(2 * time.Millisecond)
 	_ = c2.Close()
 	waitFor(t, func() bool { return srv.ActiveConns() == 0 }, "zero active conns")
-	if !srv.LastActivity().After(before) && srv.LastActivity() != before {
-		// Disconnect must refresh the idle clock (>= is fine on coarse clocks).
-		t.Error("LastActivity did not advance on disconnect")
-	}
+	waitFor(t, func() bool { return srv.LastActivity().After(before) }, "idle clock refreshed on disconnect")
 }
 
 func TestDial_NoDaemonReturnsErrClosed(t *testing.T) {

--- a/pkg/memory/rpc/server.go
+++ b/pkg/memory/rpc/server.go
@@ -1,0 +1,383 @@
+package rpc
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// Backend is the in-process surface the RPC server wraps.
+//
+// It is deliberately a strict subset of graymatter.AdvancedStore: DB()
+// is excluded because raw bbolt handles cannot cross a process
+// boundary, and Consolidate keeps the in-process signature so
+// *memory.Store satisfies us directly.
+//
+// The concrete *memory.Store satisfies this interface (verified by the
+// compile-time assertion below). Tests may supply their own minimal
+// implementation.
+type Backend interface {
+	Put(ctx context.Context, agentID, text string) error
+	PutShared(ctx context.Context, text string) error
+	Recall(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	RecallShared(ctx context.Context, query string, topK int) ([]string, error)
+	RecallAll(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	List(agentID string) ([]memory.Fact, error)
+	ListAgents() ([]string, error)
+	Stats(agentID string) (memory.MemoryStats, error)
+	Delete(agentID, factID string) error
+	UpdateFact(agentID string, f memory.Fact) error
+	Consolidate(ctx context.Context, agentID string, cfg memory.ConsolidateConfig) error
+	PendingVectorCount() int
+}
+
+// compile-time guarantee that *memory.Store satisfies Backend.
+var _ Backend = (*memory.Store)(nil)
+
+// Server exposes a Backend over net/rpc + JSON.
+//
+// One Server instance handles many concurrent client connections; net/rpc
+// dispatches each call on its own goroutine. The underlying Backend is
+// expected to be safe for concurrent use (memory.Store is).
+//
+// Server tracks a "last activity" timestamp updated on every successful
+// dispatch. Daemon mode uses this to drive idle-exit; standalone callers
+// can ignore it.
+type Server struct {
+	backend          Backend
+	consolidateCfg   memory.ConsolidateConfig
+	lastActivityUnix int64 // atomic; UnixNano
+	activeConns      int64 // atomic
+	token            string
+	extra            map[string]any // additional net/rpc services, by name
+
+	stop      chan struct{}
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+	listener  net.Listener
+	listenErr atomic.Value // error
+
+	connsMu sync.Mutex
+	conns   map[net.Conn]struct{}
+}
+
+// NewServer constructs a Server wrapping backend. The consolidateCfg is
+// used when handling RPC ConsolidateRequest calls; pass the same Config
+// the daemon uses elsewhere so consolidation policy is consistent.
+func NewServer(backend Backend, consolidateCfg memory.ConsolidateConfig) *Server {
+	s := &Server{
+		backend:        backend,
+		consolidateCfg: consolidateCfg,
+		stop:           make(chan struct{}),
+		conns:          make(map[net.Conn]struct{}),
+	}
+	s.touch()
+	return s
+}
+
+// trackConn registers an authenticated connection for shutdown teardown.
+func (s *Server) trackConn(c net.Conn) {
+	s.connsMu.Lock()
+	s.conns[c] = struct{}{}
+	s.connsMu.Unlock()
+}
+
+// untrackConn removes a connection after its codec loop exits.
+func (s *Server) untrackConn(c net.Conn) {
+	s.connsMu.Lock()
+	delete(s.conns, c)
+	s.connsMu.Unlock()
+}
+
+// touch updates the last-activity timestamp to now.
+func (s *Server) touch() {
+	atomic.StoreInt64(&s.lastActivityUnix, time.Now().UnixNano())
+}
+
+// LastActivity returns the wall-clock time of the most recent successful RPC
+// dispatch or connection close. Useful for idle-exit timers.
+func (s *Server) LastActivity() time.Time {
+	return time.Unix(0, atomic.LoadInt64(&s.lastActivityUnix))
+}
+
+// ActiveConns returns the number of currently connected clients. Idle-exit
+// logic must check this is zero in addition to LastActivity — a TUI sitting
+// open without making calls still holds a connection and must keep the
+// daemon alive.
+func (s *Server) ActiveConns() int {
+	return int(atomic.LoadInt64(&s.activeConns))
+}
+
+// SetAuthToken installs the shared-secret token clients must present as a
+// connection preamble. An empty token disables authentication (tests only —
+// the daemon always sets one). Must be called before Serve.
+func (s *Server) SetAuthToken(token string) { s.token = token }
+
+// RegisterExtra registers an additional net/rpc service on this server under
+// name. The daemon uses this to expose host-level services (checkpoints,
+// sessions, knowledge graph) next to the core store service without the
+// library package needing to know about them. Must be called before Serve.
+func (s *Server) RegisterExtra(name string, rcvr any) {
+	if s.extra == nil {
+		s.extra = map[string]any{}
+	}
+	s.extra[name] = rcvr
+}
+
+// maxTokenLine bounds the auth preamble read: 64 hex chars + newline slack.
+const maxTokenLine = 256
+
+// authenticate reads the token preamble (a single line) from conn and
+// compares it in constant time. The read is deadline-bounded so a client
+// that connects and sends nothing cannot pin a goroutine forever.
+func (s *Server) authenticate(conn net.Conn) bool {
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return false
+	}
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	line := make([]byte, 0, len(s.token)+1)
+	buf := [1]byte{}
+	for len(line) < maxTokenLine {
+		n, err := conn.Read(buf[:])
+		if err != nil {
+			return false
+		}
+		if n == 0 {
+			continue
+		}
+		if buf[0] == '\n' {
+			return subtle.ConstantTimeCompare(line, []byte(s.token)) == 1
+		}
+		line = append(line, buf[0])
+	}
+	return false
+}
+
+// Serve registers the service on a fresh net/rpc.Server, accepts connections
+// from listener until Stop is called or listener errors out, and returns
+// the first non-nil error encountered.
+//
+// Serve blocks; run it in its own goroutine.
+func (s *Server) Serve(listener net.Listener) error {
+	s.listener = listener
+	rpcSrv := rpc.NewServer()
+	if err := rpcSrv.RegisterName(ServiceName, s); err != nil {
+		return fmt.Errorf("rpc.RegisterName: %w", err)
+	}
+	for name, rcvr := range s.extra {
+		if err := rpcSrv.RegisterName(name, rcvr); err != nil {
+			return fmt.Errorf("rpc.RegisterName %s: %w", name, err)
+		}
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case <-s.stop:
+				// Graceful shutdown — listener was closed by Stop.
+				s.wg.Wait()
+				return nil
+			default:
+			}
+			// Surfaceable error.
+			s.listenErr.Store(err)
+			s.wg.Wait()
+			return err
+		}
+
+		s.wg.Add(1)
+		go func(c net.Conn) {
+			defer s.wg.Done()
+			defer func() { _ = c.Close() }()
+
+			if s.token != "" && !s.authenticate(c) {
+				return // wrong or missing token: drop before any dispatch
+			}
+
+			s.trackConn(c)
+			atomic.AddInt64(&s.activeConns, 1)
+			defer func() {
+				atomic.AddInt64(&s.activeConns, -1)
+				s.untrackConn(c)
+				// Idle countdown starts when the last client leaves, not at
+				// its last RPC — otherwise a long-lived quiet client could
+				// outlive the timeout and get its daemon killed under it.
+				s.touch()
+			}()
+
+			rpcSrv.ServeCodec(jsonrpc.NewServerCodec(c))
+		}(conn)
+	}
+}
+
+// Stop closes the listener, tears down active client connections, and waits
+// for their codec loops to drain. In-flight calls already dispatched to the
+// backend complete; idle connections are cut. Safe to call multiple times.
+func (s *Server) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.stop)
+		if s.listener != nil {
+			_ = s.listener.Close()
+		}
+		s.connsMu.Lock()
+		for c := range s.conns {
+			_ = c.Close()
+		}
+		s.connsMu.Unlock()
+	})
+	s.wg.Wait()
+}
+
+// --- RPC method handlers ---
+//
+// Each handler matches net/rpc's required signature:
+//   func (s *Server) Method(req *Req, resp *Resp) error
+//
+// On error, we return the error to net/rpc which wraps and ships its
+// .Error() string to the client. There are no sentinel errors in
+// pkg/memory at this point, so plain string round-trip is sufficient.
+// When PR #7 lands ErrStoreReadOnly, this is the place to add a kind
+// prefix (e.g. "[read_only] ...") and a client-side mapper.
+
+// Put handles a remote AdvancedStore.Put.
+func (s *Server) Put(req *PutRequest, resp *PutResponse) error {
+	defer s.touch()
+	return s.backend.Put(context.Background(), req.AgentID, req.Text)
+}
+
+// PutShared handles a remote AdvancedStore.PutShared.
+func (s *Server) PutShared(req *PutSharedRequest, resp *PutSharedResponse) error {
+	defer s.touch()
+	return s.backend.PutShared(context.Background(), req.Text)
+}
+
+// Recall handles a remote AdvancedStore.Recall.
+func (s *Server) Recall(req *RecallRequest, resp *RecallResponse) error {
+	defer s.touch()
+	facts, err := s.backend.Recall(context.Background(), req.AgentID, req.Query, req.TopK)
+	if err != nil {
+		return err
+	}
+	resp.Facts = facts
+	return nil
+}
+
+// RecallShared handles a remote AdvancedStore.RecallShared.
+func (s *Server) RecallShared(req *RecallSharedRequest, resp *RecallSharedResponse) error {
+	defer s.touch()
+	facts, err := s.backend.RecallShared(context.Background(), req.Query, req.TopK)
+	if err != nil {
+		return err
+	}
+	resp.Facts = facts
+	return nil
+}
+
+// RecallAll handles a remote Store.RecallAll (agent + shared merged).
+func (s *Server) RecallAll(req *RecallAllRequest, resp *RecallAllResponse) error {
+	defer s.touch()
+	facts, err := s.backend.RecallAll(context.Background(), req.AgentID, req.Query, req.TopK)
+	if err != nil {
+		return err
+	}
+	resp.Facts = facts
+	return nil
+}
+
+// List handles a remote AdvancedStore.List.
+func (s *Server) List(req *ListRequest, resp *ListResponse) error {
+	defer s.touch()
+	facts, err := s.backend.List(req.AgentID)
+	if err != nil {
+		return err
+	}
+	resp.Facts = facts
+	return nil
+}
+
+// ListAgents handles a remote AdvancedStore.ListAgents.
+func (s *Server) ListAgents(req *ListAgentsRequest, resp *ListAgentsResponse) error {
+	defer s.touch()
+	ids, err := s.backend.ListAgents()
+	if err != nil {
+		return err
+	}
+	resp.AgentIDs = ids
+	return nil
+}
+
+// Stats handles a remote AdvancedStore.Stats.
+func (s *Server) Stats(req *StatsRequest, resp *StatsResponse) error {
+	defer s.touch()
+	stats, err := s.backend.Stats(req.AgentID)
+	if err != nil {
+		return err
+	}
+	resp.Stats = stats
+	return nil
+}
+
+// Delete handles a remote AdvancedStore.Delete.
+func (s *Server) Delete(req *DeleteRequest, resp *DeleteResponse) error {
+	defer s.touch()
+	return s.backend.Delete(req.AgentID, req.FactID)
+}
+
+// UpdateFact handles a remote AdvancedStore.UpdateFact.
+func (s *Server) UpdateFact(req *UpdateFactRequest, resp *UpdateFactResponse) error {
+	defer s.touch()
+	return s.backend.UpdateFact(req.AgentID, req.Fact)
+}
+
+// Consolidate handles a remote consolidation request, applying the
+// daemon-side consolidation policy.
+func (s *Server) Consolidate(req *ConsolidateRequest, resp *ConsolidateResponse) error {
+	defer s.touch()
+	if s.consolidateCfg == nil {
+		return errors.New("consolidation not configured on server")
+	}
+	return s.backend.Consolidate(context.Background(), req.AgentID, s.consolidateCfg)
+}
+
+// PendingVectorCount handles a remote AdvancedStore.PendingVectorCount.
+func (s *Server) PendingVectorCount(req *PendingVectorCountRequest, resp *PendingVectorCountResponse) error {
+	defer s.touch()
+	resp.Count = s.backend.PendingVectorCount()
+	return nil
+}
+
+// Ping handles a liveness probe. Touches activity so a heartbeat keeps
+// the daemon alive — useful for long-idle TUIs that just want the
+// dashboard refreshed without making writes.
+func (s *Server) Ping(req *PingRequest, resp *PingResponse) error {
+	defer s.touch()
+	resp.Protocol = Protocol
+	return nil
+}
+
+// errIsClosedConn returns true if err means "the other side closed cleanly".
+// Useful when distinguishing legitimate disconnects from real errors.
+func errIsClosedConn(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	return false
+}

--- a/pkg/memory/rpc/server.go
+++ b/pkg/memory/rpc/server.go
@@ -170,7 +170,12 @@ func (s *Server) authenticate(conn net.Conn) bool {
 //
 // Serve blocks; run it in its own goroutine.
 func (s *Server) Serve(listener net.Listener) error {
+	// Publish the listener under connsMu so a concurrent Stop (which closes
+	// it to unblock Accept) cannot race the assignment.
+	s.connsMu.Lock()
 	s.listener = listener
+	s.connsMu.Unlock()
+
 	rpcSrv := rpc.NewServer()
 	if err := rpcSrv.RegisterName(ServiceName, s); err != nil {
 		return fmt.Errorf("rpc.RegisterName: %w", err)
@@ -228,10 +233,10 @@ func (s *Server) Serve(listener net.Listener) error {
 func (s *Server) Stop() {
 	s.stopOnce.Do(func() {
 		close(s.stop)
+		s.connsMu.Lock()
 		if s.listener != nil {
 			_ = s.listener.Close()
 		}
-		s.connsMu.Lock()
 		for c := range s.conns {
 			_ = c.Close()
 		}

--- a/pkg/memory/rpc/sock.go
+++ b/pkg/memory/rpc/sock.go
@@ -1,0 +1,128 @@
+package rpc
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// discoveryFile is the file in DataDir where the daemon writes its listener
+// address and auth token, one per line:
+//
+//	line 1: unix:///path/to/graymatter.sock  (or tcp://127.0.0.1:port)
+//	line 2: 64-hex-char auth token
+//
+// The file is written atomically with 0600 perms. On Unix the socket file
+// itself is also permission-gated; on Windows (TCP loopback) the token is the
+// actual access control — any local process can reach 127.0.0.1, but only
+// ones that can read this file can authenticate.
+const discoveryFile = "graymatter.addr"
+
+// pidFile is the file in DataDir where the daemon writes its PID.
+// Used by `graymatter daemon status|stop` and stale-daemon reaping.
+const pidFile = "graymatter.pid"
+
+// PIDFilePath returns the absolute path to the daemon's PID file in
+// dataDir. Exported for tests and CLI introspection.
+func PIDFilePath(dataDir string) string {
+	return filepath.Join(dataDir, pidFile)
+}
+
+// DiscoveryFilePath returns the absolute path to the daemon's discovery
+// file in dataDir.
+func DiscoveryFilePath(dataDir string) string {
+	return filepath.Join(dataDir, discoveryFile)
+}
+
+// GenerateToken returns a fresh 256-bit random token, hex-encoded.
+func GenerateToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("rpc: generate token: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// DiscoveryAddr returns the listener address recorded in dataDir's discovery
+// file, without the token. For status displays and logs.
+func DiscoveryAddr(dataDir string) (string, error) {
+	addr, _, err := readDiscovery(dataDir)
+	return addr, err
+}
+
+// readDiscovery reads the daemon's listener address and auth token from the
+// discovery file in dataDir. Returns net.ErrClosed if the file does not
+// exist (callers use errors.Is to distinguish "no daemon" from "broken
+// daemon").
+func readDiscovery(dataDir string) (addr, token string, err error) {
+	path := DiscoveryFilePath(dataDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", "", net.ErrClosed
+		}
+		return "", "", err
+	}
+	lines := strings.SplitN(strings.TrimSpace(string(data)), "\n", 3)
+	addr = strings.TrimSpace(lines[0])
+	if addr == "" {
+		return "", "", fmt.Errorf("rpc: empty discovery file at %s", path)
+	}
+	if len(lines) > 1 {
+		token = strings.TrimSpace(lines[1])
+	}
+	return addr, token, nil
+}
+
+// writeDiscovery atomically records the listener address and token to
+// dataDir's discovery file with 0600 perms.
+func writeDiscovery(dataDir, addr, token string) error {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return err
+	}
+	path := DiscoveryFilePath(dataDir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(addr+"\n"+token+"\n"), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// removeDiscovery deletes the discovery file. Best-effort.
+func removeDiscovery(dataDir string) {
+	_ = os.Remove(DiscoveryFilePath(dataDir))
+}
+
+// dialAddr opens a connection to addr using the right transport.
+// addr is the string form returned by Listen and recorded in the
+// discovery file:
+//
+//	unix:///abs/path/to/sock     — Unix domain socket
+//	tcp://127.0.0.1:54321        — TCP loopback (Windows)
+func dialAddr(addr string, timeout time.Duration) (net.Conn, error) {
+	scheme, target, err := parseAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+	d := net.Dialer{Timeout: timeout}
+	return d.Dial(scheme, target)
+}
+
+// parseAddr splits a discovery address into (network, target) suitable
+// for net.Dial. Unknown schemes return an error.
+func parseAddr(addr string) (network, target string, err error) {
+	switch {
+	case strings.HasPrefix(addr, "unix://"):
+		return "unix", strings.TrimPrefix(addr, "unix://"), nil
+	case strings.HasPrefix(addr, "tcp://"):
+		return "tcp", strings.TrimPrefix(addr, "tcp://"), nil
+	default:
+		return "", "", fmt.Errorf("rpc: unknown discovery address scheme: %q", addr)
+	}
+}

--- a/pkg/memory/rpc/sock_unix.go
+++ b/pkg/memory/rpc/sock_unix.go
@@ -3,22 +3,48 @@
 package rpc
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 )
 
+// maxUnixSocketPath is a conservative cap on the length of a Unix domain
+// socket path. The kernel struct sockaddr_un.sun_path is 104 bytes on
+// macOS/BSD and 108 on Linux (including the NUL terminator); 100 is safely
+// under both. Paths longer than this fail bind() with EINVAL.
+const maxUnixSocketPath = 100
+
+// socketPath chooses where to bind the daemon socket. It prefers a socket
+// inside dataDir (nice for `ls .graymatter`), but deeply nested project
+// paths can blow past sun_path — so when the in-dir path is too long it
+// falls back to a short, stable path under the system temp dir, derived
+// from a hash of the absolute data dir. The discovery file records whichever
+// path we pick, so clients never need to recompute it.
+func socketPath(dataDir string) string {
+	inDir := filepath.Join(dataDir, "graymatter.sock")
+	if len(inDir) <= maxUnixSocketPath {
+		return inDir
+	}
+	abs, err := filepath.Abs(dataDir)
+	if err != nil {
+		abs = dataDir
+	}
+	sum := sha256.Sum256([]byte(abs))
+	return filepath.Join(os.TempDir(), "graymatter-"+hex.EncodeToString(sum[:8])+".sock")
+}
+
 // Listen creates a listener for the daemon, writes a discovery file with the
 // address and auth token, and returns the listener plus a cleanup func that
-// removes both the discovery file and the socket. On Unix this binds a Unix
-// domain socket at $DataDir/graymatter.sock, chmod 0600 so other local users
-// cannot connect even where the data dir itself is world-readable.
+// removes both the discovery file and the socket. The socket is chmod 0600 so
+// other local users cannot connect even where the data dir is world-readable.
 func Listen(dataDir, token string) (net.Listener, func(), error) {
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("rpc: create data dir: %w", err)
 	}
-	sockPath := filepath.Join(dataDir, "graymatter.sock")
+	sockPath := socketPath(dataDir)
 
 	// Remove any stale socket from a previous crashed daemon. Best-effort:
 	// if the file is held by a live daemon, the subsequent Listen will

--- a/pkg/memory/rpc/sock_unix.go
+++ b/pkg/memory/rpc/sock_unix.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package rpc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// Listen creates a listener for the daemon, writes a discovery file with the
+// address and auth token, and returns the listener plus a cleanup func that
+// removes both the discovery file and the socket. On Unix this binds a Unix
+// domain socket at $DataDir/graymatter.sock, chmod 0600 so other local users
+// cannot connect even where the data dir itself is world-readable.
+func Listen(dataDir, token string) (net.Listener, func(), error) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("rpc: create data dir: %w", err)
+	}
+	sockPath := filepath.Join(dataDir, "graymatter.sock")
+
+	// Remove any stale socket from a previous crashed daemon. Best-effort:
+	// if the file is held by a live daemon, the subsequent Listen will
+	// fail with EADDRINUSE and we surface that.
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("rpc: listen unix %s: %w", sockPath, err)
+	}
+	if err := os.Chmod(sockPath, 0o600); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
+		return nil, nil, fmt.Errorf("rpc: chmod socket: %w", err)
+	}
+
+	addr := "unix://" + sockPath
+	if err := writeDiscovery(dataDir, addr, token); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
+		return nil, nil, fmt.Errorf("rpc: write discovery: %w", err)
+	}
+
+	cleanup := func() {
+		removeDiscovery(dataDir)
+		_ = os.Remove(sockPath)
+	}
+	return ln, cleanup, nil
+}

--- a/pkg/memory/rpc/sock_windows.go
+++ b/pkg/memory/rpc/sock_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package rpc
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// Listen creates a listener for the daemon, writes a discovery file with the
+// address and auth token, and returns the listener plus a cleanup func to
+// remove the discovery file. On Windows, native Unix domain sockets are not
+// portably available from the standard library, so we bind TCP loopback on a
+// kernel-assigned port. The loopback interface is reachable by every local
+// process, which is why the auth token in the 0600 discovery file is
+// mandatory here — connections that fail the token preamble are dropped
+// before any RPC dispatch (see Server.authenticate).
+func Listen(dataDir, token string) (net.Listener, func(), error) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("rpc: create data dir: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, fmt.Errorf("rpc: listen tcp 127.0.0.1: %w", err)
+	}
+
+	addr := "tcp://" + ln.Addr().String()
+	if err := writeDiscovery(dataDir, addr, token); err != nil {
+		_ = ln.Close()
+		return nil, nil, fmt.Errorf("rpc: write discovery: %w", err)
+	}
+
+	cleanup := func() {
+		removeDiscovery(dataDir)
+	}
+	return ln, cleanup, nil
+}

--- a/pkg/memory/rpc/wire.go
+++ b/pkg/memory/rpc/wire.go
@@ -1,0 +1,158 @@
+// Package rpc provides a net/rpc + JSON transport that exposes the
+// AdvancedStore surface of pkg/memory across processes.
+//
+// The package is intentionally narrow:
+//
+//   - Server wraps an in-process *memory.Store and serves it over a
+//     local socket (Unix domain socket on POSIX, TCP loopback on Windows).
+//   - Client dials the server and provides typed methods that mirror
+//     AdvancedStore (minus DB(), which cannot cross a process boundary).
+//
+// The wire format is JSON via net/rpc/jsonrpc — stdlib only, zero new
+// transitive dependencies.
+//
+// This is the foundation layer for the v0.6.0 daemon mode tracked in
+// issue #8. It is deliberately consumer-agnostic: the TUI, MCP server,
+// CLI subcommands, and plugin host migrate to this client in subsequent
+// changes.
+package rpc
+
+import "github.com/angelnicolasc/graymatter/pkg/memory"
+
+// ServiceName is the net/rpc service name registered by Server.
+// Clients call methods as "{ServiceName}.{Method}".
+const ServiceName = "GrayMatter"
+
+// PutRequest is the wire form of AdvancedStore.Put.
+type PutRequest struct {
+	AgentID string
+	Text    string
+}
+
+// PutResponse carries no data; presence indicates success.
+type PutResponse struct{}
+
+// PutSharedRequest is the wire form of AdvancedStore.PutShared.
+type PutSharedRequest struct {
+	Text string
+}
+
+// PutSharedResponse carries no data.
+type PutSharedResponse struct{}
+
+// RecallRequest is the wire form of AdvancedStore.Recall.
+type RecallRequest struct {
+	AgentID string
+	Query   string
+	TopK    int
+}
+
+// RecallResponse carries the recalled facts in ranked order.
+type RecallResponse struct {
+	Facts []string
+}
+
+// RecallSharedRequest is the wire form of AdvancedStore.RecallShared.
+type RecallSharedRequest struct {
+	Query string
+	TopK  int
+}
+
+// RecallSharedResponse carries the recalled shared facts in ranked order.
+type RecallSharedResponse struct {
+	Facts []string
+}
+
+// RecallAllRequest is the wire form of Store.RecallAll (agent + shared
+// namespaces merged and deduplicated).
+type RecallAllRequest struct {
+	AgentID string
+	Query   string
+	TopK    int
+}
+
+// RecallAllResponse carries the merged facts in ranked order.
+type RecallAllResponse struct {
+	Facts []string
+}
+
+// ListRequest is the wire form of AdvancedStore.List.
+type ListRequest struct {
+	AgentID string
+}
+
+// ListResponse carries every fact for an agent, newest first.
+type ListResponse struct {
+	Facts []memory.Fact
+}
+
+// ListAgentsRequest is the wire form of AdvancedStore.ListAgents.
+// It carries no fields; the empty struct is required by net/rpc.
+type ListAgentsRequest struct{}
+
+// ListAgentsResponse carries every known agent ID.
+type ListAgentsResponse struct {
+	AgentIDs []string
+}
+
+// StatsRequest is the wire form of AdvancedStore.Stats.
+type StatsRequest struct {
+	AgentID string
+}
+
+// StatsResponse carries aggregate fact statistics.
+type StatsResponse struct {
+	Stats memory.MemoryStats
+}
+
+// DeleteRequest is the wire form of AdvancedStore.Delete.
+type DeleteRequest struct {
+	AgentID string
+	FactID  string
+}
+
+// DeleteResponse carries no data.
+type DeleteResponse struct{}
+
+// UpdateFactRequest is the wire form of AdvancedStore.UpdateFact.
+type UpdateFactRequest struct {
+	AgentID string
+	Fact    memory.Fact
+}
+
+// UpdateFactResponse carries no data.
+type UpdateFactResponse struct{}
+
+// ConsolidateRequest triggers server-side consolidation for an agent.
+//
+// Note: unlike AdvancedStore.Consolidate, the wire form does NOT carry a
+// ConsolidateConfig. The daemon owns its consolidation policy and uses
+// its own configuration. Clients cannot override it across the wire.
+type ConsolidateRequest struct {
+	AgentID string
+}
+
+// ConsolidateResponse carries no data.
+type ConsolidateResponse struct{}
+
+// PendingVectorCountRequest is the wire form of
+// AdvancedStore.PendingVectorCount.
+type PendingVectorCountRequest struct{}
+
+// PendingVectorCountResponse carries the pending count.
+type PendingVectorCountResponse struct {
+	Count int
+}
+
+// PingRequest is a liveness probe used by Client.Dial to verify the server
+// is reachable before the client returns. Carries no fields.
+type PingRequest struct{}
+
+// PingResponse echoes the server's protocol version.
+type PingResponse struct {
+	Protocol string
+}
+
+// Protocol identifies the wire-format version. Bump on breaking changes;
+// clients refuse to talk to a server with a mismatched protocol string.
+const Protocol = "graymatter-rpc/1"

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -74,6 +74,13 @@ type StoreConfig struct {
 	// to read-only if the write lock is held by another process.
 	ReadOnly bool
 
+	// StrictWrite disables the automatic read-only fallback: if the write lock
+	// cannot be acquired, Open fails immediately with the lock-holder error
+	// instead of degrading. The daemon uses this — a store owner that silently
+	// came up read-only would break every connected client. Mutually exclusive
+	// with ReadOnly (StrictWrite wins).
+	StrictWrite bool
+
 	// OnRecall, if non-nil, is called after each Recall with timing and count.
 	OnRecall func(agentID, query string, resultCount int, duration time.Duration)
 
@@ -134,7 +141,7 @@ func Open(cfg StoreConfig) (*Store, error) {
 	}
 
 	dbPath := filepath.Join(cfg.DataDir, "gray.db")
-	db, readOnly, err := openBoltDB(dbPath, cfg.ReadOnly)
+	db, readOnly, err := openBoltDB(dbPath, cfg.ReadOnly, cfg.StrictWrite)
 	if err != nil {
 		return nil, err
 	}
@@ -204,10 +211,12 @@ func Open(cfg StoreConfig) (*Store, error) {
 
 // openBoltDB opens the bbolt database at path. If forceRO is true it opens
 // directly in read-only mode. Otherwise it attempts a normal write open; on
-// lock timeout it falls back to read-only and returns isReadOnly=true. If both
-// modes fail a descriptive error is returned.
-func openBoltDB(path string, forceRO bool) (db *bolt.DB, isReadOnly bool, err error) {
-	if forceRO {
+// lock timeout it falls back to read-only and returns isReadOnly=true —
+// unless strictWrite is set, in which case the lock timeout is surfaced
+// immediately (daemon mode must never come up degraded). If both modes fail
+// a descriptive error is returned.
+func openBoltDB(path string, forceRO, strictWrite bool) (db *bolt.DB, isReadOnly bool, err error) {
+	if forceRO && !strictWrite {
 		db, err = bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true, Timeout: boltOpenTimeout})
 		if err != nil {
 			return nil, false, fmt.Errorf("open bbolt read-only: %w", err)
@@ -221,6 +230,10 @@ func openBoltDB(path string, forceRO bool) (db *bolt.DB, isReadOnly bool, err er
 	}
 	if !errors.Is(err, bolt.ErrTimeout) {
 		return nil, false, fmt.Errorf("open bbolt: %w", err)
+	}
+	if strictWrite {
+		return nil, false, fmt.Errorf(
+			"gray.db is locked by another process (strict-write open refused to degrade): %w", err)
 	}
 
 	// Write lock held by another process; fall back to read-only.


### PR DESCRIPTION
## What this is

The structural fix for [#8](https://github.com/angelnicolasc/graymatter/issues/8): a client/server model so multiple `graymatter` processes can use the same store at once. Closes the lock-contention reports in [#4](https://github.com/angelnicolasc/graymatter/issues/4) and [#9](https://github.com/angelnicolasc/graymatter/issues/9).

bbolt is single-writer. Today a second process on the same `--dir` times out: `graymatter tui` + an MCP server, two agents' MCP servers (Claude + Codex), `run` + `tui`, opencode + `tui`. All of these now work.

## Design (as agreed on #8)

- **One daemon owns the store**, everything else is a thin client over a local endpoint — Unix domain socket on POSIX, TCP loopback on Windows. The TUI, MCP server, one-shot CLI commands, and the `run` harness were all migrated to the client path.
- **Transport: `net/rpc` + JSON** (`pkg/memory/rpc`). **Stdlib only — zero new dependencies.** `go.mod` is unchanged; the stripped binary is ~18 MB. The "single static binary, no Docker, no Redis" narrative is intact.
- **Always through the server, no direct-bbolt fallback.** This is the explicit conclusion from the #8 thread (thanks @ishan5ain and @MikeCase): the fallback was a TOCTOU race and a second code path. One path, deterministic semantics.
- **Launch-on-connect + idle-exit.** Clients spawn the daemon on first use; it exits after 2 min idle with no clients. One-shot CLI stays snappy (`dial → spawn → retry → idle-exit`), nothing lingers.
- **No silent degradation.** The daemon opens the store *strict-write*: if it can't own the lock it fails loudly rather than coming up read-only under its clients. The spawn race is resolved by the bbolt lock itself — only the winner writes the discovery file, losers exit, clients converge via dial-retry.
- **Local-only auth.** A 256-bit per-run token in a `0600` discovery file, presented as a connection preamble and constant-time compared. On Windows loopback this is the access control; on Unix the socket is also `0600`. (Answers the open "authentication" question in #8.)

## New surface

- `graymatter daemon run|status|stop` — you normally never run these; clients manage the daemon. They exist for service managers and debugging.
- `--no-daemon` / `GRAYMATTER_NO_DAEMON=1` — in-process open for debugging or air-gapped inspection (reintroduces the single-writer lock by design).
- `graymatter doctor` now reports store health *through* the daemon when one is running, and only flags a lock held by a non-daemon process.

## Tests

- `pkg/memory/rpc`: round-trip over the real socket, 4 concurrent clients writing, wrong/missing-token rejection, active-conn tracking, idle clock.
- `cmd/graymatter/internal/daemon`: builds the real binary and exercises spawn-on-connect, four concurrent clients through one daemon (the #4/#9 scenario), idle-exit, and graceful stop.
- Full suite green on the existing CI matrix (Ubuntu/macOS/Windows × Go 1.22/1.23). Local `-race` needs CGO; CI runs the race matrix.

## Not in scope

- Cross-project federation (the `registry.json` idea from #8) — deferred; this PR is the base refactor it builds on.
- The standalone REST server (`graymatter server`) still opens the store directly; it's a separate long-lived owner. Tracked as a follow-up.
