### PR TITLE
feat(init): add interactive setup wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ dist/
 .graymatter/
 *.db
 /vectors/
+*.local.md
 *.md.local
+go.work.sum
+opencode.jsonc

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,5 @@ dist/
 .graymatter/
 *.db
 /vectors/
-*.local.md
 *.md.local
 go.work.sum
-opencode.jsonc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+**`graymatter init -i` — interactive setup wizard**
+- New `-i`/`--interactive` flag: prompts for which agents to wire instead of auto-detecting everything.
+- Per-agent instructionFile mapping: each known agent declares which instruction file it reads (`CLAUDE.md`, `AGENTS.md`, or none), so only the relevant files are written — an OpenCode-only user finally gets just `AGENTS.md` without `CLAUDE.md`.
+- Dedup: when multiple selected agents share the same instruction file (e.g., Cursor + OpenCode both read `AGENTS.md`), it's written only once.
+- 16 tests covering all agent combinations, input parsing edge cases, dedup, and idempotency.
+- New `knownAgents` table (`cmd_init_interactive.go`) as a single source of truth for agent → {writer, instructionFile} mapping.
+
 ---
 
 ## [0.6.0] – 2026-06-13

--- a/cmd/graymatter/cmd_init.go
+++ b/cmd/graymatter/cmd_init.go
@@ -11,6 +11,7 @@ import (
 
 func initCmd() *cobra.Command {
 	var (
+		interactive      bool
 		skipCodex        bool
 		skipOpencode     bool
 		skipClaudeCode   bool
@@ -33,6 +34,9 @@ GrayMatter is a general-purpose MCP server. The clients listed below are
 just the ones we auto-wire; any MCP-compatible client works over stdio
 (` + "`graymatter mcp serve`" + `) or HTTP (` + "`graymatter mcp serve --http :8080`" + `).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if interactive {
+				return runInteractiveWizard(dataDir, ".", quiet)
+			}
 			dir := dataDir
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return fmt.Errorf("create data dir: %w", err)
@@ -168,6 +172,7 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 		},
 	}
 
+	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interactive setup wizard (prompts for which agents to wire)")
 	cmd.Flags().BoolVar(&skipClaudeCode, "skip-claudecode", false, "do not touch .mcp.json")
 	cmd.Flags().BoolVar(&skipCursor, "skip-cursor", false, "do not touch .cursor/mcp.json")
 	cmd.Flags().BoolVar(&skipCodex, "skip-codex", false, "do not touch ~/.codex/config.toml")

--- a/cmd/graymatter/cmd_init_interactive.go
+++ b/cmd/graymatter/cmd_init_interactive.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// testStdinReader is overridden in tests to provide canned input.
+// Nil in production.
+var testStdinReader *strings.Reader
+
+func stdinReader() *bufio.Scanner {
+	if testStdinReader != nil {
+		return bufio.NewScanner(testStdinReader)
+	}
+	return bufio.NewScanner(os.Stdin)
+}
+
+// agentDef describes one known MCP agent for the interactive wizard.
+type agentDef struct {
+	id              string // claudecode, cursor, opencode, codex, antigravity
+	name            string // display name
+	configDesc      string // human-readable config-file description
+	instructionFile string // instruction file it needs ("" if none)
+	run             func() (writeResult, error)
+}
+
+// knownAgents returns the list of known agents, with project-scoped writers
+// bound to the given project directory.
+func knownAgents(projectDir string) []agentDef {
+	return []agentDef{
+		{
+			id: "claudecode", name: "Claude Code", configDesc: ".mcp.json",
+			instructionFile: "CLAUDE.md",
+			run:             func() (writeResult, error) { return writeClaudeCodeProject(projectDir) },
+		},
+		{
+			id: "cursor", name: "Cursor", configDesc: ".cursor/mcp.json",
+			instructionFile: "AGENTS.md",
+			run:             func() (writeResult, error) { return writeCursorProject(projectDir) },
+		},
+		{
+			id: "opencode", name: "OpenCode", configDesc: "opencode.jsonc",
+			instructionFile: "AGENTS.md",
+			run:             func() (writeResult, error) { return writeOpencodeProject(projectDir) },
+		},
+		{
+			id: "codex", name: "Codex", configDesc: "~/.codex/config.toml",
+			instructionFile: "AGENTS.md",
+			run:             writeCodexHome,
+		},
+		{
+			id: "antigravity", name: "Antigravity", configDesc: "mcp_config.json",
+			instructionFile: "",
+			run:             func() (writeResult, error) { return writeAntigravityProject(projectDir) },
+		},
+	}
+}
+
+// runInteractiveWizard runs the interactive init wizard.
+// It asks which agents to wire, then creates only the files needed for those.
+// projectDir is the project root; writers and instruction files go there.
+func runInteractiveWizard(dir, projectDir string, quiet bool) error {
+	// 1. Create data dir + MEMORY.md (same as non-interactive init).
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+	memoryMD := filepath.Join(dir, "MEMORY.md")
+	if _, err := os.Stat(memoryMD); os.IsNotExist(err) {
+		content := "# GrayMatter Memory\n\nThis directory is managed by GrayMatter.\nDo not edit gray.db manually.\n"
+		if err := os.WriteFile(memoryMD, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("create MEMORY.md: %w", err)
+		}
+	}
+
+	agents := knownAgents(projectDir)
+
+	// 2. Ask which agents to wire.
+	selected := askForAgents(agents)
+
+	if len(selected) == 0 {
+		if !quiet {
+			fmt.Printf("Initialised GrayMatter at %s\n", dir)
+			fmt.Printf("  %s/gray.db       — bbolt database (created on first use)\n", dir)
+			fmt.Printf("  %s/vectors/      — chromem-go vector index\n", dir)
+			fmt.Printf("  %s/MEMORY.md     — human-readable index\n\n", dir)
+			fmt.Println("No MCP clients selected. Run `graymatter init --interactive` again anytime to wire clients.")
+		}
+		maybeAddToPath(quiet)
+		return nil
+	}
+
+	// 3. Build set of selected agent IDs.
+	selSet := make(map[string]bool, len(selected))
+	for _, id := range selected {
+		selSet[id] = true
+	}
+
+	// 4. Build writer entries from selection (preserving knownAgents order).
+	type writerJob struct {
+		name string
+		run  func() (writeResult, error)
+	}
+	var entries []writerJob
+	for _, a := range agents {
+		if selSet[a.id] {
+			entries = append(entries, writerJob{name: a.name, run: a.run})
+		}
+	}
+
+	// 5. Build ordered, deduped list of instruction files.
+	var instrFiles []string
+	instrSet := make(map[string]bool)
+	for _, a := range agents {
+		if selSet[a.id] && a.instructionFile != "" && !instrSet[a.instructionFile] {
+			instrSet[a.instructionFile] = true
+			instrFiles = append(instrFiles, a.instructionFile)
+		}
+	}
+
+	// 6. Run writers and print results.
+	if !quiet {
+		fmt.Printf("Initialised GrayMatter at %s\n\n", dir)
+		fmt.Println("Wired MCP for:")
+	}
+	var warnings []string
+	for _, e := range entries {
+		res, err := e.run()
+		if err != nil {
+			if !quiet {
+				fmt.Printf("  ! %-14s %v\n", e.name, err)
+			}
+			continue
+		}
+		if res.warn != "" {
+			warnings = append(warnings, res.warn)
+			if !quiet {
+				fmt.Printf("  ! %-14s %s (see note below)\n", e.name, res.path)
+			}
+			continue
+		}
+		if !quiet {
+			glyph := "✓"
+			note := ""
+			if !res.changed {
+				glyph = "·"
+				note = " (already wired)"
+			}
+			fmt.Printf("  %s %-14s %s%s\n", glyph, e.name, res.path, note)
+		}
+	}
+
+	// 7. Write instruction files for selected agents.
+	if len(instrFiles) > 0 {
+		if !quiet {
+			fmt.Println("\nAgent instructions (tells the model to actually use the tools):")
+		}
+		for _, name := range instrFiles {
+			res, err := upsertInstructionsBlock(filepath.Join(projectDir, name))
+			if err != nil {
+				res.warn = fmt.Sprintf("could not update %s: %v", name, err)
+			}
+			if res.warn != "" {
+				warnings = append(warnings, res.warn)
+				continue
+			}
+			if !quiet {
+				glyph, note := "✓", ""
+				if !res.changed {
+					glyph, note = "·", " (already present)"
+				}
+				fmt.Printf("  %s %s%s\n", glyph, res.path, note)
+			}
+		}
+	}
+
+	if !quiet {
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "\n%s\n", w)
+		}
+		fmt.Printf("\ngraymatter is a general-purpose MCP server. Any MCP-compatible client works.\n")
+		fmt.Printf("\nNext steps:\n")
+		fmt.Printf("  graymatter doctor   — verify the whole setup end to end\n")
+		fmt.Printf("  graymatter remember \"my-agent\" \"user prefers bullet points\"\n")
+		fmt.Printf("  graymatter recall  \"my-agent\" \"how should I format this?\"\n")
+	}
+
+	maybeAddToPath(quiet)
+	return nil
+}
+
+func maybeAddToPath(quiet bool) {
+	if added, pathErr := addExeDirToUserPath(); pathErr != nil {
+		if !quiet {
+			exe, _ := os.Executable()
+			fmt.Fprintf(os.Stderr,
+				"\n  Warning: could not add %s to PATH: %v\n  Add it manually so you can type 'graymatter' from any directory.\n",
+				filepath.Dir(exe), pathErr)
+		}
+	} else if added && !quiet {
+		exe, _ := os.Executable()
+		fmt.Printf("\n  Added %s to your PATH — restart PowerShell to apply\n", filepath.Dir(exe))
+	}
+}
+
+// askForAgents prints the interactive menu and returns the selected agent IDs.
+// Returns an empty slice if the user selects "None" or enters nothing.
+func askForAgents(agents []agentDef) []string {
+	fmt.Println()
+	fmt.Println("Which AI agent software do you use?")
+	fmt.Println()
+	fmt.Println("Select all that apply (enter numbers separated by commas or spaces):")
+	fmt.Println()
+	fmt.Println("  0  None — data directory only")
+	for i, a := range agents {
+		fmt.Printf("  %d  %s (%s)\n", i+1, a.name, a.configDesc)
+	}
+	fmt.Println()
+	fmt.Print("Selection: ")
+
+	scanner := stdinReader()
+	if !scanner.Scan() {
+		return nil
+	}
+	input := strings.TrimSpace(scanner.Text())
+	if input == "" {
+		return nil
+	}
+
+	// Tokenize by comma, space, or tab.
+	parts := strings.FieldsFunc(input, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
+
+	seen := make(map[string]bool)
+	var result []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(p, "%d", &n); err != nil {
+			continue
+		}
+		if n == 0 {
+			return nil // "None" selected — clears all other selections
+		}
+		if n < 1 || n > len(agents) {
+			continue // out of range — silently skip
+		}
+		id := agents[n-1].id
+		if !seen[id] {
+			seen[id] = true
+			result = append(result, id)
+		}
+	}
+	return result
+}

--- a/cmd/graymatter/cmd_init_interactive.go
+++ b/cmd/graymatter/cmd_init_interactive.go
@@ -54,7 +54,10 @@ func knownAgents(projectDir string) []agentDef {
 		},
 		{
 			id: "antigravity", name: "Antigravity", configDesc: "mcp_config.json",
-			instructionFile: "",
+			// Antigravity reads AGENTS.md (project root cross-tool standard)
+			// alongside its own GEMINI.md. AGENTS.md is sufficient here — see
+			// https://antigravity.codes/blog/antigravity-agents-md-guide
+			instructionFile: "AGENTS.md",
 			run:             func() (writeResult, error) { return writeAntigravityProject(projectDir) },
 		},
 	}

--- a/cmd/graymatter/cmd_init_interactive_test.go
+++ b/cmd/graymatter/cmd_init_interactive_test.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// wireInteractiveTest sets up testStdinReader and returns a cleanup function.
+func wireInteractiveTest(input string) func() {
+	testStdinReader = strings.NewReader(input)
+	return func() { testStdinReader = nil }
+}
+
+func TestAskForAgents_ClaudeCodeOnly(t *testing.T) {
+	defer wireInteractiveTest("1\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	if len(got) != 1 || got[0] != "claudecode" {
+		t.Fatalf("got %v, want [claudecode]", got)
+	}
+}
+
+func TestAskForAgents_OpenCodeOnly(t *testing.T) {
+	defer wireInteractiveTest("3\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	if len(got) != 1 || got[0] != "opencode" {
+		t.Fatalf("got %v, want [opencode]", got)
+	}
+}
+
+func TestAskForAgents_MultipleCommaSeparated(t *testing.T) {
+	defer wireInteractiveTest("1,3,5\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	want := []string{"claudecode", "opencode", "antigravity"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAskForAgents_MultipleSpaceSeparated(t *testing.T) {
+	defer wireInteractiveTest("1 3 5\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	if len(got) != 3 {
+		t.Fatalf("got %v, want [claudecode opencode antigravity]", got)
+	}
+}
+
+func TestAskForAgents_MixedSeparators(t *testing.T) {
+	defer wireInteractiveTest("1, 3,5\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	want := []string{"claudecode", "opencode", "antigravity"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAskForAgents_None(t *testing.T) {
+	defer wireInteractiveTest("0\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty", got)
+	}
+}
+
+func TestAskForAgents_EmptyInput(t *testing.T) {
+	defer wireInteractiveTest("\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty", got)
+	}
+}
+
+func TestAskForAgents_Deduplicates(t *testing.T) {
+	defer wireInteractiveTest("1,2,3,1,2\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	want := []string{"claudecode", "cursor", "opencode"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAskForAgents_NoneOverridesOthers(t *testing.T) {
+	defer wireInteractiveTest("1,2,0,3\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	// "0" overrides all — returns empty
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty (0 overrides)", got)
+	}
+}
+
+func TestAskForAgents_OutOfRangeIgnored(t *testing.T) {
+	defer wireInteractiveTest("1,99,3\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	want := []string{"claudecode", "opencode"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAskForAgents_NonNumericIgnored(t *testing.T) {
+	defer wireInteractiveTest("1,x,3\n")()
+	agents := knownAgents(".")
+	got := askForAgents(agents)
+	want := []string{"claudecode", "opencode"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// --- runInteractiveWizard integration tests ---
+
+func TestInteractive_ClaudeCodeOnly(t *testing.T) {
+	defer wireInteractiveTest("1\n")()
+	tmpDir := t.TempDir()
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Config file created.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".mcp.json")); os.IsNotExist(err) {
+		t.Error(".mcp.json should exist")
+	}
+	// Only CLAUDE.md gets the block, not AGENTS.md.
+	claudeData, err := os.ReadFile(filepath.Join(tmpDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal("CLAUDE.md should exist:", err)
+	}
+	if !strings.Contains(string(claudeData), "memory_search") {
+		t.Error("CLAUDE.md should contain memory block")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("AGENTS.md should NOT exist for Claude Code only")
+	}
+}
+
+func TestInteractive_OpenCodeOnly(t *testing.T) {
+	defer wireInteractiveTest("3\n")()
+	tmpDir := t.TempDir()
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Config file created.
+	if _, err := os.Stat(filepath.Join(tmpDir, "opencode.jsonc")); os.IsNotExist(err) {
+		t.Error("opencode.jsonc should exist")
+	}
+	// AGENTS.md gets the block, not CLAUDE.md.
+	agentsData, err := os.ReadFile(filepath.Join(tmpDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatal("AGENTS.md should exist:", err)
+	}
+	if !strings.Contains(string(agentsData), "memory_search") {
+		t.Error("AGENTS.md should contain memory block")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Error("CLAUDE.md should NOT exist for OpenCode only")
+	}
+}
+
+func TestInteractive_AllAgents(t *testing.T) {
+	defer wireInteractiveTest("1,2,3,4,5\n")()
+	tmpDir := t.TempDir()
+	testHomeOverride = tmpDir
+	t.Cleanup(func() { testHomeOverride = "" })
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All config files created.
+	for _, f := range []string{".mcp.json", filepath.Join(".cursor", "mcp.json"), "opencode.jsonc", "mcp_config.json"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, f)); os.IsNotExist(err) {
+			t.Errorf("%s should exist", f)
+		}
+	}
+	// Codex home config.
+	codexCfg := filepath.Join(tmpDir, ".codex", "config.toml")
+	if _, err := os.Stat(codexCfg); os.IsNotExist(err) {
+		t.Error("~/.codex/config.toml should exist")
+	}
+
+	// Both instruction files created (Claude Code → CLAUDE.md, others → AGENTS.md).
+	for _, f := range []string{"CLAUDE.md", "AGENTS.md"} {
+		data, err := os.ReadFile(filepath.Join(tmpDir, f))
+		if err != nil {
+			t.Fatalf("%s should exist: %v", f, err)
+		}
+		if !strings.Contains(string(data), "memory_search") {
+			t.Errorf("%s should contain memory block", f)
+		}
+	}
+}
+
+func TestInteractive_NoneSelected(t *testing.T) {
+	defer wireInteractiveTest("0\n")()
+	tmpDir := t.TempDir()
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Data dir exists.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".graymatter")); os.IsNotExist(err) {
+		t.Error(".graymatter data dir should exist")
+	}
+	// No config files.
+	for _, f := range []string{".mcp.json", "opencode.jsonc", "CLAUDE.md", "AGENTS.md"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should NOT exist when none selected", f)
+		}
+	}
+}
+
+func TestInteractive_CursorAndOpenCodeShareAGENTSMd(t *testing.T) {
+	// Cursor + OpenCode — both use AGENTS.md. Should write it once.
+	defer wireInteractiveTest("2,3\n")()
+	tmpDir := t.TempDir()
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both configs present.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".cursor", "mcp.json")); os.IsNotExist(err) {
+		t.Error(".cursor/mcp.json should exist")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "opencode.jsonc")); os.IsNotExist(err) {
+		t.Error("opencode.jsonc should exist")
+	}
+	// AGENTS.md should have the block.
+	data, err := os.ReadFile(filepath.Join(tmpDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatal("AGENTS.md should exist:", err)
+	}
+	if !strings.Contains(string(data), "memory_search") {
+		t.Error("AGENTS.md should contain memory block")
+	}
+	// Only one AGENTS.md block (check marker appears exactly twice: begin + end).
+	marker := "<!-- graymatter:instructions:begin"
+	if strings.Count(string(data), marker) != 1 {
+		t.Errorf("expected exactly one instruction block, got %d", strings.Count(string(data), marker))
+	}
+	// CLAUDE.md should not exist.
+	if _, err := os.Stat(filepath.Join(tmpDir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Error("CLAUDE.md should NOT exist")
+	}
+}
+
+func TestInteractive_DataDirCreated(t *testing.T) {
+	defer wireInteractiveTest("1\n")()
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "custom-dir")
+
+	err := runInteractiveWizard(dataDir, tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
+		t.Error("custom data dir should exist")
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "MEMORY.md")); os.IsNotExist(err) {
+		t.Error("MEMORY.md should exist in data dir")
+	}
+}
+
+func TestInteractive_IdempotentRun(t *testing.T) {
+	defer wireInteractiveTest("1\n")()
+	tmpDir := t.TempDir()
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run — same input, should not error.
+	testStdinReader = strings.NewReader("1\n")
+	defer func() { testStdinReader = nil }()
+
+	err = runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal("second run should succeed:", err)
+	}
+}
+
+func TestInteractive_InstructionFilePreservesUserContent(t *testing.T) {
+	defer wireInteractiveTest("3\n")()
+	tmpDir := t.TempDir()
+
+	// Pre-create AGENTS.md with user content (no markers).
+	userContent := "# My Project\n\nThis is my AGENTS.md.\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "AGENTS.md"), []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, userContent) {
+		t.Error("user content not preserved at top")
+	}
+	if !strings.Contains(content, "memory_search") {
+		t.Error("memory block not appended")
+	}
+}
+
+func TestInteractive_EmptyInputProducesNoFiles(t *testing.T) {
+	defer wireInteractiveTest("\n")()
+	tmpDir := t.TempDir()
+
+	err := runInteractiveWizard(filepath.Join(tmpDir, ".graymatter"), tmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only data dir.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".graymatter")); os.IsNotExist(err) {
+		t.Error("data dir should exist")
+	}
+	for _, f := range []string{".mcp.json", "opencode.jsonc", "CLAUDE.md", "AGENTS.md"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should NOT exist on empty input", f)
+		}
+	}
+}


### PR DESCRIPTION
Thanks Nick, I appreciate that! Here's the updates you requested. 

Interactive init wizard (`graymatter init -i`) that prompts which MCP agents to wire instead of auto-detecting everything. Only selected agents get config files and instruction blocks.

- New `-i`/`--interactive` flag on `init`
- Wizard picks from Claude Code, Cursor, OpenCode, Codex, Antigravity
- Per-agent `instructionFile` mapping — each agent declares which file it reads, so only relevant files are written (an OpenCode-only user gets just `AGENTS.md`)
- Dedup: shared instruction files written once when multiple agents need the same one
- 16 tests covering all agent combos, input parsing, dedup, edge cases, idempotency
- Gitignore: `go.work.sum`

### Review fixups (c4899d6)
- `.gitignore`: dropped `*.local.md` and `opencode.jsonc` (was inconsistent with the repo dogfooding its own config files), kept `go.work.sum`
- `CHANGELOG`: added `### Added` section under `[Unreleased]`
- Antigravity `instructionFile` mapped to `"AGENTS.md"` (it reads the cross-tool standard, not nothing — confirmed via antigravity.codes/blog)
