### PR TITLE
fix: make agents actually use memory (closes #14, #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - New `knownAgents` table (`cmd_init_interactive.go`) as a single source of truth for agent → {writer, instructionFile} mapping.
 
 **`graymatter init --global` (issue #17)**
-- Writes the managed memory block into `~/.claude/CLAUDE.md` and `~/.config/opencode/AGENTS.md`, the home-scoped files agents read no matter which project they are working in. Global installs no longer need `init` run in every repo just to get the instructions.
+- Writes the managed memory block into `~/.claude/CLAUDE.md` and `~/.config/opencode/AGENTS.md`, the home-scoped files agents read no matter which project they are working in. Global installs no longer need `init` run in every repo just to get the instructions. Works with `-i` too.
+- `XDG_CONFIG_HOME` is honoured for the OpenCode path. OpenCode resolves its global config through it, so hardcoding `~/.config` would have written where nothing reads. The directory is `~/.config/opencode` on every platform, Windows included; OpenCode does not use `%APPDATA%`.
 - Same marker-based upsert as the project files, so it stays idempotent and leaves your own global instructions untouched.
+- The block guards on the tools actually being present, since a global install reaches projects that never wired GrayMatter. It is a capability check, not a judgement call, so it cannot become the hedge that made the old block ignorable.
+- Deliberately not a `SKILL.md`. OpenCode loads skills lazily, advertising only name and description and leaving the body to the model's discretion, which puts the same "the model decides whether to bother" failure one level up. Instructions that must run before the first reply belong in a file that is always loaded.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - 16 tests covering all agent combinations, input parsing edge cases, dedup, and idempotency.
 - New `knownAgents` table (`cmd_init_interactive.go`) as a single source of truth for agent → {writer, instructionFile} mapping.
 
+**`graymatter init --global` (issue #17)**
+- Writes the managed memory block into `~/.claude/CLAUDE.md` and `~/.config/opencode/AGENTS.md`, the home-scoped files agents read no matter which project they are working in. Global installs no longer need `init` run in every repo just to get the instructions.
+- Same marker-based upsert as the project files, so it stays idempotent and leaves your own global instructions untouched.
+
+### Fixed
+
+**Agent instructions now read as a procedure (issue #14)**
+- The generated block described the five tools and told the model to search "when prior context might matter", a condition it can resolve to false every single time. Reported by several users as "init and doctor are green but nothing is ever stored".
+- Rewritten as an unconditional session protocol plus a trigger table, matching the briefing this repo already dogfoods in its own `AGENTS.md`.
+- `agent_id` is now derivable instead of invented: it is the repository root directory name. The old `<project>-<role>` template produced a different id per session, which scattered facts across namespaces and looked exactly like memory being broken.
+- Existing files migrate in place. The markers are unchanged, so re-running `init` replaces the old block rather than stacking a second one.
+
+**`graymatter doctor` notices a project that was set up and never used (issue #14)**
+- Every other check can be green while the agent has never called a single tool, and the summary still read "Everything looks good". That is why this failure produced so few reports: a fresh install and a week of silence looked identical, so people quietly gave up instead of filing anything.
+- A project initialised more than 24 hours ago that still holds no facts is now a warning with an actionable hint. The age is read from `MEMORY.md`, which `init` writes once and nothing else touches.
+
+**MCP tools no longer advertise themselves as destructive**
+- All five tools inherited mcp-go's defaults (`readOnlyHint: false`, `destructiveHint: true`, `openWorldHint: true`), so `memory_search` and `checkpoint_resume`, both pure reads, were announced to clients as destructive open-world calls. Clients use those hints to choose between auto-approving a call and prompting for it.
+- Each tool now declares what it actually does, and a test pins the annotations so a dependency bump cannot quietly reset them.
+
 ---
 
 ## [0.6.0] – 2026-06-13

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -144,12 +145,51 @@ func checkDataDir(dir string) checkResult {
 	return c
 }
 
+// staleAfter is how long a project may sit initialised with nothing stored
+// before doctor stops calling that normal. Long enough that a genuinely new
+// project stays quiet, short enough that a broken setup surfaces inside a
+// working day.
+const staleAfter = 24 * time.Hour
+
+// projectAge reports how long ago the project was initialised, using MEMORY.md
+// as the anchor: init writes it once and nothing else touches it, unlike the
+// data directory whose mtime moves every time the daemon starts.
+func projectAge(dir string) (time.Duration, bool) {
+	info, err := os.Stat(filepath.Join(dir, "MEMORY.md"))
+	if err != nil {
+		return 0, false
+	}
+	return time.Since(info.ModTime()), true
+}
+
+// flagIfUnused downgrades an otherwise-healthy store check to a warning when a
+// project has been set up for a while and still holds nothing.
+//
+// This is the gap issue #14 fell through: wiring, instructions and store can
+// all be green while the agent never calls a single tool, and the old summary
+// still read "Everything looks good". A user had no way to tell a fresh install
+// apart from a week of silence, so the failure produced no bug reports, just
+// people quietly giving up.
+func flagIfUnused(c checkResult, dir string, facts int) checkResult {
+	if facts > 0 || (c.Status != "ok" && c.Status != "info") {
+		return c
+	}
+	age, ok := projectAge(dir)
+	if !ok || age < staleAfter {
+		return c
+	}
+	c.Status = "warn"
+	c.Detail = fmt.Sprintf("initialised %d day(s) ago and still holds no facts", int(age.Hours()/24))
+	c.Hint = "the tools are wired but nothing is calling them; confirm CLAUDE.md / AGENTS.md carry the memory block (re-run `graymatter init` to refresh it) and that your agent loads that file, or use `graymatter init --global` to install it for every project"
+	return c
+}
+
 func checkStore(dir string) checkResult {
 	c := checkResult{Name: "store"}
 	dbPath := filepath.Join(dir, "gray.db")
 	if _, err := os.Stat(dbPath); err != nil {
 		c.Status, c.Detail = "info", "no database yet (gray.db is created on first write)"
-		return c
+		return flagIfUnused(c, dir, 0)
 	}
 
 	// Preferred path: ask the daemon, which owns the store in normal
@@ -175,7 +215,7 @@ func checkStore(dir string) checkResult {
 			c.Detail += fmt.Sprintf(", %d pending vector write(s)", pending)
 			c.Hint = "pending vectors in a quiescent system mean the embedding backend is failing — check your embedding configuration (Ollama URL / API keys)"
 		}
-		return c
+		return flagIfUnused(c, dir, facts)
 	}
 
 	// No daemon: read-only probe. Lock contention here means some non-daemon
@@ -213,7 +253,7 @@ func checkStore(dir string) checkResult {
 		c.Detail += fmt.Sprintf(", %d pending vector write(s)", pending)
 		c.Hint = "pending vectors in a quiescent system mean the embedding backend is failing — check your embedding configuration (Ollama URL / API keys)"
 	}
-	return c
+	return flagIfUnused(c, dir, facts)
 }
 
 // mcpClientConfigs mirrors the paths used by the init writers

--- a/cmd/graymatter/cmd_doctor_test.go
+++ b/cmd/graymatter/cmd_doctor_test.go
@@ -6,9 +6,43 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
+
+// TestCheckStore_FlagsLongIdleProject covers the state issue #14 was actually
+// about: a project that is wired correctly, reports green everywhere, and has
+// never stored a single fact. A fresh install looks identical, so the check has
+// to key off how long the project has been sitting there.
+func TestCheckStore_FlagsLongIdleProject(t *testing.T) {
+	dir := t.TempDir()
+	memoryMD := filepath.Join(dir, "MEMORY.md")
+	if err := os.WriteFile(memoryMD, []byte("# GrayMatter Memory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Just initialised and empty: nothing to complain about yet.
+	if got := checkStore(dir); got.Status != "info" {
+		t.Errorf("fresh project: status = %q, want info (%s)", got.Status, got.Detail)
+	}
+
+	// Two days on, still empty. That is the failure users kept reporting.
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(memoryMD, old, old); err != nil {
+		t.Fatal(err)
+	}
+	got := checkStore(dir)
+	if got.Status != "warn" {
+		t.Fatalf("idle project: status = %q, want warn (%s)", got.Status, got.Detail)
+	}
+	if got.Hint == "" {
+		t.Error("idle warning must carry an actionable hint, that is the whole point")
+	}
+	if !strings.Contains(got.Detail, "no facts") {
+		t.Errorf("detail should say nothing was stored, got %q", got.Detail)
+	}
+}
 
 func TestCheckDataDir(t *testing.T) {
 	t.Run("missing", func(t *testing.T) {

--- a/cmd/graymatter/cmd_init.go
+++ b/cmd/graymatter/cmd_init.go
@@ -36,7 +36,17 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 (` + "`graymatter mcp serve`" + `) or HTTP (` + "`graymatter mcp serve --http :8080`" + `).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if interactive {
-				return runInteractiveWizard(dataDir, ".", quiet)
+				if err := runInteractiveWizard(dataDir, ".", quiet); err != nil {
+					return err
+				}
+				// --global is orthogonal to which clients the wizard wired, so
+				// it applies to both paths rather than only the flag-driven one.
+				if global {
+					for _, w := range installGlobalInstructions(quiet) {
+						fmt.Fprintf(os.Stderr, "\n%s\n", w)
+					}
+				}
+				return nil
 			}
 			dir := dataDir
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -150,22 +160,7 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 			// files, so agents pick up memory in projects that never ran init
 			// (issue #17).
 			if global {
-				if !quiet {
-					fmt.Println("\nGlobal agent instructions (apply in every project):")
-				}
-				for _, res := range writeGlobalInstructionFiles() {
-					if res.warn != "" {
-						warnings = append(warnings, res.warn)
-						continue
-					}
-					if !quiet {
-						glyph, note := "✓", ""
-						if !res.changed {
-							glyph, note = "·", " (already present)"
-						}
-						fmt.Printf("  %s %s%s\n", glyph, res.path, note)
-					}
-				}
+				warnings = append(warnings, installGlobalInstructions(quiet)...)
 			}
 
 			if !quiet {

--- a/cmd/graymatter/cmd_init.go
+++ b/cmd/graymatter/cmd_init.go
@@ -12,6 +12,7 @@ import (
 func initCmd() *cobra.Command {
 	var (
 		interactive      bool
+		global           bool
 		skipCodex        bool
 		skipOpencode     bool
 		skipClaudeCode   bool
@@ -145,6 +146,28 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 				}
 			}
 
+			// --global also writes the block into the home-scoped instruction
+			// files, so agents pick up memory in projects that never ran init
+			// (issue #17).
+			if global {
+				if !quiet {
+					fmt.Println("\nGlobal agent instructions (apply in every project):")
+				}
+				for _, res := range writeGlobalInstructionFiles() {
+					if res.warn != "" {
+						warnings = append(warnings, res.warn)
+						continue
+					}
+					if !quiet {
+						glyph, note := "✓", ""
+						if !res.changed {
+							glyph, note = "·", " (already present)"
+						}
+						fmt.Printf("  %s %s%s\n", glyph, res.path, note)
+					}
+				}
+			}
+
 			if !quiet {
 				for _, w := range warnings {
 					fmt.Fprintf(os.Stderr, "\n%s\n", w)
@@ -179,6 +202,7 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 	cmd.Flags().BoolVar(&skipOpencode, "skip-opencode", false, "do not touch opencode.jsonc")
 	cmd.Flags().BoolVar(&withAntigravity, "with-antigravity", false, "also wire mcp_config.json for Antigravity")
 	cmd.Flags().BoolVar(&skipInstructions, "skip-instructions", false, "do not write the memory block into CLAUDE.md / AGENTS.md")
+	cmd.Flags().BoolVar(&global, "global", false, "also write the memory block into ~/.claude/CLAUDE.md and ~/.config/opencode/AGENTS.md, so agents use memory in every project")
 	cmd.Flags().StringVar(&only, "only", "", "CSV of writers to run (overrides skip flags, not --skip-instructions): claudecode,cursor,codex,opencode,antigravity")
 	return cmd
 }

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -39,9 +39,15 @@ const (
 const blockTmpl = `
 ## Memory (GrayMatter)
 
-You have persistent memory in this project through the ~graymatter~ MCP tools.
-Wiring the MCP server only makes those tools available; nothing calls them for
-you. That is your job, every session.
+You have persistent memory through the ~graymatter~ MCP tools. Wiring the MCP
+server only makes them available; nothing calls them for you. That is your job,
+every session.
+
+This block can be installed globally, so it may reach a project that has no
+GrayMatter wired. If ~memory_search~ is not in your toolbelt for this session,
+skip the rest of this section. That is a check on what tools exist, not a
+judgement call about whether memory seems useful: if the tools are there,
+everything below applies.
 
 ### Your identity
 
@@ -175,10 +181,31 @@ func globalInstructionPaths() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	opencodeDir, err := opencodeConfigDir()
+	if err != nil {
+		return nil, err
+	}
 	return []string{
 		filepath.Join(home, ".claude", "CLAUDE.md"),
-		filepath.Join(home, ".config", "opencode", "AGENTS.md"),
+		filepath.Join(opencodeDir, "AGENTS.md"),
 	}, nil
+}
+
+// opencodeConfigDir resolves OpenCode's global config directory.
+//
+// It is ~/.config/opencode on every platform, Windows included: OpenCode does
+// not use %APPDATA%. XDG_CONFIG_HOME takes precedence when set, which OpenCode
+// supports but does not document on the rules page (anomalyco/opencode#6669) —
+// hardcoding ~/.config would silently write where nothing reads.
+func opencodeConfigDir() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "opencode"), nil
+	}
+	home, err := resolveHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "opencode"), nil
 }
 
 // writeGlobalInstructionFiles upserts the memory block into every path returned
@@ -197,6 +224,30 @@ func writeGlobalInstructionFiles() []writeResult {
 		out = append(out, res)
 	}
 	return out
+}
+
+// installGlobalInstructions writes the block into the home-scoped files and
+// prints what happened, returning any warnings for the caller to surface.
+// Shared by the plain --global path and the wizard so the two cannot drift.
+func installGlobalInstructions(quiet bool) []string {
+	var warnings []string
+	if !quiet {
+		fmt.Println("\nGlobal agent instructions (apply in every project):")
+	}
+	for _, res := range writeGlobalInstructionFiles() {
+		if res.warn != "" {
+			warnings = append(warnings, res.warn)
+			continue
+		}
+		if !quiet {
+			glyph, note := "✓", ""
+			if !res.changed {
+				glyph, note = "·", " (already present)"
+			}
+			fmt.Printf("  %s %s%s\n", glyph, res.path, note)
+		}
+	}
+	return warnings
 }
 
 // hasInstructionsBlock reports whether path contains the managed block (or at

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -18,22 +18,85 @@ const (
 )
 
 // instructionsBlock is the canonical memory-usage briefing, including the
-// begin/end markers. Param names here must match the MCP tool schemas
-// (cmd/graymatter/internal/mcp/server.go) — notably memory_reflect's `agent`
-// vs everyone else's `agent_id`.
-func instructionsBlock() string {
-	return instrBeginMarker + `
+// begin/end markers.
+//
+// Two things this text has to get right, both learned the hard way from issue
+// #14 ("everything is green but the agent never stored anything"):
+//
+//  1. It has to read as a procedure, not as API documentation. The earlier
+//     version described the five tools and said to search "when prior context
+//     might matter" — a condition a model can resolve to false every single
+//     time. Triggers are now unconditional and tabulated.
+//  2. The agent_id has to be derivable, not invented. A template like
+//     `<project>-<role>` produces a different id per session, which scatters
+//     facts across namespaces and looks exactly like memory not working.
+//
+// Param names must match the MCP tool schemas
+// (cmd/graymatter/internal/mcp/server.go).
+//
+// blockTmpl uses ~ where the rendered markdown needs a backtick: Go raw strings
+// cannot contain one, and this text is mostly code spans.
+const blockTmpl = `
 ## Memory (GrayMatter)
 
-This project has persistent agent memory via the ` + "`graymatter`" + ` MCP tools:
+You have persistent memory in this project through the ~graymatter~ MCP tools.
+Wiring the MCP server only makes those tools available; nothing calls them for
+you. That is your job, every session.
 
-- ` + "`memory_search`" + ` (` + "`agent_id`, `query`" + `) — call at the **start of a task** when prior context might matter.
-- ` + "`memory_add`" + ` (` + "`agent_id`, `text`" + `) — call whenever you learn something **durable**: user preferences, decisions, conventions, gotchas.
-- ` + "`memory_reflect`" + ` (` + "`action`, `agent`, `text`/`target`" + `) — update or forget stale facts. ⚠ takes ` + "`agent`" + `, not ` + "`agent_id`" + `.
-- ` + "`checkpoint_save`" + ` / ` + "`checkpoint_resume`" + ` (` + "`agent_id`" + `) — snapshot/restore session state before major refactors or across restarts.
+### Your identity
 
-Use a stable ` + "`agent_id`" + ` of the form ` + "`<project>-<role>`" + ` (e.g. ` + "`myapp-backend`" + `). Store conclusions, not conversation logs. Err on the side of remembering.
-` + instrEndMarker + "\n"
+Your ~agent_id~ is the name of this repository's root directory, used verbatim
+every session. Add a ~-<role>~ suffix only when several agents share the repo
+(~myapp-backend~, ~myapp-frontend~). Inventing a new id per session scatters
+your facts across namespaces and looks exactly like memory being broken.
+
+Facts every agent in the project should see go to the reserved id ~__shared__~.
+
+### Every session, without exception
+
+1. **Before your first reply**, call ~memory_search~ with the user's request as
+   the query. Then call it again with ~agent_id~ set to ~__shared__~. Fold both
+   results into your working context before you answer.
+2. **Resuming long-running work**: ~checkpoint_resume~ first.
+3. **Before you stop**, store what you learned (see the table) and call
+   ~checkpoint_save~ if the task is unfinished.
+
+### What triggers a call
+
+| When this happens | Call |
+|---|---|
+| You start any task | ~memory_search~ |
+| The user states a preference | ~memory_add~ |
+| You discover a project convention | ~memory_add~ with ~agent_id: "__shared__"~ |
+| You make a non-obvious decision | ~memory_add~, include the reasoning |
+| You fix a non-trivial bug or find a workaround | ~memory_add~ |
+| The user corrects you | ~memory_reflect~ with ~action="update"~ |
+| A stored fact became wrong | ~memory_reflect~ with ~action="forget"~ |
+
+Err toward storing. A fact you never needed costs nothing. One you failed to
+store costs the same mistake a second time.
+
+### The tools
+
+| Tool | Required | Optional |
+|---|---|---|
+| ~memory_search~ | ~agent_id~, ~query~ | ~top_k~ (default 8) |
+| ~memory_add~ | ~agent_id~, ~text~ | |
+| ~memory_reflect~ | ~action~, ~agent~ | ~text~, ~target~ |
+| ~checkpoint_save~ | ~agent_id~ | ~state~ |
+| ~checkpoint_resume~ | ~agent_id~ | |
+
+⚠ ~memory_reflect~ takes ~agent~, not ~agent_id~. The other four take
+~agent_id~. Mixing them up fails validation.
+
+### Store conclusions, not transcripts
+
+One idea per call. Skip anything already in the code or the README, anything
+transient (that is what checkpoints are for), and never store secrets.
+`
+
+func instructionsBlock() string {
+	return instrBeginMarker + strings.ReplaceAll(blockTmpl, "~", "`") + instrEndMarker + "\n"
 }
 
 // upsertInstructionsBlock writes the graymatter memory block into path:
@@ -91,6 +154,45 @@ func writeInstructionFiles(projectDir string) []writeResult {
 		res, err := upsertInstructionsBlock(filepath.Join(projectDir, name))
 		if err != nil {
 			res.warn = fmt.Sprintf("could not update %s: %v", name, err)
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+// globalInstructionPaths returns the home-scoped instruction files agents read
+// no matter which project they are working in. Writing the block here is what
+// makes memory available in every repo without running `init` in each one
+// (issue #17).
+//
+// Claude Code reads ~/.claude/CLAUDE.md. OpenCode renders the global
+// ~/.config/opencode/AGENTS.md before any project-level AGENTS.md, so the block
+// lands ahead of project content rather than replacing it. Both are plain
+// markdown, so the same marker-based upsert applies and a user's own global
+// instructions are left untouched.
+func globalInstructionPaths() ([]string, error) {
+	home, err := resolveHome()
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".config", "opencode", "AGENTS.md"),
+	}, nil
+}
+
+// writeGlobalInstructionFiles upserts the memory block into every path returned
+// by globalInstructionPaths. Returns one result per file, in a stable order.
+func writeGlobalInstructionFiles() []writeResult {
+	paths, err := globalInstructionPaths()
+	if err != nil {
+		return []writeResult{{warn: fmt.Sprintf("could not resolve home directory: %v", err)}}
+	}
+	out := make([]writeResult, 0, len(paths))
+	for _, p := range paths {
+		res, err := upsertInstructionsBlock(p)
+		if err != nil {
+			res.warn = fmt.Sprintf("could not update %s: %v", p, err)
 		}
 		out = append(out, res)
 	}

--- a/cmd/graymatter/cmd_init_instructions_test.go
+++ b/cmd/graymatter/cmd_init_instructions_test.go
@@ -131,6 +131,12 @@ func TestInstructionsBlock_IsProcedural(t *testing.T) {
 		"root directory",                   // agent_id is derivable, not invented
 		"checkpoint_resume",
 		"checkpoint_save",
+		// --global puts this block in projects that may not have GrayMatter
+		// wired, so it has to guard on the tools existing. The guard is a
+		// capability check on purpose: phrased as judgement it would recreate
+		// the very hedge that made the old block ignorable.
+		"not in your toolbelt",
+		"not a\njudgement call",
 	} {
 		if !strings.Contains(block, want) {
 			t.Errorf("block no longer contains %q", want)
@@ -159,6 +165,42 @@ func TestInstructionsBlock_IsProcedural(t *testing.T) {
 		if r > 127 && !strings.ContainsRune(allowed, r) {
 			t.Errorf("unexpected non-ASCII rune %q in generated block body", r)
 		}
+	}
+}
+
+// TestGlobalInstructionPaths_HonoursXDG pins where --global writes. OpenCode
+// resolves its global config through XDG_CONFIG_HOME when that is set, so
+// hardcoding ~/.config would put the block somewhere nothing reads and make
+// --global look like it worked while doing nothing.
+func TestGlobalInstructionPaths_HonoursXDG(t *testing.T) {
+	home := t.TempDir()
+	testHomeOverride = home
+	t.Cleanup(func() { testHomeOverride = "" })
+
+	// Unset: ~/.config/opencode on every platform, Windows included.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	paths, err := globalInstructionPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".config", "opencode", "AGENTS.md"); paths[1] != want {
+		t.Errorf("default opencode path = %q, want %q", paths[1], want)
+	}
+
+	// Set: it wins.
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	paths, err = globalInstructionPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(xdg, "opencode", "AGENTS.md"); paths[1] != want {
+		t.Errorf("XDG opencode path = %q, want %q", paths[1], want)
+	}
+
+	// Claude Code's own path is home-based and unaffected by XDG.
+	if want := filepath.Join(home, ".claude", "CLAUDE.md"); paths[0] != want {
+		t.Errorf("claude path = %q, want %q", paths[0], want)
 	}
 }
 

--- a/cmd/graymatter/cmd_init_instructions_test.go
+++ b/cmd/graymatter/cmd_init_instructions_test.go
@@ -115,6 +115,110 @@ func TestUpsertInstructions_ReplacesManagedBlockOnly(t *testing.T) {
 	}
 }
 
+// TestInstructionsBlock_IsProcedural guards the property that issue #14 turned
+// on: the block has to tell the model what to do and when, not just describe
+// the tools. The earlier version listed the five tools and gated the search on
+// "when prior context might matter", which a model can read as never. If these
+// anchors disappear the briefing has drifted back to being documentation.
+func TestInstructionsBlock_IsProcedural(t *testing.T) {
+	block := instructionsBlock()
+
+	for _, want := range []string{
+		"Every session, without exception", // unconditional session protocol
+		"Before your first reply",          // concrete first action
+		"__shared__",                       // shared namespace is discoverable
+		"What triggers a call",             // trigger table, not prose
+		"root directory",                   // agent_id is derivable, not invented
+		"checkpoint_resume",
+		"checkpoint_save",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("block no longer contains %q", want)
+		}
+	}
+
+	// The conditional phrasing that made the old block ignorable.
+	for _, unwanted := range []string{"might matter", "when prior context"} {
+		if strings.Contains(block, unwanted) {
+			t.Errorf("block reintroduced conditional phrasing %q", unwanted)
+		}
+	}
+
+	// The template placeholder must be fully rendered: a stray ~ means a code
+	// span leaked into the generated markdown.
+	if strings.Contains(block, "~") {
+		t.Error("block contains an unrendered ~ placeholder")
+	}
+
+	// Guard against stray non-ASCII in the briefing the user actually reads,
+	// with an allowlist for the glyphs it uses on purpose. Scoped to the body:
+	// instrBeginMarker predates this and cannot be retyped without breaking the
+	// upsert on every file that already carries the old marker.
+	const allowed = "⚠"
+	for _, r := range strings.ReplaceAll(blockTmpl, "~", "`") {
+		if r > 127 && !strings.ContainsRune(allowed, r) {
+			t.Errorf("unexpected non-ASCII rune %q in generated block body", r)
+		}
+	}
+}
+
+func TestWriteGlobalInstructionFiles(t *testing.T) {
+	home := t.TempDir()
+	testHomeOverride = home
+	t.Cleanup(func() { testHomeOverride = "" })
+
+	results := writeGlobalInstructionFiles()
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "CLAUDE.md"),
+		filepath.Join(".config", "opencode", "AGENTS.md"),
+	} {
+		data, err := os.ReadFile(filepath.Join(home, rel))
+		if err != nil {
+			t.Fatalf("%s not written: %v", rel, err)
+		}
+		if !strings.Contains(string(data), "memory_search") {
+			t.Errorf("%s missing the memory block", rel)
+		}
+	}
+
+	// Second run is a no-op: the block is managed by markers, so re-running
+	// init --global must not stack duplicates in a user's global file.
+	for _, res := range writeGlobalInstructionFiles() {
+		if res.changed {
+			t.Errorf("second run rewrote %s", res.path)
+		}
+	}
+}
+
+func TestWriteGlobalInstructionFiles_PreservesUserContent(t *testing.T) {
+	home := t.TempDir()
+	testHomeOverride = home
+	t.Cleanup(func() { testHomeOverride = "" })
+
+	claude := filepath.Join(home, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(claude), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const userContent = "# My global rules\n\nAlways answer in Spanish.\n"
+	if err := os.WriteFile(claude, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeGlobalInstructionFiles()
+
+	data, _ := os.ReadFile(claude)
+	if !strings.HasPrefix(string(data), userContent) {
+		t.Error("existing global instructions were not preserved")
+	}
+	if !strings.Contains(string(data), "memory_search") {
+		t.Error("memory block not appended to the global file")
+	}
+}
+
 func TestHasInstructionsBlock(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/graymatter/internal/mcp/annotations_test.go
+++ b/cmd/graymatter/internal/mcp/annotations_test.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestToolAnnotations pins the hints every tool advertises in tools/list.
+//
+// This goes through HandleMessage rather than inspecting the Tool structs so it
+// asserts on exactly the payload a client receives. It exists because mcp-go's
+// NewTool defaults everything to destructive + non-idempotent + open-world: if
+// a dependency bump ever drops our annotations, hosts start gating plain
+// lookups behind an approval prompt and unattended agents quietly stop calling
+// them. That failure is invisible from the outside, so it gets a test.
+func TestToolAnnotations(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	req := json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	raw, err := json.Marshal(s.mcpSrv.HandleMessage(context.Background(), req))
+	if err != nil {
+		t.Fatalf("marshal tools/list response: %v", err)
+	}
+
+	var resp struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				Annotations struct {
+					ReadOnlyHint    *bool `json:"readOnlyHint"`
+					DestructiveHint *bool `json:"destructiveHint"`
+					IdempotentHint  *bool `json:"idempotentHint"`
+					OpenWorldHint   *bool `json:"openWorldHint"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode tools/list response: %v\n%s", err, raw)
+	}
+
+	type hints struct{ readOnly, destructive, idempotent bool }
+	want := map[string]hints{
+		"memory_search":     {readOnly: true, destructive: false, idempotent: true},
+		"checkpoint_resume": {readOnly: true, destructive: false, idempotent: true},
+		"memory_add":        {readOnly: false, destructive: false, idempotent: false},
+		"checkpoint_save":   {readOnly: false, destructive: false, idempotent: false},
+		"memory_reflect":    {readOnly: false, destructive: true, idempotent: false},
+	}
+
+	if len(resp.Result.Tools) != len(want) {
+		t.Fatalf("got %d tools, want %d", len(resp.Result.Tools), len(want))
+	}
+
+	seen := make(map[string]bool, len(want))
+	for _, tool := range resp.Result.Tools {
+		exp, ok := want[tool.Name]
+		if !ok {
+			t.Errorf("unexpected tool %q; add it to the annotation table", tool.Name)
+			continue
+		}
+		seen[tool.Name] = true
+
+		a := tool.Annotations
+		for _, c := range []struct {
+			field string
+			got   *bool
+			want  bool
+		}{
+			{"readOnlyHint", a.ReadOnlyHint, exp.readOnly},
+			{"destructiveHint", a.DestructiveHint, exp.destructive},
+			{"idempotentHint", a.IdempotentHint, exp.idempotent},
+			// Every tool reads and writes the local store only. An open world
+			// hint would push hosts toward treating them like network calls.
+			{"openWorldHint", a.OpenWorldHint, false},
+		} {
+			if c.got == nil {
+				t.Errorf("%s: %s missing from tools/list", tool.Name, c.field)
+				continue
+			}
+			if *c.got != c.want {
+				t.Errorf("%s: %s = %v, want %v", tool.Name, c.field, *c.got, c.want)
+			}
+		}
+	}
+
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("tool %q missing from tools/list", name)
+		}
+	}
+}

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -159,11 +159,43 @@ func (s *Server) ServeHTTP(addr string) error {
 	return http.ListenAndServe(addr, h)
 }
 
+// Tool annotations. Clients read these hints to decide whether a call needs
+// user approval, so the defaults matter: mcp-go's NewTool marks every tool
+// destructive, non-idempotent and open-world, which makes hosts gate even a
+// plain lookup behind a confirmation prompt — and an agent running unattended
+// then never calls it. Every GrayMatter tool works against the local store, so
+// openWorldHint is false throughout.
+
+// readOnlyTool annotates a tool that only reads. memory_search does bump access
+// counters for recency scoring, but that is internal bookkeeping the caller
+// cannot observe, so it stays read-only from the client's point of view.
+func readOnlyTool() mcp.ToolOption {
+	return mcp.WithToolAnnotation(mcp.ToolAnnotation{
+		ReadOnlyHint:    mcp.ToBoolPtr(true),
+		DestructiveHint: mcp.ToBoolPtr(false),
+		IdempotentHint:  mcp.ToBoolPtr(true),
+		OpenWorldHint:   mcp.ToBoolPtr(false),
+	})
+}
+
+// writeTool annotates a tool that writes. destructive is true only where a call
+// can remove or supersede an existing fact; appending a fact or a checkpoint is
+// additive. Nothing here is idempotent: every call stores a new record.
+func writeTool(destructive bool) mcp.ToolOption {
+	return mcp.WithToolAnnotation(mcp.ToolAnnotation{
+		ReadOnlyHint:    mcp.ToBoolPtr(false),
+		DestructiveHint: mcp.ToBoolPtr(destructive),
+		IdempotentHint:  mcp.ToBoolPtr(false),
+		OpenWorldHint:   mcp.ToBoolPtr(false),
+	})
+}
+
 func (s *Server) registerTools() {
 	// memory_search
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_search",
 			mcp.WithDescription("Search GrayMatter memory for relevant facts."),
+			readOnlyTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent whose memory to search."),
@@ -183,6 +215,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_add",
 			mcp.WithDescription("Store a new fact in GrayMatter memory."),
+			writeTool(false),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent to associate this memory with."),
@@ -199,6 +232,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("checkpoint_save",
 			mcp.WithDescription("Save a checkpoint of current agent state."),
+			writeTool(false),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent to checkpoint."),
@@ -214,6 +248,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("checkpoint_resume",
 			mcp.WithDescription("Restore the latest checkpoint for an agent."),
+			readOnlyTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent whose checkpoint to restore."),
@@ -226,6 +261,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_reflect",
 			mcp.WithDescription("Update your own knowledge graph mid-session. Use when you discover a contradiction, complete a task, or learn a user preference that should persist."),
+			writeTool(true),
 			mcp.WithString("action",
 				mcp.Required(),
 				mcp.Description("One of: add, update, forget, link."),


### PR DESCRIPTION
Fixes the "everything is green but the agent never stores anything" reports in #14, and makes a global install work without dropping a file in every repo (#17).

## What #14 actually was

The first thing I chased was the MCP layer, since all five tools ship with mcp-go's default annotations and that makes `memory_search` announce itself as destructive and non read-only. It turns out those defaults are what the spec prescribes when a server stays quiet, plenty of servers run that way, and mcp-go v0.32.0 has been pinned since the first commit, including in the releases people are using successfully. So it is wrong, but it is not the explanation.

The actual cause was the block `init` writes. It described the five tools and said to call `memory_search` "when prior context might matter", which a model can resolve to false every single time. Meanwhile this repo's own `AGENTS.md`, the one that works, carries an unconditional session protocol and a trigger table. @MikeCase independently rewrote his global `AGENTS.md` into the same shape and reported it working, which was the strongest signal in the thread and the one I initially under-weighted.

So `init` now writes that shape instead of a summary of it.

## Changes

**`init` writes a procedure, not a tool list.** Unconditional session protocol, a table of what triggers which call, and the anti-patterns. `agent_id` is derivable rather than invented: it is the repository root directory name, not a `<project>-<role>` template the model fills in differently each session, which scattered facts across namespaces and looked exactly like memory being broken.

**`init --global` (#17).** Writes the block into `~/.claude/CLAUDE.md` and OpenCode's global `AGENTS.md`, the home-scoped files agents read regardless of project. Works with `-i` too. `XDG_CONFIG_HOME` is honoured, which OpenCode supports but does not document on its rules page (anomalyco/opencode#6669); hardcoding `~/.config` wrote where nothing reads and reported success. The directory is `~/.config/opencode` on every platform, Windows included.

Since a global block reaches projects that never wired GrayMatter, it guards on the tools existing. Deliberately phrased as a capability check and not a judgement call, because a judgement-shaped hedge is the exact thing that made the old block ignorable.

**Not a `SKILL.md`.** #17 asked for one. OpenCode loads skills lazily, advertising only name and description and leaving the body to the model's discretion, with no autoinvoke and no way to force eager loading. For instructions that have to run before the first reply that puts the same "the model decides whether to bother" failure one level up. The global instruction file is always loaded, so it gets the job done. Also worth noting `graymatter run` already uses SKILL.md to define agents, so reusing the name here would have collided.

**`doctor` notices a project that was set up and never used.** This is what made #14 invisible. Wiring, instructions and store could all be green while nothing had ever been written, and the summary still said "Everything looks good", so a fresh install and a week of silence were indistinguishable. People had nothing to report and quietly gave up. A project initialised over 24 hours ago holding no facts is now a warning with an actionable hint, keyed off `MEMORY.md`'s mtime since `init` writes it once and nothing else touches it.

**MCP tool annotations corrected anyway.** `memory_search` and `checkpoint_resume` are pure reads, `memory_reflect` is the only genuinely destructive tool, nothing is open-world. A test drives `HandleMessage` and asserts on the `tools/list` payload a client actually receives, so a dependency bump cannot quietly reset them.

## Verification

- Full suite green on both modules, uncached. `vet` and `gofmt` clean.
- Migration from the old block checked end to end: markers are unchanged, so re-running `init` replaces it rather than stacking a second one, and user content above and below survives.
- `--global` verified against an isolated `HOME` and with `XDG_CONFIG_HOME` set, confirming it lands where each client reads.
- The doctor check verified against a backdated project: quiet on a fresh install, warns at 8 days empty.
- MCP handshake, `tools/list` and all five tools exercised over stdio against the built binary.
- Eight concurrent writers through one daemon: 11 facts across 10 agents, no lost writes.

## Not in scope

The sweep turned up an unrelated bug: `graymatter server` is the only command that still opens bbolt directly instead of going through the daemon, so every data route 503s whenever a daemon is running. Filed separately as #19 rather than folded in here, since it has its own blast radius.

Also still open from the #16 review and heading into the agent table unification: `maybeAddToPath` exists in two copies, `init -i --only cursor` silently drops the flag, and the two agent tables are ordered differently.

Closes #14
Closes #17
