### PR TITLE
fix(server): serve the REST API through the daemon (closes #19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,21 @@ jobs:
         shell: bash
         run: go test -race -count=1 -timeout=300s -coverprofile=../../coverage-cli.out -covermode=atomic ./internal/harness/... ./internal/kg/... ./internal/server/... ./internal/plugin/... ./internal/mcp/... ./internal/daemon/...
 
+      # The two coverage steps above enumerate packages explicitly, which left
+      # the root package and the CLI entrypoint untested on every platform:
+      # `graymatter` itself is the public API surface, and `cmd/graymatter`
+      # holds init, doctor, the TUI and the store handles. Both are run here
+      # rather than folded into the steps above so the coverage gates keep
+      # measuring the same thing they always have.
+      - name: Test root package
+        shell: bash
+        run: go test -race -count=1 -timeout=120s .
+
+      - name: Test CLI entrypoint package
+        working-directory: cmd/graymatter
+        shell: bash
+        run: go test -race -count=1 -timeout=300s .
+
       - name: Coverage gate — core library (≥70%)
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Every other check can be green while the agent has never called a single tool, and the summary still read "Everything looks good". That is why this failure produced so few reports: a fresh install and a week of silence looked identical, so people quietly gave up instead of filing anything.
 - A project initialised more than 24 hours ago that still holds no facts is now a warning with an actionable hint. The age is read from `MEMORY.md`, which `init` writes once and nothing else touches.
 
+**REST server reaches the store through the daemon (issue #19)**
+- `graymatter server` was the only command still opening bbolt directly. Clients spawn the daemon on first use and it lingers afterwards, so that is the normal state of the system rather than an edge case: every data route answered 503 while `/healthz` still reported ok. The server now takes a store handle, the same one every other command uses, and never touches the lock.
+- It fails to start when the store cannot be opened, rather than coming up and serving nothing but errors.
+- `/healthz` reports readiness. It round-trips to the store and answers 503 when that fails, with the reason going to the log rather than to whoever can reach the probe.
+- The handle reconnects. A CLI command's store lives for milliseconds; the server holds one for as long as it runs, so `daemon stop`, a crash or an upgrade would otherwise leave it returning 500 forever. A dead connection is re-dialled once per call, and because that re-dial spawns a daemon when none is running, the usual outcome is a served request. Only connection loss is retried: an error that reached the daemon is reported, never replayed.
+- `/consolidate` runs with the store owner's policy instead of a config the REST layer assembled itself, which also drops a hardcoded model id. Its `ANTHROPIC_API_KEY` gate is gone: consolidation is mostly decay and pruning, which need no LLM, and once the work moved behind the daemon that check was reading the wrong process's environment. It rejected requests the daemon could have served and admitted ones where the daemon had no key. The endpoint now returns 200 and does its real work with no provider configured.
+
 **MCP tools no longer advertise themselves as destructive**
 - All five tools inherited mcp-go's defaults (`readOnlyHint: false`, `destructiveHint: true`, `openWorldHint: true`), so `memory_search` and `checkpoint_resume`, both pure reads, were announced to clients as destructive open-world calls. Clients use those hints to choose between auto-approving a call and prompting for it.
 - Each tool now declares what it actually does, and a test pins the annotations so a dependency bump cannot quietly reset them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - The handle reconnects. A CLI command's store lives for milliseconds; the server holds one for as long as it runs, so `daemon stop`, a crash or an upgrade would otherwise leave it returning 500 forever. A dead connection is re-dialled once per call, and because that re-dial spawns a daemon when none is running, the usual outcome is a served request. Only connection loss is retried: an error that reached the daemon is reported, never replayed.
 - `/consolidate` runs with the store owner's policy instead of a config the REST layer assembled itself, which also drops a hardcoded model id. Its `ANTHROPIC_API_KEY` gate is gone: consolidation is mostly decay and pruning, which need no LLM, and once the work moved behind the daemon that check was reading the wrong process's environment. It rejected requests the daemon could have served and admitted ones where the daemon had no key. The endpoint now returns 200 and does its real work with no provider configured.
 
+### Internal
+
+**CI runs the root and CLI entrypoint packages**
+- Both coverage steps enumerate packages by hand, and neither list included the root package or `cmd/graymatter`. The public API surface and the whole CLI entrypoint (`init`, `doctor`, the TUI, the store handles) had never been executed by CI on any platform, so tests living there were reported green by a workflow that never ran them.
+- Both now run under `-race` as their own steps, deliberately outside the coverage profiles so the existing gates keep measuring what they always measured.
+
 **MCP tools no longer advertise themselves as destructive**
 - All five tools inherited mcp-go's defaults (`readOnlyHint: false`, `destructiveHint: true`, `openWorldHint: true`), so `memory_search` and `checkpoint_resume`, both pure reads, were announced to clients as destructive open-world calls. Clients use those hints to choose between auto-approving a call and prompting for it.
 - Each tool now declares what it actually does, and a test pins the annotations so a dependency bump cannot quietly reset them.

--- a/cmd/graymatter/cmd_init_instructions_test.go
+++ b/cmd/graymatter/cmd_init_instructions_test.go
@@ -208,6 +208,10 @@ func TestWriteGlobalInstructionFiles(t *testing.T) {
 	home := t.TempDir()
 	testHomeOverride = home
 	t.Cleanup(func() { testHomeOverride = "" })
+	// XDG_CONFIG_HOME outranks the home directory for the OpenCode path, and it
+	// is set on some CI runners. Without pinning it this test would assert
+	// against the wrong location and, worse, write into the real config dir.
+	t.Setenv("XDG_CONFIG_HOME", "")
 
 	results := writeGlobalInstructionFiles()
 	if len(results) != 2 {
@@ -240,6 +244,7 @@ func TestWriteGlobalInstructionFiles_PreservesUserContent(t *testing.T) {
 	home := t.TempDir()
 	testHomeOverride = home
 	t.Cleanup(func() { testHomeOverride = "" })
+	t.Setenv("XDG_CONFIG_HOME", "")
 
 	claude := filepath.Join(home, ".claude", "CLAUDE.md")
 	if err := os.MkdirAll(filepath.Dir(claude), 0o755); err != nil {

--- a/cmd/graymatter/cmd_server.go
+++ b/cmd/graymatter/cmd_server.go
@@ -32,7 +32,21 @@ Routes:
   GET    /healthz`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := slog.New(slog.NewTextHandler(cmd.OutOrStderr(), nil))
-			srv := server.New(addr, dataDir, logger)
+
+			// Reach the store the same way every other command does. Opening
+			// bbolt here would lose the race against the daemon that owns it
+			// and leave the API up but serving 503s (issue #19). Failing now
+			// is better than starting a server that cannot answer anything.
+			store, err := openStore()
+			if err != nil {
+				return fmt.Errorf("open store: %w", err)
+			}
+			// Unlike a CLI command, this handle has to survive the daemon being
+			// stopped, crashing, or upgraded underneath it.
+			rs := newReconnectingStore(store)
+			defer func() { _ = rs.Close() }()
+
+			srv := server.New(addr, rs, logger)
 
 			// Graceful shutdown on SIGINT / SIGTERM.
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/cmd/graymatter/internal/daemon/rest_through_daemon_test.go
+++ b/cmd/graymatter/internal/daemon/rest_through_daemon_test.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/server"
+)
+
+// TestRESTServer_ThroughDaemon is the issue #19 acceptance test.
+//
+// The REST server used to open bbolt itself. Because the daemon owns the write
+// lock in normal operation, the server lost that race, came up with a nil store
+// and answered every data route with 503 while /healthz still reported ok. It
+// now takes a Store, and *Client satisfies that interface directly, so this
+// exercises the exact configuration the bug lived in: a daemon owning the store
+// while the API serves traffic against it.
+//
+// It lives here rather than in internal/server because spawning a daemon needs
+// this package's build-and-point-at-it helper, and it belongs beside the other
+// "several owners of one store" tests.
+func TestRESTServer_ThroughDaemon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary; skipped in -short")
+	}
+	withBuiltDaemon(t)
+	dir := t.TempDir()
+
+	// The daemon takes the write lock. Under the old code this is precisely
+	// what made the server unusable.
+	c, err := Connect(dir)
+	if err != nil {
+		t.Fatalf("Connect (should auto-spawn): %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if pid := ReadPIDFile(dir); pid == 0 {
+		t.Fatal("expected a daemon to own the store before starting the server")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	// The daemon client backs every route directly; no second bbolt handle is
+	// opened anywhere. Production wraps this in package main's reconnecting
+	// store, which is what supplies Ready there.
+	srv := server.New(ln.Addr().String(), restStore{c}, nil)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	base := "http://" + ln.Addr().String()
+
+	// Write through the API.
+	status, body := doRequest(t, http.MethodPost, base+"/remember", map[string]string{
+		"agent": "rest-agent",
+		"text":  "the REST API reaches the store through the daemon",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("POST /remember: got %d, want 200; body: %s", status, body)
+	}
+
+	// Read it back through the API.
+	status, body = doRequest(t, http.MethodGet, base+"/recall?agent=rest-agent&q=daemon", nil)
+	if status != http.StatusOK {
+		t.Fatalf("GET /recall: got %d, want 200; body: %s", status, body)
+	}
+	var recalled struct {
+		Results []string `json:"results"`
+	}
+	if err := json.Unmarshal(body, &recalled); err != nil {
+		t.Fatalf("decode recall response: %v\n%s", err, body)
+	}
+	if len(recalled.Results) != 1 || recalled.Results[0] != "the REST API reaches the store through the daemon" {
+		t.Fatalf("recall returned %v", recalled.Results)
+	}
+
+	// And the same fact is visible to a plain daemon client, confirming both
+	// surfaces are talking to one store rather than two.
+	facts, err := c.List("rest-agent")
+	if err != nil {
+		t.Fatalf("List through the daemon client: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("daemon client sees %d facts, want 1", len(facts))
+	}
+
+	// The daemon is still the owner; the server never took the lock from it.
+	if pid := ReadPIDFile(dir); pid == 0 {
+		t.Error("daemon stopped owning the store while the server was running")
+	}
+
+	if err := c.Shutdown(); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+}
+
+// restStore adds Ready to *Client so it satisfies server.Store, reusing the
+// protocol ping the RPC client already exposes.
+type restStore struct{ *Client }
+
+func (r restStore) Ready() error { return r.Ping() }
+
+func doRequest(t *testing.T, method, url string, body any) (int, []byte) {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		r = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, url, r)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, data
+}

--- a/cmd/graymatter/internal/server/server.go
+++ b/cmd/graymatter/internal/server/server.go
@@ -3,11 +3,15 @@
 // processes (Python scripts, shell agents, etc.) interact with the same bbolt
 // store that the CLI uses.
 //
+// The store arrives as a constructor argument (see Store). This package never
+// opens bbolt, so it reaches the same store every other command does, through
+// the daemon when one owns it.
+//
 // Routes:
 //
 //	POST   /remember           body: {"agent":"<id>","text":"<text>"}
 //	GET    /recall?agent=<id>&q=<query>[&k=<int>]
-//	POST   /consolidate        body: {"agent":"<id>"}  (requires ANTHROPIC_API_KEY env var)
+//	POST   /consolidate        body: {"agent":"<id>"}
 //	GET    /facts?agent=<id>[&limit=<int>]
 //	DELETE /forget             body: {"agent":"<id>","query":"<query>"}
 //	GET    /healthz
@@ -19,11 +23,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
-	"github.com/angelnicolasc/graymatter/pkg/embedding"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
@@ -36,40 +38,48 @@ const (
 	shutdownGrace = 5 * time.Second
 )
 
+// Store is the persistence surface the handlers need.
+//
+// The server takes this rather than opening bbolt itself. bbolt is single
+// writer and the daemon owns the lock in normal operation (issue #8), so a
+// second opener simply fails: the server used to come up anyway with a nil
+// store and 503 every data route while /healthz still reported ok. The caller
+// passes in whatever `openStore` returns, daemon client or direct store, and
+// the server stays out of the lock business entirely (issue #19).
+//
+// The caller owns the store's lifecycle. Shutdown does not close it.
+type Store interface {
+	Remember(ctx context.Context, agentID, text string) error
+	Recall(ctx context.Context, agentID, query string, topK int) ([]string, error)
+	List(agentID string) ([]memory.Fact, error)
+	Delete(agentID, factID string) error
+	Consolidate(ctx context.Context, agentID string) error
+
+	// Ready reports whether the store answers right now. It backs /healthz,
+	// which otherwise has no way to tell "serving" apart from "serving
+	// nothing but errors".
+	Ready() error
+}
+
 // Server wraps an HTTP server backed by a GrayMatter memory store.
-// The store is opened once at construction time and shared across all
-// requests; call Shutdown to close it.
 type Server struct {
 	httpSrv *http.Server
-	store   *memory.Store // nil if Open failed; handlers return 503 in that case
+	store   Store
 	metrics *serverMetrics
-	dataDir string
 	addr    string
 	logger  *slog.Logger
 }
 
-// New creates a Server that opens the memory store at dataDir and will listen
-// on addr (e.g. ":8080"). The store is opened once and reused for all requests.
-func New(addr, dataDir string, logger *slog.Logger) *Server {
+// New creates a Server bound to store that will listen on addr (e.g. ":8080").
+func New(addr string, store Store, logger *slog.Logger) *Server {
 	if logger == nil {
 		logger = slog.Default()
-	}
-
-	emb := embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
-	store, err := memory.Open(memory.StoreConfig{
-		DataDir:  dataDir,
-		Embedder: emb,
-	})
-	if err != nil {
-		logger.Error("graymatter server: failed to open store", "error", err)
-		// store remains nil; storeReady() will reject all data requests with 503.
 	}
 
 	m := newServerMetrics("graymatter_server")
 	s := &Server{
 		store:   store,
 		metrics: m,
-		dataDir: dataDir,
 		addr:    addr,
 		logger:  logger,
 	}
@@ -109,31 +119,31 @@ func (s *Server) Serve(l net.Listener) error {
 	return s.httpSrv.Serve(l)
 }
 
-// Shutdown gracefully stops the HTTP server and closes the underlying store.
+// Shutdown gracefully stops the HTTP server. The store belongs to the caller
+// that constructed it, so closing it is the caller's job.
 func (s *Server) Shutdown(ctx context.Context) error {
 	shutCtx, cancel := context.WithTimeout(ctx, shutdownGrace)
 	defer cancel()
-	httpErr := s.httpSrv.Shutdown(shutCtx)
-	if s.store != nil {
-		if storeErr := s.store.Close(); storeErr != nil && httpErr == nil {
-			return storeErr
-		}
-	}
-	return httpErr
-}
-
-// storeReady returns false and writes a 503 if the store failed to open.
-func (s *Server) storeReady(w http.ResponseWriter) bool {
-	if s.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "store unavailable")
-		return false
-	}
-	return true
+	return s.httpSrv.Shutdown(shutCtx)
 }
 
 // --- handlers ---
 
+// handleHealthz reports readiness, not just liveness.
+//
+// This endpoint used to answer ok unconditionally, which is how a server that
+// 503'd every data route still looked healthy to anything watching it (issue
+// #19). A GrayMatter server that cannot reach its store has nothing to offer,
+// so the store is the one dependency worth probing here.
+//
+// The reason for a failure goes to the log, not the response: a probe is often
+// reachable from further away than the service itself.
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if err := s.store.Ready(); err != nil {
+		s.logger.Error("healthz: store not ready", "error", err)
+		writeError(w, http.StatusServiceUnavailable, "store unavailable")
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -151,10 +161,7 @@ func (s *Server) handleRemember(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "agent and text are required")
 		return
 	}
-	if !s.storeReady(w) {
-		return
-	}
-	if err := s.store.Put(r.Context(), req.Agent, req.Text); err != nil {
+	if err := s.store.Remember(r.Context(), req.Agent, req.Text); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -174,9 +181,6 @@ func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
 		if v, err := strconv.Atoi(ks); err == nil && v > 0 {
 			topK = v
 		}
-	}
-	if !s.storeReady(w) {
-		return
 	}
 	results, err := s.store.Recall(r.Context(), agent, query, topK)
 	if err != nil {
@@ -200,16 +204,14 @@ func (s *Server) handleConsolidate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "agent is required")
 		return
 	}
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		writeError(w, http.StatusServiceUnavailable, "ANTHROPIC_API_KEY not set; consolidate requires LLM access")
-		return
-	}
-	if !s.storeReady(w) {
-		return
-	}
-	cfg := &restConsolidateCfg{apiKey: apiKey}
-	if err := s.store.Consolidate(r.Context(), req.Agent, cfg); err != nil {
+	// No API-key gate here. Consolidation is mostly decay and pruning, which
+	// need no LLM; summarisation is one conditional step that runs when the
+	// store owner has a provider configured and the agent is over threshold.
+	// Gating on this process's environment was wrong in both directions once
+	// the work moved behind the daemon: it rejected requests the daemon could
+	// have served, and admitted ones where the daemon had no key anyway.
+	// Whoever owns the store owns the policy.
+	if err := s.store.Consolidate(r.Context(), req.Agent); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -227,9 +229,6 @@ func (s *Server) handleFacts(w http.ResponseWriter, r *http.Request) {
 		if v, err := strconv.Atoi(ls); err == nil && v > 0 {
 			limit = v
 		}
-	}
-	if !s.storeReady(w) {
-		return
 	}
 	facts, err := s.store.List(agent)
 	if err != nil {
@@ -269,9 +268,6 @@ func (s *Server) handleForget(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "agent and query are required")
 		return
 	}
-	if !s.storeReady(w) {
-		return
-	}
 	// Recall 1 result to find the best match, then delete its fact ID.
 	results, err := s.store.Recall(r.Context(), req.Agent, req.Query, 1)
 	if err != nil {
@@ -301,17 +297,6 @@ func (s *Server) handleForget(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "not_found"})
 }
-
-// restConsolidateCfg is a minimal ConsolidateConfig used by the REST layer.
-type restConsolidateCfg struct {
-	apiKey string
-}
-
-func (c *restConsolidateCfg) GetAnthropicAPIKey() string     { return c.apiKey }
-func (c *restConsolidateCfg) GetConsolidateLLM() string      { return "anthropic" }
-func (c *restConsolidateCfg) GetConsolidateModel() string    { return "claude-haiku-4-5-20251001" }
-func (c *restConsolidateCfg) GetConsolidateThreshold() int   { return 20 }
-func (c *restConsolidateCfg) GetDecayHalfLife() time.Duration { return 168 * time.Hour } // 1 week
 
 // --- HTTP utilities ---
 

--- a/cmd/graymatter/internal/server/server_test.go
+++ b/cmd/graymatter/internal/server/server_test.go
@@ -4,31 +4,82 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
+
+// testStore adapts *memory.Store to the Store interface the server takes.
+//
+// In production the implementations are the daemon client and the CLI's direct
+// store, both of which live in package main, so the adapter exists only to
+// exercise the handlers here. Whether the server reaches the store through the
+// daemon is covered where the daemon lives, not in this package.
+type testStore struct{ *memory.Store }
+
+func (t testStore) Remember(ctx context.Context, agentID, text string) error {
+	return t.Put(ctx, agentID, text)
+}
+
+func (t testStore) Consolidate(ctx context.Context, agentID string) error {
+	return t.Store.Consolidate(ctx, agentID, testConsolidateCfg{})
+}
+
+func (t testStore) Ready() error {
+	_, err := t.ListAgents()
+	return err
+}
+
+// unreadyStore stands in for a store whose owner has gone away.
+type unreadyStore struct {
+	Store
+	err error
+}
+
+func (u unreadyStore) Ready() error { return u.err }
+
+type testConsolidateCfg struct{}
+
+func (testConsolidateCfg) GetAnthropicAPIKey() string      { return os.Getenv("ANTHROPIC_API_KEY") }
+func (testConsolidateCfg) GetConsolidateLLM() string       { return "anthropic" }
+func (testConsolidateCfg) GetConsolidateModel() string     { return "claude-haiku-4-5-20251001" }
+func (testConsolidateCfg) GetConsolidateThreshold() int    { return 20 }
+func (testConsolidateCfg) GetDecayHalfLife() time.Duration { return 168 * time.Hour }
 
 // startTestServer starts the REST server on a random free port and returns
 // the base URL + a cleanup function that shuts it down.
-// The server is shut down via t.Cleanup so the store is closed before
-// TempDir removal (important on Windows where bbolt holds a file lock).
+//
+// Cleanups run last-registered-first, so the order here matters: TempDir is
+// claimed first and removed last, the store closes before that, and the server
+// stops before the store. bbolt holds a file lock on Windows, so closing after
+// removal would fail.
 func startTestServer(t *testing.T) (baseURL string, cleanup func()) {
 	t.Helper()
 
-	// Create data dir manually so we control cleanup ordering:
-	// shutdown must happen before the directory is removed.
 	dataDir := t.TempDir()
+
+	emb := embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
+	st, err := memory.Open(memory.StoreConfig{DataDir: dataDir, Embedder: emb})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 
-	srv := New(ln.Addr().String(), dataDir, nil)
+	srv := New(ln.Addr().String(), testStore{st}, nil)
 	go func() { _ = srv.Serve(ln) }()
 
 	stop := func() { _ = srv.Shutdown(context.Background()) }
@@ -62,6 +113,30 @@ func doJSON(t *testing.T, method, url string, body any) (statusCode int, respBod
 	data, _ := io.ReadAll(resp.Body)
 	return resp.StatusCode, data
 }
+
+// TestHealthz_ReportsStoreLoss is the readiness half of issue #19. The endpoint
+// used to answer ok unconditionally, so a server that had lost its store still
+// looked healthy to anything monitoring it.
+func TestHealthz_ReportsStoreLoss(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := New(ln.Addr().String(), unreadyStore{err: errStoreGone}, nil)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	status, body := doJSON(t, http.MethodGet, "http://"+ln.Addr().String()+"/healthz", nil)
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503; body: %s", status, body)
+	}
+	// The probe must not leak the underlying failure to whoever can reach it.
+	if strings.Contains(string(body), errStoreGone.Error()) {
+		t.Errorf("healthz body leaked the internal error: %s", body)
+	}
+}
+
+var errStoreGone = errors.New("connection is shut down")
 
 func TestHealthz(t *testing.T) {
 	base, stop := startTestServer(t)
@@ -232,18 +307,39 @@ func TestForget(t *testing.T) {
 	}
 }
 
-func TestConsolidate_NoAPIKey(t *testing.T) {
+// TestConsolidate_WorksWithoutAPIKey pins that consolidation is not refused for
+// want of an LLM. Decay and pruning are the bulk of the work and need no
+// provider; summarisation is a conditional step inside the store. The endpoint
+// used to reject the request outright based on this process's environment,
+// which became meaningless once the work moved behind the daemon.
+func TestConsolidate_WorksWithoutAPIKey(t *testing.T) {
 	base, stop := startTestServer(t)
 	defer stop()
 
-	// Without ANTHROPIC_API_KEY set the server should return 503.
 	t.Setenv("ANTHROPIC_API_KEY", "")
 
-	status, body := doJSON(t, http.MethodPost, base+"/consolidate", map[string]string{
+	// Store something so consolidation has real work to do.
+	status, body := doJSON(t, http.MethodPost, base+"/remember", map[string]string{
+		"agent": "eve", "text": "a fact worth decaying",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("remember: got %d; body: %s", status, body)
+	}
+
+	status, body = doJSON(t, http.MethodPost, base+"/consolidate", map[string]string{
 		"agent": "eve",
 	})
-	if status != http.StatusServiceUnavailable {
-		t.Errorf("expected 503 without API key, got %d; body: %s", status, body)
+	if status != http.StatusOK {
+		t.Fatalf("consolidate without an API key: got %d, want 200; body: %s", status, body)
+	}
+
+	// The fact must survive: consolidation decays and prunes, it does not wipe.
+	status, body = doJSON(t, http.MethodGet, base+"/facts?agent=eve", nil)
+	if status != http.StatusOK {
+		t.Fatalf("facts: got %d; body: %s", status, body)
+	}
+	if !strings.Contains(string(body), "a fact worth decaying") {
+		t.Errorf("consolidation lost the fact: %s", body)
 	}
 }
 

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -34,6 +34,9 @@ type cliStore interface {
 	Stats(agentID string) (memory.MemoryStats, error)
 	Delete(agentID, factID string) error
 	UpdateFact(agentID string, f memory.Fact) error
+	// Consolidate runs with the store owner's own policy: through the daemon
+	// that is the daemon's configuration, and clients cannot override it.
+	Consolidate(ctx context.Context, agentID string) error
 
 	// Host-level surface (checkpoints, sessions, KG, audit, tokens).
 	CheckpointSave(cp session.Checkpoint) (session.Checkpoint, error)
@@ -151,6 +154,9 @@ func (d *directStore) Stats(agentID string) (memory.MemoryStats, error) {
 	return d.store.Stats(agentID)
 }
 func (d *directStore) Delete(agentID, factID string) error { return d.store.Delete(agentID, factID) }
+func (d *directStore) Consolidate(ctx context.Context, agentID string) error {
+	return d.mem.Consolidate(ctx, agentID)
+}
 func (d *directStore) UpdateFact(agentID string, f memory.Fact) error {
 	return d.store.UpdateFact(agentID, f)
 }

--- a/cmd/graymatter/store_reconnect.go
+++ b/cmd/graymatter/store_reconnect.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	netrpc "net/rpc"
+	"sync"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/server"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// The REST server consumes exactly this. Asserting it here means a change to
+// either side fails to compile rather than at runtime.
+var _ server.Store = (*reconnectingStore)(nil)
+
+// reconnectingStore keeps a long-lived process usable across daemon restarts.
+//
+// net/rpc offers no reconnection: once a connection closes, every later call
+// fails with ErrShutdown, and pkg/memory/rpc states plainly that re-dialling is
+// the caller's job. CLI commands never notice because their handle lives for
+// milliseconds. The REST server holds one for as long as it runs, so a
+// `graymatter daemon stop`, a daemon crash, or an upgrade would otherwise leave
+// it answering 500 forever (issue #19).
+//
+// Recovery is cheap here because openStore spawns a daemon when none is
+// running, so the usual outcome of a redial is a fresh daemon and a served
+// request rather than an error.
+type reconnectingStore struct {
+	mu  sync.Mutex
+	cur cliStore
+}
+
+func newReconnectingStore(initial cliStore) *reconnectingStore {
+	return &reconnectingStore{cur: initial}
+}
+
+// reopenStore is how a reconnect obtains a fresh handle. Swapped in tests to
+// exercise the redial path without standing up a daemon, following the same
+// hook pattern as resolveExecutable and testHomeOverride.
+var reopenStore = openStore
+
+func (r *reconnectingStore) snapshot() cliStore {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cur
+}
+
+// redial replaces failed with a fresh handle. If another goroutine already
+// reconnected, that handle is returned instead of opening a second one.
+func (r *reconnectingStore) redial(failed cliStore) (cliStore, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cur != failed {
+		return r.cur, nil
+	}
+	next, err := reopenStore()
+	if err != nil {
+		return nil, err
+	}
+	_ = failed.Close()
+	r.cur = next
+	return next, nil
+}
+
+// do runs fn, and on a dead connection reconnects and runs it exactly once
+// more. Only connection death is retried: a store error means the call reached
+// the daemon and genuinely failed, and repeating a write that already landed
+// would be worse than reporting it.
+func (r *reconnectingStore) do(fn func(cliStore) error) error {
+	s := r.snapshot()
+	err := fn(s)
+	if err == nil || !connDead(err) {
+		return err
+	}
+	next, rerr := r.redial(s)
+	if rerr != nil {
+		return fmt.Errorf("%w (reconnect failed: %v)", err, rerr)
+	}
+	return fn(next)
+}
+
+// connDead reports whether err means the connection is gone rather than the
+// operation having failed on its merits.
+//
+// A call that times out is not listed: pkg/memory/rpc closes the connection on
+// timeout, so the next call surfaces ErrShutdown and recovers there. Retrying
+// the timed-out call itself could duplicate a write that is still in flight.
+func connDead(err error) bool {
+	return errors.Is(err, netrpc.ErrShutdown) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed)
+}
+
+// --- the surface the REST server consumes ---
+
+func (r *reconnectingStore) Remember(ctx context.Context, agentID, text string) error {
+	return r.do(func(s cliStore) error { return s.Remember(ctx, agentID, text) })
+}
+
+func (r *reconnectingStore) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
+	var out []string
+	err := r.do(func(s cliStore) error {
+		var e error
+		out, e = s.Recall(ctx, agentID, query, topK)
+		return e
+	})
+	return out, err
+}
+
+func (r *reconnectingStore) List(agentID string) ([]memory.Fact, error) {
+	var out []memory.Fact
+	err := r.do(func(s cliStore) error {
+		var e error
+		out, e = s.List(agentID)
+		return e
+	})
+	return out, err
+}
+
+func (r *reconnectingStore) Delete(agentID, factID string) error {
+	return r.do(func(s cliStore) error { return s.Delete(agentID, factID) })
+}
+
+func (r *reconnectingStore) Consolidate(ctx context.Context, agentID string) error {
+	return r.do(func(s cliStore) error { return s.Consolidate(ctx, agentID) })
+}
+
+// Ready reports whether the store answers right now, reconnecting first if the
+// connection died. ListAgents is the cheapest call that proves a real
+// round-trip to whoever owns the store.
+func (r *reconnectingStore) Ready() error {
+	return r.do(func(s cliStore) error {
+		_, err := s.ListAgents()
+		return err
+	})
+}
+
+func (r *reconnectingStore) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cur.Close()
+}

--- a/cmd/graymatter/store_reconnect_test.go
+++ b/cmd/graymatter/store_reconnect_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	netrpc "net/rpc"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeStore is a cliStore that fails with a connection error until it is
+// replaced. Only the methods the REST server uses are meaningful; the rest of
+// the interface is satisfied by the embedded nil and never called.
+type fakeStore struct {
+	cliStore
+	dead   atomic.Bool
+	calls  atomic.Int64
+	closed atomic.Bool
+}
+
+func (f *fakeStore) Remember(ctx context.Context, agentID, text string) error {
+	f.calls.Add(1)
+	if f.dead.Load() {
+		return netrpc.ErrShutdown
+	}
+	return nil
+}
+
+func (f *fakeStore) ListAgents() ([]string, error) {
+	f.calls.Add(1)
+	if f.dead.Load() {
+		return nil, netrpc.ErrShutdown
+	}
+	return []string{"a"}, nil
+}
+
+func (f *fakeStore) Close() error {
+	f.closed.Store(true)
+	return nil
+}
+
+func TestConnDead(t *testing.T) {
+	for _, err := range []error{netrpc.ErrShutdown, io.EOF, io.ErrUnexpectedEOF} {
+		if !connDead(err) {
+			t.Errorf("connDead(%v) = false, want true", err)
+		}
+	}
+	// A store error means the call reached the daemon and failed on its
+	// merits. Retrying it could duplicate a write that already landed.
+	for _, err := range []error{nil, errors.New("agent not found")} {
+		if connDead(err) {
+			t.Errorf("connDead(%v) = true, want false", err)
+		}
+	}
+}
+
+func TestReconnectingStore_RecoversFromDeadConnection(t *testing.T) {
+	dead := &fakeStore{}
+	dead.dead.Store(true)
+	fresh := &fakeStore{}
+
+	prev := reopenStore
+	reopenStore = func() (cliStore, error) { return fresh, nil }
+	t.Cleanup(func() { reopenStore = prev })
+
+	rs := newReconnectingStore(dead)
+	if err := rs.Remember(context.Background(), "a", "b"); err != nil {
+		t.Fatalf("Remember should have recovered, got %v", err)
+	}
+	if !dead.closed.Load() {
+		t.Error("the dead handle was not closed on reconnect")
+	}
+	if rs.snapshot() != cliStore(fresh) {
+		t.Error("store was not swapped for the reconnected handle")
+	}
+}
+
+func TestReconnectingStore_ReturnsRealErrors(t *testing.T) {
+	// A reconnect must not be attempted for an ordinary failure.
+	s := &fakeStore{}
+	reopened := false
+	prev := reopenStore
+	reopenStore = func() (cliStore, error) { reopened = true; return s, nil }
+	t.Cleanup(func() { reopenStore = prev })
+
+	rs := newReconnectingStore(s)
+	want := errors.New("boom")
+	err := rs.do(func(cliStore) error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+	if reopened {
+		t.Error("reconnected on an error that was not a dead connection")
+	}
+}
+
+func TestReconnectingStore_ReportsFailedReconnect(t *testing.T) {
+	dead := &fakeStore{}
+	dead.dead.Store(true)
+
+	prev := reopenStore
+	reopenStore = func() (cliStore, error) { return nil, errors.New("daemon unreachable") }
+	t.Cleanup(func() { reopenStore = prev })
+
+	rs := newReconnectingStore(dead)
+	err := rs.Remember(context.Background(), "a", "b")
+	if err == nil {
+		t.Fatal("expected an error when the reconnect fails")
+	}
+	// The original connection error stays wrapped so callers can still match it.
+	if !errors.Is(err, netrpc.ErrShutdown) {
+		t.Errorf("original error lost: %v", err)
+	}
+}
+
+// TestReconnectingStore_ConcurrentRedial is aimed at the race detector: many
+// goroutines hit a dead connection at once and must end up sharing a single
+// replacement rather than each opening their own.
+func TestReconnectingStore_ConcurrentRedial(t *testing.T) {
+	dead := &fakeStore{}
+	dead.dead.Store(true)
+	fresh := &fakeStore{}
+
+	var reopens atomic.Int64
+	prev := reopenStore
+	reopenStore = func() (cliStore, error) {
+		reopens.Add(1)
+		return fresh, nil
+	}
+	t.Cleanup(func() { reopenStore = prev })
+
+	rs := newReconnectingStore(dead)
+
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = rs.Remember(context.Background(), "a", "b")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+	if got := reopens.Load(); got != 1 {
+		t.Errorf("reopened %d times, want exactly 1", got)
+	}
+}
+
+func TestReconnectingStore_ReadyProbesTheStore(t *testing.T) {
+	s := &fakeStore{}
+	rs := newReconnectingStore(s)
+
+	if err := rs.Ready(); err != nil {
+		t.Fatalf("Ready on a live store: %v", err)
+	}
+	if s.calls.Load() == 0 {
+		t.Error("Ready did not make a round-trip; it would report healthy for a store it never touched")
+	}
+
+	// A store that has gone away and cannot be replaced must report unready.
+	s.dead.Store(true)
+	prev := reopenStore
+	reopenStore = func() (cliStore, error) { return nil, errors.New("gone") }
+	t.Cleanup(func() { reopenStore = prev })
+
+	if err := rs.Ready(); err == nil {
+		t.Error("Ready returned nil for an unreachable store")
+	}
+}


### PR DESCRIPTION
Fixes #19, and a CI gap found while verifying it.

## The bug

`graymatter server` was the only command still opening bbolt itself. Every other one goes through `openStore` and gets either the daemon client or the direct store. Since clients spawn the daemon on first use and it lingers for two minutes after, a daemon holding the lock is the normal state of the system, not an edge case. So the server lost the race, came up with a nil store, and answered every data route with 503 while `/healthz` still reported `{"status":"ok"}`.

`server.New` now takes a `Store` and the command passes in whatever `openStore` returns. The signature no longer has a data dir, so the package cannot open bbolt even by accident.

## What verifying it turned up

Three things, two of them defects in the first version of this fix.

**No reconnection.** A CLI command's store handle lives for milliseconds; the server holds one for as long as it runs. `daemon stop`, a crash or an upgrade left it answering `connection is shut down` forever with no recovery. `net/rpc` has no reconnection and `pkg/memory/rpc` says outright that re-dialling is the caller's job, so the wrapper belongs here. Only connection loss is retried: an error that reached the daemon is reported, never replayed, since repeating a write that already landed is worse than surfacing it. The re-dial spawns a daemon when none is running, so the usual outcome is a served request rather than an error.

**`/healthz` lied again, through a different door.** Failing to start without a store covers boot, not runtime. It now round-trips to the store and answers 503 when that fails, with the reason going to the log rather than to whoever can reach the probe.

**`/consolidate` had an incoherent gate.** It refused the request when this process had no `ANTHROPIC_API_KEY`. But consolidation is mostly decay and pruning, which need no LLM at all, and once the work moved behind the daemon the check was reading the wrong process's environment: it rejected requests the daemon could have served and admitted ones where the daemon had no key either. The gate is gone; the store owner owns the policy. This also drops a hardcoded model id.

## The CI gap

Both coverage steps enumerate packages by hand:

```
go test -race ... ./pkg/memory/...
go test -race ... ./internal/harness/... ./internal/kg/... ./internal/server/... \
                  ./internal/plugin/... ./internal/mcp/... ./internal/daemon/...
```

Neither list includes the root package or `cmd/graymatter`. The public API surface and the entire CLI entrypoint (`init`, `doctor`, the TUI, the store handles) had never been executed by CI on any platform. Tests added there were reported green by a workflow that never ran them, including the ones that shipped in #20.

Both now run under `-race` as separate steps, kept out of the coverage profiles so the existing gates keep measuring what they always measured.

## Verification

- `-race` on Linux, in a container, for both modules and every package. Clean, including the two packages CI had never run. No pre-existing races surfaced either.
- The issue's own repro: `/remember`, `/recall`, `/facts`, `/forget` all 200 with a daemon owning the store.
- Cross-surface: `/forget` deleted a REST-written fact and the CLI saw only its own, confirming one store rather than two.
- Soak: 30 writes with the daemon killed three times mid-run. 30 succeeded, 30 landed, `/healthz` green throughout, zero errors in the log.
- `--no-daemon server`: full path including consolidate, and no daemon left behind.
- Idle-exit: the server's connection keeps the daemon alive, so a long-running API does not get pulled out from under itself.
- Fail-fast: exits 1 with the real reason and leaves nothing listening.
- Regression test lives beside the other "several owners of one store" tests and stands a server up against a daemon-owned store.

## Behaviour changes worth knowing

- `graymatter server` now keeps a daemon alive for as long as it runs, because it holds a connection. It previously used no daemon at all.
- `/consolidate` returns 200 with no LLM configured and does its real work, instead of 503.

Closes #19
