### PR TITLE
fix: write the instruction files agents read, and check the block that is there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+**`init` writes only the instruction files the agents you wire actually read (issue #13)**
+- `graymatter init --only opencode` created a `CLAUDE.md` alongside the `AGENTS.md` it needed, and every other value had the same problem pointing the other way: `--only claudecode` wrote an `AGENTS.md`, `--only cursor` and `--only codex` wrote a `CLAUDE.md`. Claude Code reads `CLAUDE.md` and does not read `AGENTS.md`, so the extra file is not harmless redundancy — it is a file nobody reads, checked into the repo.
+- The interactive wizard already had the per-agent mapping; the flag path kept its own list of writers and wrote both files regardless. `knownAgents` is now the one table `init`, the wizard and `doctor` all read.
+- `--only` rejects an unrecognised id instead of silently wiring nothing. That was cosmetic while both files were written unconditionally; now that the files follow the selection, a typo would produce a run that writes nothing and still exits 0.
+- Plain `graymatter init` is unchanged, byte for byte. `--skip-claudecode` no longer writes a `CLAUDE.md` nobody asked for.
+
+**The block writer stops damaging files it updates**
+- It always spliced LF. With `core.autocrlf=true` a checkout hands the file back as CRLF, so the managed block came back LF and the rest stayed CRLF, leaving the file with both — and because the change comparison then never matched, every `init` rewrote the file and dirtied the tree. The block now follows the file's dominant line ending, by majority, so one pasted CRLF line in an LF file does not drag the block across.
+- It replaced only the first marker pair, so a duplicate could keep the old text while the file still satisfied anything that read the first pair and stopped. All managed blocks are now collapsed into one. An orphaned begin marker is left alone rather than paired with a later block's terminator, which would delete every line in between.
+
+**`doctor` checks the block that is there, and who it reaches (issues #14, #17)**
+- Instruction coverage is resolved per wired agent. A project relying on `init --global` was told nothing tells the model to use the memory tools, by the same check whose hint recommends `--global`. Crediting the global block to everyone would have been worse: it reaches Claude Code and OpenCode, not Cursor or Codex.
+- A project still carrying the pre-0.7.0 briefing — the one that gated the search on "when prior context might matter" — reported "Everything looks good", because the check accepted any file containing the marker or the word "graymatter". It now compares the block against the text we ship, with line endings normalised so a CRLF checkout is not mistaken for drift. A briefing you wrote yourself is recognised and never called stale.
+- `graymatter init` migrates a stale block in place, as before: markers are unchanged and anything outside them is untouched.
+
 ---
 
 ## [0.7.1] – 2026-08-10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,12 @@ When in doubt, open an issue first. A quick description of what you're building 
 
 ## Setup
 
-**Requirements:** Go 1.22+, no CGO, no Docker, no external services.
+**Requirements:** Go 1.23+, no Docker, no external services.
+
+The workspace declares `go 1.23.0`, so an older toolchain either fetches 1.23
+or refuses outright when `GOTOOLCHAIN=local` — which is what container images
+set. The shipped binary is built without CGO; that constraint is about the
+release artifact, not about your machine. See the note on `-race` below.
 
 ```bash
 git clone https://github.com/angelnicolasc/graymatter
@@ -57,6 +62,27 @@ go test -count=1 -timeout=300s ./...
 Use `./...` rather than naming packages. Both commands used to enumerate
 subtrees, which quietly excluded the root package and `cmd/graymatter` itself,
 so tests living there passed locally and were never run by anyone else.
+
+### The race detector
+
+CI runs every one of those packages under `-race`. The commands above do not,
+so a change can pass locally and still fail the pull request. Add the flag when
+you touch anything concurrent — the daemon, the RPC layer, the store handles,
+the TUI's background loads:
+
+```bash
+go test -race -count=1 -timeout=120s ./...
+
+cd cmd/graymatter
+go test -race -count=1 -timeout=300s ./...
+```
+
+`-race` is the one thing here that needs a C compiler, because the detector is
+built on CGO. Linux and macOS usually have one already; on Windows install
+mingw-w64 or TDM-GCC. Without it the flag fails with `-race requires cgo`, and
+the honest fallback is to run the suite without it and let CI catch what you
+cannot. That is a gap in your local coverage, not a licence to skip the flag
+when you have the toolchain.
 
 All tests use `t.TempDir()` with injected stubs. No real embedding model is required — tests that need one use a fixed-vector stub or keyword mode.
 

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -261,17 +261,28 @@ func checkStore(dir string) checkResult {
 	return flagIfUnused(c, dir, facts)
 }
 
-// mcpClientConfigs mirrors the paths used by the init writers
-// (cmd_init_writers.go). Codex is home-scoped; the rest are project-scoped.
-func mcpClientConfigs(projectDir string) []struct{ client, path string } {
-	out := []struct{ client, path string }{
-		{"Claude Code", filepath.Join(projectDir, ".mcp.json")},
-		{"Cursor", filepath.Join(projectDir, ".cursor", "mcp.json")},
-		{"OpenCode", filepath.Join(projectDir, "opencode.jsonc")},
-		{"Antigravity", filepath.Join(projectDir, "mcp_config.json")},
-	}
-	if codexPath, err := codexConfigPath(); err == nil {
-		out = append(out, struct{ client, path string }{"Codex", codexPath})
+// wiredAgents returns the known agents whose MCP config in this project
+// references graymatter. Paths come from knownAgents, the same table the init
+// writers use, so doctor cannot look somewhere the writer never wrote.
+func wiredAgents(projectDir string) []agentDef {
+	var out []agentDef
+	for _, a := range knownAgents(projectDir) {
+		if a.configPath == nil {
+			continue
+		}
+		p, err := a.configPath(projectDir)
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		// String containment is deliberately tolerant: it covers JSON, JSONC
+		// (comments) and TOML without needing three parsers here.
+		if strings.Contains(string(data), "graymatter") {
+			out = append(out, a)
+		}
 	}
 	return out
 }
@@ -279,16 +290,9 @@ func mcpClientConfigs(projectDir string) []struct{ client, path string } {
 func checkMCPWiring(projectDir string) checkResult {
 	c := checkResult{Name: "mcp wiring"}
 	var wired []string
-	for _, cc := range mcpClientConfigs(projectDir) {
-		data, err := os.ReadFile(cc.path)
-		if err != nil {
-			continue
-		}
-		// String containment is deliberately tolerant: it covers JSON, JSONC
-		// (comments) and TOML without needing three parsers here.
-		if strings.Contains(string(data), "graymatter") {
-			wired = append(wired, fmt.Sprintf("%s (%s)", cc.client, cc.path))
-		}
+	for _, a := range wiredAgents(projectDir) {
+		p, _ := a.configPath(projectDir)
+		wired = append(wired, fmt.Sprintf("%s (%s)", a.name, p))
 	}
 	if len(wired) == 0 {
 		c.Status = "warn"
@@ -300,22 +304,164 @@ func checkMCPWiring(projectDir string) checkResult {
 	return c
 }
 
+// checkInstructions asks the question that matters: for each client actually
+// wired here, does a briefing reach it?
+//
+// It used to look only at the project's CLAUDE.md and AGENTS.md, which made it
+// contradict `graymatter init --global` — the very command its own hint
+// recommends. A global install writes the block where Claude Code and OpenCode
+// read it in every project, and doctor reported that as missing (issue #17).
+// The inverse error is just as bad: crediting a global block to Cursor, which
+// has no global file graymatter writes, would hide a real gap. So coverage is
+// resolved per agent, from the same table that decides where init writes.
 func checkInstructions(projectDir string) checkResult {
 	c := checkResult{Name: "instructions"}
-	var present []string
-	for _, name := range []string{"CLAUDE.md", "AGENTS.md"} {
-		if hasInstructionsBlock(filepath.Join(projectDir, name)) {
-			present = append(present, name)
+
+	agents := wiredAgents(projectDir)
+	if len(agents) == 0 {
+		// Nothing wired, so there is no agent whose needs we can check against.
+		// Demanding a file for all five here would double-report the missing
+		// wiring that `mcp wiring` already warns about, so this degrades to the
+		// older question — is there a briefing at all — while still reporting a
+		// stale one.
+		return checkAnyInstructions(projectDir)
+	}
+
+	// An agent whose only briefing is stale is "uncovered", but reporting it in
+	// both lists says the same thing twice and buries the actionable half. It
+	// is counted as outdated only.
+	var covered, uncovered, stale []string
+	seenStale := map[string]bool{}
+	for _, a := range agents {
+		if a.instructionFile == "" {
+			continue
+		}
+		// Every source is inspected, not just the first that covers the agent.
+		// A project block does not shadow the global one — Claude Code loads
+		// the user file and the project file, so an outdated block in either
+		// is still being fed to the model and has to be reported.
+		hit, outdated := "", false
+		for _, cand := range instructionSources(projectDir, a) {
+			switch inspectBlock(cand.path) {
+			case blockCurrent, blockCustom:
+				if hit == "" {
+					hit = cand.label
+				}
+			case blockStale:
+				outdated = true
+				if !seenStale[cand.path] {
+					seenStale[cand.path] = true
+					stale = append(stale, cand.label)
+				}
+			}
+		}
+		switch {
+		case hit != "":
+			covered = append(covered, fmt.Sprintf("%s → %s", a.name, hit))
+		case outdated:
+			// already accounted for in `stale`
+		default:
+			uncovered = append(uncovered, a.name)
 		}
 	}
-	if len(present) == 0 {
+
+	switch {
+	case len(uncovered) > 0 && len(stale) > 0:
+		c.Status = "warn"
+		c.Detail = fmt.Sprintf("nothing tells %s to use the memory tools, and %s %s an outdated block",
+			strings.Join(uncovered, ", "), strings.Join(stale, ", "), carries(len(stale)))
+		c.Hint = "re-run `graymatter init` — it adds what is missing and replaces the managed block in place, leaving everything outside the markers alone"
+	case len(uncovered) > 0:
+		c.Status = "warn"
+		c.Detail = "nothing tells " + strings.Join(uncovered, ", ") + " to use the memory tools"
+		c.Hint = "an MCP connection only makes tools *available* — without instructions the model never calls them; run `graymatter init` (or `--global` for every project)"
+	case len(stale) > 0:
+		// Everything is covered, but by a briefing from before v0.7.0 — the one
+		// that told the model to search "when prior context might matter",
+		// which is a condition it can resolve to false every time (issue #14).
+		c.Status = "warn"
+		c.Detail = strings.Join(stale, ", ") + " " + carries(len(stale)) + " a memory block from an older version"
+		c.Hint = "the old block described the tools instead of prescribing a procedure, which is why agents did not call them; re-run `graymatter init` to replace it in place"
+	default:
+		c.Status, c.Detail = "ok", strings.Join(covered, ", ")
+	}
+	return c
+}
+
+// carries agrees the verb with the number of files, so a single outdated file
+// does not read as a grammar slip in the one message meant to be trusted.
+func carries(n int) string {
+	if n == 1 {
+		return "carries"
+	}
+	return "carry"
+}
+
+// checkAnyInstructions answers "is there a briefing anywhere" for a project
+// with no MCP client wired yet. Staleness is still reported: an old block is
+// worth flagging whether or not anything is wired.
+func checkAnyInstructions(projectDir string) checkResult {
+	c := checkResult{Name: "instructions"}
+	var present, stale []string
+	for _, a := range knownAgents(projectDir) {
+		if a.instructionFile == "" {
+			continue
+		}
+		for _, cand := range instructionSources(projectDir, a) {
+			switch inspectBlock(cand.path) {
+			case blockCurrent, blockCustom:
+				if !contains(present, cand.label) {
+					present = append(present, cand.label)
+				}
+			case blockStale:
+				if !contains(stale, cand.label) {
+					stale = append(stale, cand.label)
+				}
+			}
+		}
+	}
+	switch {
+	case len(present) == 0 && len(stale) == 0:
 		c.Status = "warn"
 		c.Detail = "neither CLAUDE.md nor AGENTS.md tells the model to use the memory tools"
 		c.Hint = "an MCP connection only makes tools *available* — without instructions the model never calls them; run `graymatter init` to add the memory block"
-		return c
+	case len(present) == 0:
+		c.Status = "warn"
+		c.Detail = strings.Join(stale, ", ") + " " + carries(len(stale)) + " a memory block from an older version"
+		c.Hint = "the old block described the tools instead of prescribing a procedure, which is why agents did not call them; re-run `graymatter init` to replace it in place"
+	default:
+		c.Status, c.Detail = "ok", strings.Join(present, ", ")+" mention the memory tools"
+		if len(stale) > 0 {
+			c.Status = "warn"
+			c.Detail += "; " + strings.Join(stale, ", ") + " " + map[bool]string{true: "is", false: "are"}[len(stale) == 1] + " outdated"
+			c.Hint = "re-run `graymatter init` to replace the managed block in place"
+		}
 	}
-	c.Status, c.Detail = "ok", strings.Join(present, ", ")+" mention the memory tools"
 	return c
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// instructionSources lists where a briefing for this agent could live, project
+// file first: a project block overrides, and is what the user most likely means
+// when both exist.
+func instructionSources(projectDir string, a agentDef) []struct{ path, label string } {
+	out := []struct{ path, label string }{
+		{filepath.Join(projectDir, a.instructionFile), a.instructionFile},
+	}
+	if a.globalInstruction != nil {
+		if p, err := a.globalInstruction(); err == nil {
+			out = append(out, struct{ path, label string }{p, p + " (global)"})
+		}
+	}
+	return out
 }
 
 // lsofHint suggests the lock-holder lookup command on platforms that have one.

--- a/cmd/graymatter/cmd_doctor_test.go
+++ b/cmd/graymatter/cmd_doctor_test.go
@@ -154,6 +154,14 @@ func TestCheckMCPWiring(t *testing.T) {
 }
 
 func TestCheckInstructions(t *testing.T) {
+	// checkInstructions now resolves coverage per wired agent, and two of the
+	// agents are home-scoped (Codex's config, Claude Code's and OpenCode's
+	// global briefings). Without pinning both, this test reads the developer's
+	// real home and its result depends on whose machine it runs on.
+	testHomeOverride = t.TempDir()
+	t.Cleanup(func() { testHomeOverride = "" })
+	t.Setenv("XDG_CONFIG_HOME", "")
+
 	t.Run("absent", func(t *testing.T) {
 		c := checkInstructions(t.TempDir())
 		if c.Status != "warn" {
@@ -170,4 +178,99 @@ func TestCheckInstructions(t *testing.T) {
 			t.Fatalf("status = %s, want ok (%s)", c.Status, c.Detail)
 		}
 	})
+}
+
+// TestCheckInstructions_GlobalCoverage is the check that used to contradict
+// `graymatter init --global`, the command its own hint recommends. A global
+// install puts the block where Claude Code and OpenCode read it in every
+// project; doctor looked only at the project directory and reported that as
+// missing.
+//
+// The inverse matters just as much. Cursor reads a project AGENTS.md and has no
+// home-scoped file that `init --global` writes, so crediting it for a global
+// block would hide a gap instead of a false alarm.
+func TestCheckInstructions_GlobalCoverage(t *testing.T) {
+	home := t.TempDir()
+	testHomeOverride = home
+	t.Cleanup(func() { testHomeOverride = "" })
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	if warns := installGlobalInstructions(true); len(warns) > 0 {
+		t.Fatalf("global install warned: %v", warns)
+	}
+
+	// wireOnly writes an MCP config for exactly one agent, so checkInstructions
+	// resolves coverage for that agent alone.
+	wireOnly := func(t *testing.T, id string) string {
+		t.Helper()
+		dir := t.TempDir()
+		for _, a := range knownAgents(dir) {
+			if a.id != id {
+				continue
+			}
+			if _, err := a.run(); err != nil {
+				t.Fatalf("wiring %s: %v", id, err)
+			}
+		}
+		return dir
+	}
+
+	t.Run("claude code is covered by the global file", func(t *testing.T) {
+		c := checkInstructions(wireOnly(t, "claudecode"))
+		if c.Status != "ok" {
+			t.Errorf("status = %s, want ok (%s)", c.Status, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "global") {
+			t.Errorf("detail should name the global file, got %q", c.Detail)
+		}
+	})
+
+	t.Run("opencode is covered by the global file", func(t *testing.T) {
+		c := checkInstructions(wireOnly(t, "opencode"))
+		if c.Status != "ok" {
+			t.Errorf("status = %s, want ok (%s)", c.Status, c.Detail)
+		}
+	})
+
+	t.Run("cursor is not", func(t *testing.T) {
+		c := checkInstructions(wireOnly(t, "cursor"))
+		if c.Status != "warn" {
+			t.Fatalf("status = %s, want warn — a global block does not reach Cursor (%s)", c.Status, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "Cursor") {
+			t.Errorf("detail should name Cursor, got %q", c.Detail)
+		}
+	})
+}
+
+// TestCheckInstructions_StaleBlock: a project set up before v0.7.0 carries the
+// briefing that told the model to search "when prior context might matter". Its
+// markers are identical to today's, so the old check reported it as healthy and
+// nobody was told to re-run init.
+func TestCheckInstructions_StaleBlock(t *testing.T) {
+	testHomeOverride = t.TempDir()
+	t.Cleanup(func() { testHomeOverride = "" })
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	dir := t.TempDir()
+	stale := instrBeginMarker + "\n## Memory (GrayMatter)\n\ncall memory_search when prior context might matter\n" + instrEndMarker + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := checkInstructions(dir)
+	if c.Status != "warn" {
+		t.Fatalf("status = %s, want warn (%s)", c.Status, c.Detail)
+	}
+	if !strings.Contains(c.Detail, "older version") {
+		t.Errorf("detail should say the block is outdated, got %q", c.Detail)
+	}
+
+	// Re-running init is the documented remedy, so it has to actually clear it.
+	if _, err := upsertInstructionsBlock(filepath.Join(dir, "CLAUDE.md")); err != nil {
+		t.Fatal(err)
+	}
+	if c := checkInstructions(dir); c.Status != "ok" {
+		t.Errorf("status after re-running init = %s, want ok (%s)", c.Status, c.Detail)
+	}
 }

--- a/cmd/graymatter/cmd_init.go
+++ b/cmd/graymatter/cmd_init.go
@@ -62,31 +62,32 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 			}
 
 			// Build the list of writers to run, honoring --only / --skip-*.
-			type writerEntry struct {
-				name    string
-				id      string
-				run     func() (writeResult, error)
-				skip    bool
-				optIn   bool
-				enabled bool
-			}
+			// Both the agent set and the instruction file each agent reads come
+			// from knownAgents, so this path and the wizard cannot disagree.
+			agents := knownAgents(".")
 
-			onlySet := parseOnlyFlag(only)
-			entries := []writerEntry{
-				{name: "Claude Code", id: "claudecode", run: func() (writeResult, error) { return writeClaudeCodeProject(".") }, skip: skipClaudeCode},
-				{name: "Cursor", id: "cursor", run: func() (writeResult, error) { return writeCursorProject(".") }, skip: skipCursor},
-				{name: "Codex", id: "codex", run: writeCodexHome, skip: skipCodex},
-				{name: "OpenCode", id: "opencode", run: func() (writeResult, error) { return writeOpencodeProject(".") }, skip: skipOpencode},
-				{name: "Antigravity", id: "antigravity", run: func() (writeResult, error) { return writeAntigravityProject(".") }, optIn: !withAntigravity},
+			onlySet, err := parseOnlyFlag(only, agents)
+			if err != nil {
+				return err
 			}
+			skipped := map[string]bool{
+				"claudecode": skipClaudeCode,
+				"cursor":     skipCursor,
+				"codex":      skipCodex,
+				"opencode":   skipOpencode,
+			}
+			optedIn := map[string]bool{"antigravity": withAntigravity}
 
-			for i := range entries {
-				e := &entries[i]
-				if len(onlySet) > 0 {
-					e.enabled = onlySet[e.id]
-					continue
+			enabled := make(map[string]bool, len(agents))
+			for _, a := range agents {
+				switch {
+				case len(onlySet) > 0:
+					enabled[a.id] = onlySet[a.id]
+				case a.optIn:
+					enabled[a.id] = optedIn[a.id]
+				default:
+					enabled[a.id] = !skipped[a.id]
 				}
-				e.enabled = !e.skip && !e.optIn
 			}
 
 			if !quiet {
@@ -98,8 +99,8 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 			}
 
 			var warnings []string
-			for _, e := range entries {
-				if !e.enabled {
+			for _, e := range agents {
+				if !enabled[e.id] {
 					if !quiet {
 						reason := "skipped"
 						if e.optIn {
@@ -141,7 +142,10 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 				if !quiet {
 					fmt.Println("\nAgent instructions (tells the model to actually use the tools):")
 				}
-				for _, res := range writeInstructionFiles(".") {
+				// Only the files the wired agents actually read. Writing both
+				// unconditionally is what put a CLAUDE.md in every
+				// OpenCode-only project (issue #13).
+				for _, res := range writeInstructionFiles(".", instructionFilesFor(agents, enabled)) {
 					if res.warn != "" {
 						warnings = append(warnings, res.warn)
 						continue
@@ -199,17 +203,40 @@ just the ones we auto-wire; any MCP-compatible client works over stdio
 	return cmd
 }
 
-func parseOnlyFlag(v string) map[string]bool {
+// parseOnlyFlag parses --only and rejects ids that match no known agent.
+//
+// Silently ignoring a typo used to mean "wire nothing" while still writing both
+// instruction files, which looked like a partial success. Now that the
+// instruction files follow the selection, an unrecognised id would produce a
+// run that writes nothing at all and still exits 0 — so it has to be an error.
+func parseOnlyFlag(v string, agents []agentDef) (map[string]bool, error) {
 	v = strings.TrimSpace(v)
 	if v == "" {
-		return nil
+		return nil, nil
 	}
+	known := make(map[string]bool, len(agents))
+	valid := make([]string, 0, len(agents))
+	for _, a := range agents {
+		known[a.id] = true
+		valid = append(valid, a.id)
+	}
+
 	out := map[string]bool{}
+	var unknown []string
 	for _, p := range strings.Split(v, ",") {
 		p = strings.TrimSpace(strings.ToLower(p))
-		if p != "" {
-			out[p] = true
+		if p == "" {
+			continue
 		}
+		if !known[p] {
+			unknown = append(unknown, p)
+			continue
+		}
+		out[p] = true
 	}
-	return out
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("--only: unknown agent %s (valid: %s)",
+			strings.Join(unknown, ", "), strings.Join(valid, ", "))
+	}
+	return out, nil
 }

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -375,15 +375,56 @@ func printNextSteps() {
 	fmt.Printf("       graymatter recall  \"my-agent\" \"how should I format this?\"\n")
 }
 
-// hasInstructionsBlock reports whether path contains the managed block (or at
-// least mentions graymatter, for users who wrote their own briefing).
-// Used by `graymatter doctor`.
-func hasInstructionsBlock(path string) bool {
+// normalizeEndings makes block comparisons independent of how a file was
+// checked out or saved. Without it a CRLF file would compare unequal to the
+// canonical block forever, and every check below would be a false alarm.
+func normalizeEndings(s string) string { return strings.ReplaceAll(s, "\r\n", "\n") }
+
+// blockStatus is what doctor needs to know about one instruction file.
+type blockStatus int
+
+const (
+	blockAbsent  blockStatus = iota // no graymatter briefing at all
+	blockCustom                     // mentions graymatter, but not our managed block
+	blockStale                      // our markers, but not the text we ship today
+	blockCurrent                    // our markers, current text
+)
+
+// inspectBlock classifies the managed block in path.
+//
+// The stale case is the one worth having. The briefing shipped before v0.7.0
+// described the five tools and told the model to search "when prior context
+// might matter" — a condition it can resolve to false every single time, which
+// is the whole of issue #14. Its markers are byte-identical to today's, so a
+// check that looks for a marker, or for the word "graymatter", reports it as
+// healthy. Comparing the text is what separates "a briefing is present" from
+// "the briefing that works is present", and it keeps working for the next
+// revision without anyone remembering to bump a version.
+//
+// Every block in the file is checked, not just the first: a duplicate that
+// still carries the old text is exactly the copy worth catching.
+func inspectBlock(path string) blockStatus {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return false
+		return blockAbsent
 	}
-	content := strings.ToLower(string(data))
-	return strings.Contains(content, strings.ToLower(instrBeginMarker)) ||
-		strings.Contains(content, "graymatter")
+	content := normalizeEndings(string(data))
+	want := normalizeEndings(strings.TrimSuffix(instructionsBlock(), "\n"))
+
+	spans := managedBlockSpans(content)
+	for _, s := range spans {
+		if content[s[0]:s[1]] != want {
+			return blockStale
+		}
+	}
+	if len(spans) > 0 {
+		return blockCurrent
+	}
+
+	// No managed block. A briefing someone wrote themselves still counts as
+	// instructions — it is theirs, so it is never "stale".
+	if strings.Contains(strings.ToLower(content), "graymatter") {
+		return blockCustom
+	}
+	return blockAbsent
 }

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -128,13 +128,25 @@ func upsertInstructionsBlock(path string) (writeResult, error) {
 		next = block
 	default:
 		content := string(data)
-		begin := strings.Index(content, instrBeginMarker)
-		end := strings.Index(content, instrEndMarker)
-		if begin >= 0 && end > begin {
-			// Replace the managed block, keep everything around it.
-			next = content[:begin] + strings.TrimSuffix(block, "\n") + content[end+len(instrEndMarker):]
+		// Match the file's existing line endings before splicing. Writing LF
+		// into a CRLF file left it with both, and once the block itself had
+		// picked up CRLF — which is what a checkout with core.autocrlf=true
+		// produces — the equality check below never held again: every run
+		// rewrote the file, reported a change, and dirtied the tree.
+		if usesCRLF(content) {
+			block = toCRLF(block)
+		}
+		le := lineEnding(content)
+
+		// Every managed block goes, and one canonical block comes back where
+		// the first one was. Replacing only the first pair left a duplicate
+		// behind still carrying the old text, which a check that reads the
+		// first pair then happily reports as healthy.
+		stripped, at := stripManagedBlocks(content)
+		if at >= 0 {
+			next = stripped[:at] + strings.TrimSuffix(block, le) + stripped[at:]
 		} else {
-			next = strings.TrimRight(content, "\n") + "\n\n" + block
+			next = strings.TrimRight(stripped, "\r\n") + le + le + block
 		}
 	}
 
@@ -150,6 +162,88 @@ func upsertInstructionsBlock(path string) (writeResult, error) {
 	}
 	res.changed = true
 	return res, nil
+}
+
+// usesCRLF reports whether the file's dominant line ending is CRLF.
+//
+// Majority, not presence: one pasted CRLF line in an otherwise LF file must not
+// drag the whole block over to CRLF. A file that is already mixed keeps what it
+// has — the block follows the majority and the surrounding lines are left
+// alone, which is what makes the result stable instead of trading one rewrite
+// for another.
+func usesCRLF(content string) bool {
+	crlf := strings.Count(content, "\r\n")
+	lines := strings.Count(content, "\n")
+	return crlf*2 > lines
+}
+
+func lineEnding(content string) string {
+	if usesCRLF(content) {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+func toCRLF(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\n", "\r\n")
+}
+
+// managedBlockSpans returns the [start,end) byte ranges of every managed block
+// in content, in order.
+//
+// Pairing is non-greedy: a begin marker with another begin marker before the
+// next end marker is orphaned — hand-mangled, half-pasted, whatever — and is
+// skipped rather than paired with some later block's terminator. Pairing it
+// would swallow everything in between, which is user content that was never
+// inside a block.
+//
+// One scanner backs both the writer and the check in doctor, so the two cannot
+// disagree about what counts as a block.
+func managedBlockSpans(content string) [][2]int {
+	var spans [][2]int
+	for off := 0; off < len(content); {
+		rel := strings.Index(content[off:], instrBeginMarker)
+		if rel < 0 {
+			break
+		}
+		begin := off + rel
+		after := begin + len(instrBeginMarker)
+
+		endRel := strings.Index(content[after:], instrEndMarker)
+		if endRel < 0 {
+			break // unterminated: nothing to pair here or after it
+		}
+		end := after + endRel + len(instrEndMarker)
+
+		if nextRel := strings.Index(content[after:], instrBeginMarker); nextRel >= 0 && after+nextRel < end {
+			off = after // this begin is orphaned; try the next one
+			continue
+		}
+		spans = append(spans, [2]int{begin, end})
+		off = end
+	}
+	return spans
+}
+
+// stripManagedBlocks removes every managed block from content and reports where
+// the first one started in the result, or -1 when there was none.
+func stripManagedBlocks(content string) (stripped string, insertAt int) {
+	spans := managedBlockSpans(content)
+	if len(spans) == 0 {
+		return content, -1
+	}
+	var b strings.Builder
+	prev := 0
+	insertAt = -1
+	for _, s := range spans {
+		b.WriteString(content[prev:s[0]])
+		if insertAt < 0 {
+			insertAt = b.Len()
+		}
+		prev = s[1]
+	}
+	b.WriteString(content[prev:])
+	return b.String(), insertAt
 }
 
 // writeInstructionFiles upserts the memory block into the given instruction

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -152,11 +152,16 @@ func upsertInstructionsBlock(path string) (writeResult, error) {
 	return res, nil
 }
 
-// writeInstructionFiles upserts the memory block into CLAUDE.md and AGENTS.md
-// in projectDir. Returns one result per file, in a stable order.
-func writeInstructionFiles(projectDir string) []writeResult {
+// writeInstructionFiles upserts the memory block into the given instruction
+// files under projectDir. Returns one result per file, in the given order.
+//
+// The file list is the caller's to decide. Writing CLAUDE.md and AGENTS.md
+// unconditionally is what put a CLAUDE.md in every OpenCode-only project: which
+// files are needed depends on which agents are being wired, and only the caller
+// knows that.
+func writeInstructionFiles(projectDir string, names []string) []writeResult {
 	var out []writeResult
-	for _, name := range []string{"CLAUDE.md", "AGENTS.md"} {
+	for _, name := range names {
 		res, err := upsertInstructionsBlock(filepath.Join(projectDir, name))
 		if err != nil {
 			res.warn = fmt.Sprintf("could not update %s: %v", name, err)
@@ -176,19 +181,27 @@ func writeInstructionFiles(projectDir string) []writeResult {
 // lands ahead of project content rather than replacing it. Both are plain
 // markdown, so the same marker-based upsert applies and a user's own global
 // instructions are left untouched.
+//
+// The paths come from knownAgents rather than being listed again here, so
+// adding an agent with a global file is one edit and doctor learns about it at
+// the same time.
 func globalInstructionPaths() ([]string, error) {
-	home, err := resolveHome()
-	if err != nil {
-		return nil, err
+	var out []string
+	seen := map[string]bool{}
+	for _, a := range knownAgents(".") {
+		if a.globalInstruction == nil {
+			continue
+		}
+		p, err := a.globalInstruction()
+		if err != nil {
+			return nil, err
+		}
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
 	}
-	opencodeDir, err := opencodeConfigDir()
-	if err != nil {
-		return nil, err
-	}
-	return []string{
-		filepath.Join(home, ".claude", "CLAUDE.md"),
-		filepath.Join(opencodeDir, "AGENTS.md"),
-	}, nil
+	return out, nil
 }
 
 // opencodeConfigDir resolves OpenCode's global config directory.

--- a/cmd/graymatter/cmd_init_instructions_test.go
+++ b/cmd/graymatter/cmd_init_instructions_test.go
@@ -266,34 +266,63 @@ func TestWriteGlobalInstructionFiles_PreservesUserContent(t *testing.T) {
 	}
 }
 
-func TestHasInstructionsBlock(t *testing.T) {
+func TestInspectBlock(t *testing.T) {
 	dir := t.TempDir()
+	write := func(name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// The pre-v0.7.0 briefing, markers and all. This is the file the users in
+	// issue #14 were left with, and the reason "is there a block" was never a
+	// good enough question.
+	staleBody := instrBeginMarker + `
+## Memory (GrayMatter)
+
+- ` + "`memory_search`" + ` — call at the start of a task when prior context might matter.
+` + instrEndMarker + "\n"
 
 	managed := filepath.Join(dir, "CLAUDE.md")
 	if _, err := upsertInstructionsBlock(managed); err != nil {
 		t.Fatal(err)
 	}
-	if !hasInstructionsBlock(managed) {
-		t.Error("managed file should be detected")
-	}
-
-	custom := filepath.Join(dir, "AGENTS.md")
-	if err := os.WriteFile(custom, []byte("Use the GrayMatter MCP tools.\n"), 0o644); err != nil {
+	current, err := os.ReadFile(managed)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if !hasInstructionsBlock(custom) {
-		t.Error("hand-written graymatter mention should be detected")
+
+	cases := []struct {
+		name string
+		path string
+		want blockStatus
+	}{
+		{"managed block we just wrote", managed, blockCurrent},
+		{"pre-0.7 block", write("STALE.md", staleBody), blockStale},
+		{"hand-written mention", write("AGENTS.md", "Use the GrayMatter MCP tools.\n"), blockCustom},
+		{"unrelated file", write("OTHER.md", "nothing to see\n"), blockAbsent},
+		{"missing file", filepath.Join(dir, "MISSING.md"), blockAbsent},
+
+		// A CRLF checkout must not read as stale, or every Windows user gets a
+		// warning they cannot clear.
+		{"current block in a CRLF file", write("CRLF.md",
+			strings.ReplaceAll(string(current), "\n", "\r\n")), blockCurrent},
+
+		// One current block plus one stale copy is a stale file: the model is
+		// still being fed the old text.
+		{"current block next to a stale one", write("BOTH.md",
+			string(current)+"\n"+staleBody), blockStale},
 	}
 
-	unrelated := filepath.Join(dir, "OTHER.md")
-	if err := os.WriteFile(unrelated, []byte("nothing to see\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if hasInstructionsBlock(unrelated) {
-		t.Error("unrelated file should not be detected")
-	}
-	if hasInstructionsBlock(filepath.Join(dir, "MISSING.md")) {
-		t.Error("missing file should not be detected")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := inspectBlock(c.path); got != c.want {
+				t.Errorf("inspectBlock = %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 

--- a/cmd/graymatter/cmd_init_instructions_test.go
+++ b/cmd/graymatter/cmd_init_instructions_test.go
@@ -296,3 +296,113 @@ func TestHasInstructionsBlock(t *testing.T) {
 		t.Error("missing file should not be detected")
 	}
 }
+
+// TestUpsertInstructions_PreservesLineEndings covers what a Windows checkout
+// does to this file. With core.autocrlf=true the block comes back from git as
+// CRLF; splicing LF into it left the file with both, and because the whole-file
+// comparison then never matched, every init rewrote it and reported a change.
+func TestUpsertInstructions_PreservesLineEndings(t *testing.T) {
+	crCount := func(s string) int { return strings.Count(s, "\r") }
+
+	t.Run("crlf file stays crlf", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "CLAUDE.md")
+		if err := os.WriteFile(path, []byte("# Project\r\nnotes\r\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := upsertInstructionsBlock(path); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(path)
+		got := string(data)
+		if lf := strings.Count(got, "\n"); crCount(got) != lf {
+			t.Errorf("mixed endings: %d CR vs %d LF", crCount(got), lf)
+		}
+
+		// The second run has to be a no-op, or git sees a dirty tree after
+		// every init.
+		res, err := upsertInstructionsBlock(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.changed {
+			t.Error("second upsert rewrote a file it had just written")
+		}
+	})
+
+	t.Run("lf file with a stray crlf stays lf", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "CLAUDE.md")
+		if err := os.WriteFile(path, []byte("# Project\na\nb\r\nc\nd\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := upsertInstructionsBlock(path); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(path)
+		// One pasted line must not convert the block. The single pre-existing
+		// CR is the only one that should survive.
+		if n := crCount(string(data)); n != 1 {
+			t.Errorf("got %d CR, want the 1 that was already there", n)
+		}
+	})
+}
+
+// TestUpsertInstructions_CollapsesDuplicateBlocks: replacing only the first
+// marker pair left later copies untouched, so a file could carry a current
+// block and a stale one at the same time and still look fine to anything that
+// read the first pair and stopped.
+func TestUpsertInstructions_CollapsesDuplicateBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+	stale := instrBeginMarker + "\nold briefing\n" + instrEndMarker
+	body := "# Project\n\nkeep me\n\n" + stale + "\n\nmiddle\n\n" + stale + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := upsertInstructionsBlock(path); err != nil {
+		t.Fatal(err)
+	}
+	got := string(mustRead(t, path))
+
+	if n := strings.Count(got, instrBeginMarker); n != 1 {
+		t.Errorf("got %d blocks, want 1", n)
+	}
+	if strings.Contains(got, "old briefing") {
+		t.Error("a stale copy survived the upsert")
+	}
+	for _, keep := range []string{"keep me", "middle"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("lost user content %q", keep)
+		}
+	}
+}
+
+// TestUpsertInstructions_LeavesOrphanMarkerAlone: a begin marker with no
+// terminator of its own is not a block this tool wrote. Pairing it with the
+// next block's end marker would delete every line in between.
+func TestUpsertInstructions_LeavesOrphanMarkerAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+	body := "# Project\n" + instrBeginMarker + "\nhand-written note\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := upsertInstructionsBlock(path); err != nil {
+		t.Fatal(err)
+	}
+	got := string(mustRead(t, path))
+	if !strings.Contains(got, "hand-written note") {
+		t.Error("orphan marker swallowed the user's content")
+	}
+	if !strings.Contains(got, instrEndMarker) {
+		t.Error("no managed block was written")
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/cmd/graymatter/cmd_init_interactive.go
+++ b/cmd/graymatter/cmd_init_interactive.go
@@ -19,13 +19,32 @@ func stdinReader() *bufio.Scanner {
 	return bufio.NewScanner(os.Stdin)
 }
 
-// agentDef describes one known MCP agent for the interactive wizard.
+// agentDef describes one known MCP agent.
+//
+// This table is the single source of truth for "which agent needs which file".
+// It used to feed only the interactive wizard, while `init`'s flag path and
+// `doctor` each carried their own parallel list. That drift is what let
+// `--only opencode` keep writing CLAUDE.md (issue #13) and what let `doctor`
+// report missing instructions for a project covered by `init --global`
+// (issue #17): three lists, one of them updated.
 type agentDef struct {
 	id              string // claudecode, cursor, opencode, codex, antigravity
 	name            string // display name
 	configDesc      string // human-readable config-file description
-	instructionFile string // instruction file it needs ("" if none)
+	instructionFile string // project instruction file it reads ("" if none)
+	optIn           bool   // wired only when explicitly asked for
 	run             func() (writeResult, error)
+
+	// configPath resolves the MCP config this agent actually reads, so doctor
+	// looks exactly where the writer wrote.
+	configPath func(projectDir string) (string, error)
+
+	// globalInstruction is the home-scoped instruction file this agent reads in
+	// every project, or nil when the agent has none that `init --global`
+	// writes. Only these agents can be covered by a global install; for the
+	// rest a project file is the only delivery path, and doctor must not credit
+	// them for a global block they never read.
+	globalInstruction func() (string, error)
 }
 
 // knownAgents returns the list of known agents, with project-scoped writers
@@ -34,23 +53,49 @@ func knownAgents(projectDir string) []agentDef {
 	return []agentDef{
 		{
 			id: "claudecode", name: "Claude Code", configDesc: ".mcp.json",
+			// Claude Code reads CLAUDE.md and explicitly does not read
+			// AGENTS.md; its user-scope file is ~/.claude/CLAUDE.md.
 			instructionFile: "CLAUDE.md",
 			run:             func() (writeResult, error) { return writeClaudeCodeProject(projectDir) },
+			configPath: func(dir string) (string, error) {
+				return filepath.Join(dir, ".mcp.json"), nil
+			},
+			globalInstruction: func() (string, error) {
+				home, err := resolveHome()
+				if err != nil {
+					return "", err
+				}
+				return filepath.Join(home, ".claude", "CLAUDE.md"), nil
+			},
 		},
 		{
 			id: "cursor", name: "Cursor", configDesc: ".cursor/mcp.json",
 			instructionFile: "AGENTS.md",
 			run:             func() (writeResult, error) { return writeCursorProject(projectDir) },
+			configPath: func(dir string) (string, error) {
+				return filepath.Join(dir, ".cursor", "mcp.json"), nil
+			},
 		},
 		{
 			id: "opencode", name: "OpenCode", configDesc: "opencode.jsonc",
 			instructionFile: "AGENTS.md",
 			run:             func() (writeResult, error) { return writeOpencodeProject(projectDir) },
+			configPath: func(dir string) (string, error) {
+				return filepath.Join(dir, "opencode.jsonc"), nil
+			},
+			globalInstruction: func() (string, error) {
+				d, err := opencodeConfigDir()
+				if err != nil {
+					return "", err
+				}
+				return filepath.Join(d, "AGENTS.md"), nil
+			},
 		},
 		{
 			id: "codex", name: "Codex", configDesc: "~/.codex/config.toml",
 			instructionFile: "AGENTS.md",
 			run:             writeCodexHome,
+			configPath:      func(string) (string, error) { return codexConfigPath() },
 		},
 		{
 			id: "antigravity", name: "Antigravity", configDesc: "mcp_config.json",
@@ -58,9 +103,29 @@ func knownAgents(projectDir string) []agentDef {
 			// alongside its own GEMINI.md. AGENTS.md is sufficient here — see
 			// https://antigravity.codes/blog/antigravity-agents-md-guide
 			instructionFile: "AGENTS.md",
+			optIn:           true,
 			run:             func() (writeResult, error) { return writeAntigravityProject(projectDir) },
+			configPath: func(dir string) (string, error) {
+				return filepath.Join(dir, "mcp_config.json"), nil
+			},
 		},
 	}
+}
+
+// instructionFilesFor returns the project instruction files the selected agents
+// need, deduped, in knownAgents order. An OpenCode-only selection yields just
+// AGENTS.md; a Claude-Code-only selection just CLAUDE.md.
+func instructionFilesFor(agents []agentDef, selected map[string]bool) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, a := range agents {
+		if !selected[a.id] || a.instructionFile == "" || seen[a.instructionFile] {
+			continue
+		}
+		seen[a.instructionFile] = true
+		out = append(out, a.instructionFile)
+	}
+	return out
 }
 
 // runInteractiveWizard runs the interactive init wizard.
@@ -115,14 +180,7 @@ func runInteractiveWizard(dir, projectDir string, quiet bool) error {
 	}
 
 	// 5. Build ordered, deduped list of instruction files.
-	var instrFiles []string
-	instrSet := make(map[string]bool)
-	for _, a := range agents {
-		if selSet[a.id] && a.instructionFile != "" && !instrSet[a.instructionFile] {
-			instrSet[a.instructionFile] = true
-			instrFiles = append(instrFiles, a.instructionFile)
-		}
-	}
+	instrFiles := instructionFilesFor(agents, selSet)
 
 	// 6. Run writers and print results.
 	if !quiet {

--- a/cmd/graymatter/cmd_init_interactive_test.go
+++ b/cmd/graymatter/cmd_init_interactive_test.go
@@ -358,3 +358,74 @@ func TestInteractive_EmptyInputProducesNoFiles(t *testing.T) {
 		}
 	}
 }
+
+// TestInstructionFilesFor pins the mapping every init path now depends on.
+//
+// Claude Code reads CLAUDE.md and does not read AGENTS.md; the other four read
+// AGENTS.md. Wiring one agent and getting the other's file is the bug this
+// table exists to prevent, so each single-agent case is spelled out rather than
+// derived from the table under test.
+func TestInstructionFilesFor(t *testing.T) {
+	agents := knownAgents(".")
+
+	cases := []struct {
+		name     string
+		selected []string
+		want     []string
+	}{
+		{"opencode alone", []string{"opencode"}, []string{"AGENTS.md"}},
+		{"claude code alone", []string{"claudecode"}, []string{"CLAUDE.md"}},
+		{"cursor alone", []string{"cursor"}, []string{"AGENTS.md"}},
+		{"codex alone", []string{"codex"}, []string{"AGENTS.md"}},
+		{"antigravity alone", []string{"antigravity"}, []string{"AGENTS.md"}},
+		// Two agents sharing a file must not produce it twice.
+		{"cursor and opencode dedupe", []string{"cursor", "opencode"}, []string{"AGENTS.md"}},
+		{"both files", []string{"claudecode", "opencode"}, []string{"CLAUDE.md", "AGENTS.md"}},
+		{"nothing selected", nil, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sel := map[string]bool{}
+			for _, id := range c.selected {
+				sel[id] = true
+			}
+			got := instructionFilesFor(agents, sel)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+			for i := range c.want {
+				if got[i] != c.want[i] {
+					t.Fatalf("got %v, want %v", got, c.want)
+				}
+			}
+		})
+	}
+}
+
+// TestKnownAgentsTableIsComplete guards the fields the other paths read off the
+// table. A new agent added without a configPath would be invisible to doctor,
+// and one without an instructionFile would be wired with nothing telling the
+// model to use the tools — both silent failures rather than build errors.
+func TestKnownAgentsTableIsComplete(t *testing.T) {
+	seen := map[string]bool{}
+	for _, a := range knownAgents(".") {
+		if a.id == "" || a.name == "" {
+			t.Errorf("agent %+v is missing an id or name", a)
+		}
+		if seen[a.id] {
+			t.Errorf("duplicate agent id %q", a.id)
+		}
+		seen[a.id] = true
+
+		if a.run == nil {
+			t.Errorf("%s has no writer", a.id)
+		}
+		if a.configPath == nil {
+			t.Errorf("%s has no configPath, so doctor cannot see it", a.id)
+		}
+		if a.instructionFile == "" {
+			t.Errorf("%s has no instructionFile", a.id)
+		}
+	}
+}

--- a/cmd/graymatter/cmd_init_writers_test.go
+++ b/cmd/graymatter/cmd_init_writers_test.go
@@ -167,7 +167,12 @@ func TestWriteAntigravity_MergesJSON(t *testing.T) {
 }
 
 func TestParseOnlyFlag(t *testing.T) {
-	got := parseOnlyFlag(" Claudecode, Cursor ,codex")
+	agents := knownAgents(".")
+
+	got, err := parseOnlyFlag(" Claudecode, Cursor ,codex", agents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := map[string]bool{"claudecode": true, "cursor": true, "codex": true}
 	if len(got) != len(want) {
 		t.Fatalf("got %v want %v", got, want)
@@ -177,7 +182,19 @@ func TestParseOnlyFlag(t *testing.T) {
 			t.Fatalf("missing key %q in %v", k, got)
 		}
 	}
-	if parseOnlyFlag("") != nil {
+
+	empty, err := parseOnlyFlag("", agents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if empty != nil {
 		t.Fatalf("empty string should return nil")
+	}
+
+	// An unrecognised id must fail loudly. Now that the instruction files
+	// follow the selection, silently ignoring it would write nothing at all
+	// and still exit 0.
+	if _, err := parseOnlyFlag("opencode,bogus", agents); err == nil {
+		t.Fatal("unknown agent id should be an error")
 	}
 }


### PR DESCRIPTION
Fixes the half of #13 that was never actually fixed, the false warning #17's own solution produces, and the reason a project stuck on the #14 briefing still reports "Everything looks good".

## One table, three copies of it

`knownAgents` knows which instruction file each agent reads. It shipped with the wizard in #16 and nothing else learned about it: `init`'s flag path kept its own list of writers, and `doctor` kept its own list of client config paths. Three lists, one of them updated. Both bugs below fall out of that.

## `init` wrote files nobody reads

`--only opencode` created a `CLAUDE.md` next to the `AGENTS.md` it needed. Every other value had the same problem in its own direction: `--only claudecode` wrote an `AGENTS.md`, `--only cursor` and `--only codex` wrote a `CLAUDE.md`. Claude Code reads `CLAUDE.md` and does not read `AGENTS.md`, so the surplus file is not harmless redundancy — for an OpenCode-only user it was the whole complaint on #13, credited in the close comment and then not fixed.

`--only` now rejects an unrecognised id. That was cosmetic while both files were written unconditionally: a typo wired nothing but still produced two files, so the run looked half-successful. Once the files follow the selection, a typo writes nothing at all and still exits 0, so it has to fail loudly.

Plain `init` is unchanged, byte for byte. `--skip-claudecode` no longer writes a `CLAUDE.md` nobody asked for.

## The writer damaged files it updated

Found while checking whether a content comparison would be safe. It always spliced LF: with `core.autocrlf=true` the block comes back from a checkout as CRLF, so the managed block was LF and the rest of the file CRLF. The whole-file comparison then never matched again, so every `init` rewrote the file and reported a change — a dirty tree after a command meant to be a no-op.

It also replaced only the first marker pair, so a file could carry a current block and a stale one at once and still satisfy anything that read the first pair and stopped.

## `doctor` answered the wrong question twice

It looked only at the project's `CLAUDE.md` and `AGENTS.md`, so a project relying on `init --global` was told nothing tells the model to use the memory tools — by the check whose own hint recommends `--global`. Simply also looking at the global files would have traded a false alarm for a false pass: a global block reaches Claude Code and OpenCode, not Cursor or Codex. Coverage is resolved per wired agent instead, off the same table.

It also accepted any file carrying the marker, or merely the word "graymatter". The pre-0.7.0 briefing satisfies both and its markers are byte-identical to today's, so a project still carrying the block behind #14 reported "Everything looks good". It now compares the block against the text we ship — no version bookkeeping to remember on the next revision — with line endings normalised so a CRLF checkout is not mistaken for drift. A briefing you wrote yourself is recognised and never called stale.

## Verification

- **Genuine artifact, not a reconstruction.** Built the v0.6.0 binary from the tag and generated a real pre-0.7.0 project. `main` reports "Everything looks good"; this branch flags both files and clears after re-running `init`, with zero v0.6 text left.
- **18 flag combinations**, `main` vs branch: 9 differ, each by exactly the surplus instruction file and nothing else. The other 9 are identical, and `--global --with-antigravity` is byte-identical across project and home.
- **Wizard**, 9 selections through stdin: identical to `main`.
- **Acceptance suite of 16 assertions** on Windows and Linux, both green. The first Linux run failed two of them and was right to: the assertions were reading the global summary line, which depends on whether `graymatter` is on PATH. They pass on Windows by accident of this machine. Re-pointed at the `instructions` line.
- **`-race`**, full CI sequence reproduced on Go 1.23: every package clean, coverage gates 73.5% core and 68.2% CLI. Verified the detector was actually armed by injecting a deliberate race and confirming it fired.
- **Line endings**, 6 scenarios including a file already mangled by the current release: all idempotent, no mixed output, an LF file with one pasted CRLF line stays LF.
- **Marker edge cases**: duplicate blocks, orphaned begin, stray end, end-before-begin. All preserve user content and converge.
- New tests fail against the previous behaviour where they describe a real bug, and are labelled as regression guards where they do not.

## Also here

`CONTRIBUTING.md` said Go 1.22+; the workspace declares 1.23.0, so 1.22 either fetches 1.23 or refuses under `GOTOOLCHAIN=local`. It listed "no CGO" as a machine requirement when it is how the release artifact is built — and `-race`, which CI runs on every package and the documented commands omit, is the one thing that does need a C toolchain.

## Not addressed

- `--global` still ignores `--only`: `--only claudecode --global` writes OpenCode's global file too. Pre-existing, preserved identically, worth deciding separately.
- Orphaned `CLAUDE.md` files already created by the bug are left alone. A fix should not delete files on the user's behalf.
- CI's `go: ["1.22"]` matrix row silently runs 1.23, since the toolchain switches to satisfy `go.work`. Same for `release.yml`. Not touched here.
