### PR TITLE
docs: name the actual Windows transport, and answer the comparison question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Documentation
+
+- **`CLAUDE.md` named the wrong Windows transport.** It described daemon
+  clients connecting over "a local socket or named pipe". There is no named
+  pipe: `pkg/memory/rpc/sock_windows.go` binds TCP loopback on a
+  kernel-assigned port, because Go's standard library has no portable named-pipe
+  support. Corrected, and the consequence is now stated — on Windows the token
+  in the 0600 discovery file is the only access control, since any local process
+  can reach loopback.
+- **Added a "How it compares" section to the README** covering code graphs and
+  context compressors, after [#23](https://github.com/angelnicolasc/graymatter/issues/23)
+  showed the existing text does not say *what* the knowledge graph is a graph of.
+
 ---
 
 ## [0.8.0] – 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   clients connecting over "a local socket or named pipe". There is no named
   pipe: `pkg/memory/rpc/sock_windows.go` binds TCP loopback on a
   kernel-assigned port, because Go's standard library has no portable named-pipe
-  support. Corrected, and the consequence is now stated — on Windows the token
-  in the 0600 discovery file is the only access control, since any local process
-  can reach loopback.
+  support. Corrected, along with what follows from it — on Windows the 256-bit
+  token in the discovery file is the only access control, and the `0600` passed
+  to `os.WriteFile` buys nothing there, since Windows ignores POSIX modes and
+  the file inherits its parent directory's ACL. Verified on Windows 10: the
+  discovery file carries zero non-inherited ACEs, and its ACL is byte-identical
+  to its parent's.
 - **Added a "How it compares" section to the README** covering code graphs and
   context compressors, after [#23](https://github.com/angelnicolasc/graymatter/issues/23)
   showed the existing text does not say *what* the knowledge graph is a graph of.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,10 @@ code conventions. Two things the tree does not make obvious:
 - **bbolt is single-writer, and daemon mode is what makes concurrent access
   work.** One process owns the store and every other one (TUI, MCP server, CLI,
   `run`, the REST server) connects as a client over a Unix domain socket on
-  POSIX, TCP loopback on Windows — where the token in the 0600 discovery file
-  is the only access control, since any local process can reach loopback.
+  POSIX, TCP loopback on Windows. On Windows the 256-bit token in the discovery
+  file is the *only* access control: any local process can reach loopback, and
+  the `0600` the code passes to `os.WriteFile` is a POSIX-only guarantee — on
+  Windows the file just inherits its parent directory's ACL.
   Clients spawn the daemon on first use and it idle-exits when unused.
   `--no-daemon` opts out and brings the lock contention back. See
   `cmd/graymatter/internal/daemon/` and `pkg/memory/rpc/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,10 @@ code conventions. Two things the tree does not make obvious:
 
 - **bbolt is single-writer, and daemon mode is what makes concurrent access
   work.** One process owns the store and every other one (TUI, MCP server, CLI,
-  `run`, the REST server) connects as a client over a local socket or named
-  pipe. Clients spawn the daemon on first use and it idle-exits when unused.
+  `run`, the REST server) connects as a client over a Unix domain socket on
+  POSIX, TCP loopback on Windows — where the token in the 0600 discovery file
+  is the only access control, since any local process can reach loopback.
+  Clients spawn the daemon on first use and it idle-exits when unused.
   `--no-daemon` opts out and brings the lock contention back. See
   `cmd/graymatter/internal/daemon/` and `pkg/memory/rpc/`.
 - **The module is split.** The root is the library; `cmd/graymatter/` is the CLI

--- a/README.md
+++ b/README.md
@@ -658,12 +658,14 @@ where the reason the direct-bbolt fast path got rejected lives.
 
 The two also mean different things by *knowledge graph*. Theirs is functions,
 classes, files, routes, with `CALLS` / `IMPORTS` edges, derived automatically by
-parsing your code, and it is the primary thing you query. GrayMatter's nodes are
-person / project / decision / preference / fact — entities named in the facts
-themselves — and the graph is built explicitly, via `memory_reflect` with
-`action="link"` or the TUI, rather than derived from anything. It is there to be
-browsed and exported (there is an Obsidian exporter), not traversed the way a
-call graph is. The clearest tell is decay: facts here carry a weight on a 30-day
+parsing your code, and it is the primary thing you query. GrayMatter's is a much
+smaller idea: entities named in the facts themselves, typed person / project /
+decision / preference / fact, never derived from source. It is also the least
+finished part of this project — the wiring that would populate it is not
+connected in shipped builds, tracked in
+[#24](https://github.com/angelnicolasc/graymatter/issues/24) — so take the fact
+store, not the graph, as what GrayMatter actually gives you today. The clearest
+tell is decay: facts here carry a weight on a 30-day
 half-life and fade when nothing touches them, which a code graph must never do,
 since a stale one is simply wrong.
 

--- a/README.md
+++ b/README.md
@@ -628,10 +628,56 @@ store, err := memory.Open(memory.StoreConfig{
 - Not a framework. Not an agent runner. Not a replacement for your existing tooling.
 - Not a hosted service. Not a SaaS. Not a cloud product.
 - Not a knowledge base UI. Not Notion. Not Obsidian.
+- Not a code-intelligence tool. It never parses, indexes, or reads your source.
 - Not trying to win the enterprise memory market.
 
 It is exactly one thing: **the missing stateful layer for Go CLI agents**,
 packaged as a library you import in three lines.
+
+---
+
+## How it compares
+
+Two categories get confused with this one often enough to be worth spelling out.
+Both are complementary: you can run them alongside GrayMatter and the tool
+surfaces never collide.
+
+**Code graphs** — [codegraph](https://github.com/colbymchenry/codegraph),
+[codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp), and
+others. These parse your source with tree-sitter and expose symbols, call
+edges, routes, and blast radius. The repo is the source of truth: delete the
+index, re-run it, and you get the same graph back, because the graph is a
+projection of code that already exists.
+
+GrayMatter never reads your source. There is no parser and no indexing step, so
+a fact exists only because something deliberately wrote it — `memory_add` over
+MCP, `graymatter remember`, `POST /remember`, or `Memory.Remember` from Go.
+Delete `.graymatter/` and nothing regenerates it, because it was never in the
+tree. A code graph tells you that every client dials the daemon; GrayMatter is
+where the reason the direct-bbolt fast path got rejected lives.
+
+The two also mean different things by *knowledge graph*. Theirs is functions,
+classes, files, routes, with `CALLS` / `IMPORTS` edges, derived automatically by
+parsing your code, and it is the primary thing you query. GrayMatter's nodes are
+person / project / decision / preference / fact — entities named in the facts
+themselves — and the graph is built explicitly, via `memory_reflect` with
+`action="link"` or the TUI, rather than derived from anything. It is there to be
+browsed and exported (there is an Obsidian exporter), not traversed the way a
+call graph is. The clearest tell is decay: facts here carry a weight on a 30-day
+half-life and fade when nothing touches them, which a code graph must never do,
+since a stale one is simply wrong.
+
+**Context compressors** — tools that sit on the transport and shrink what is
+already moving through it: file reads, shell output, request payloads.
+GrayMatter never sees your traffic. The agent writes one distilled sentence and
+recalls a handful of facts later, so the payload is not made smaller, it stops
+being sent. Some compressors also ship session memory, which genuinely overlaps;
+the difference is scope, since GrayMatter is five MCP tools in a static binary
+with nothing in your request path and no account.
+
+Token-reduction numbers across these categories are not comparable either. A
+code graph saves you exploration tokens; a compressor saves you payload bytes;
+GrayMatter saves you conversation history. They stack.
 
 ---
 


### PR DESCRIPTION
Docs only, no code touched.

### The Windows transport was wrong in `CLAUDE.md`

It said daemon clients connect over "a local socket or named pipe". There is no named pipe: `sock_windows.go` binds TCP loopback on a kernel-assigned port, because the standard library has no portable named-pipe support.

Verified against a running daemon on Windows 10 rather than by reading the source — `tcp://127.0.0.1:52074`, listener confirmed with `netstat`. The security consequence is now spelled out too, and corrected: the `0600` the code passes to `os.WriteFile` buys nothing on Windows, where the file carries zero non-inherited ACEs and its ACL is identical to its parent directory's. The 256-bit token is the only real access control there, and it is enforced — a wrong token gets the connection reset before dispatch, a valid one reaches RPC dispatch.

### The README had no answer to #23

It says "knowledge graph" without ever saying a graph of what, which is what prompted the question. Adds a `How it compares` section covering code-graph tools and context compressors, plus a line to `What GrayMatter is NOT` stating that it never reads your source.

That section deliberately does not oversell the graph: testing it end to end turned up that nodes have no reachable write path in a shipped build, which is now #24. It points there and says to take the fact store as what the project delivers today.

### Known inconsistency left in place

The roadmap line `[x] Knowledge graph (entity extraction, node/edge linking, Obsidian export)` is wrong on all three counts and now visibly contradicts the new section. Left for #24 to resolve, since unchecking a shipped roadmap item is a product call rather than a docs fix.

Refs #23, #24