### PR TITLE
docs: uncheck the knowledge graph roadmap line

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ GrayMatter saves you conversation history. They stack.
 - [x] Hybrid retrieval (vector + keyword + recency, RRF fusion)
 - [x] CLI: `init remember recall checkpoint export run sessions plugin server`
 - [x] MCP server (Claude Code / Cursor) + `memory_reflect` self-edit tool
-- [x] Knowledge graph (entity extraction, node/edge linking, Obsidian export)
+- [ ] Knowledge graph — schema, bbolt storage and the TUI view are in, but nodes have no write path in shipped builds, so entity extraction and the graph's Obsidian export never run ([#24](https://github.com/angelnicolasc/graymatter/issues/24))
 - [x] Shared memory across agents (`--shared`, `--all` flags, `__shared__` namespace)
 - [x] REST API server mode (`graymatter server --addr :8080`)
 - [x] Plugin system (JSON line protocol, `graymatter plugin install/list/remove`)


### PR DESCRIPTION
One line. The roadmap claimed entity extraction, node/edge linking and the Obsidian export were all shipped.

Testing against a built binary showed none of that is true end to end: nodes have no reachable write path, so extraction never runs and the graph's Obsidian export is uncallable, while `memory_reflect action="link"` writes edges that dangle. Details in #24.

The `How it compares` section added in #25 already says the wiring is not connected, so until now the README contradicted itself forty lines apart. This removes that.

Refs #24