### PR TITLE
v0.10.0: make the claims true — supersede tombstones, honest decay, and seven ADRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,162 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
-## [Unreleased]
+## [0.10.0] - 2026-08-23
+
+A release about claims. Every number this project published, and every
+behaviour it described, checked against what the code does — and where they
+disagreed, the code fixed or the claim withdrawn. Three of the disagreements
+were bugs, and one had been shipping since the feature existed.
+
+Nothing here requires action from a caller. Every addition is a new field whose
+zero value reproduces v0.9.0 exactly, enforced by
+`TestRankingDefaults_MatchV09Behaviour`. One default changes, listed below.
+
+### Fixed
+
+**Forgetting a fact did not stop it being recalled.** `memory_reflect` with
+`action="forget"` or `"update"` set the fact's weight to 0 and answered *"Fact
+suppressed for agent"*. `Recall` never reads weight — it ranks on vector,
+keyword and recency — so the fact came back on the very next search. An agent
+that had just corrected itself received both versions:
+
+```
+Found 2 relevant memories for agent "billing-agent":
+1. Billing runs through Polar
+2. Billing runs through Lemon Squeezy
+```
+
+with nothing to indicate which was current. Nothing cleared it up until a
+consolidation cycle happened to prune the zero-weight fact, and consolidation
+only fires past `ConsolidateThreshold` facts — so on a smaller store, never.
+
+`Fact` gains `SupersededBy`. Non-empty means retired, and `Recall` drops those
+before scoring, so a tombstoned fact cannot even displace a live one from the
+top-k. The value is the replacement fact's ID for `update`, or
+`SupersededByAgent` for `forget`, so a correction can be followed rather than
+merely noticed. Nothing is deleted: `List`, `export` and the TUI still show
+retired facts, and pruning by decay remains the only thing that removes
+anything. Precedence between tombstone, decay and pruning is now stated and
+tested — see [ADR-007](docs/decisions/007-supersede-tombstones.md).
+
+`update` also stopped retiring the old fact before storing the replacement. The
+previous order zeroed the weight first, so a failing `Remember` left an agent
+with a retired fact and nothing in its place.
+
+**Decay ran on a half-life of one consolidation cycle, not 30 days.**
+`Consolidate` computed `weight *= exp(-lambda * hoursSinceAccessed)` using the
+full elapsed time on every run — nothing recorded that a fact had already been
+decayed, so each cycle re-applied the whole period. A fact one half-life stale,
+across five cycles in the same millisecond: 0.5, 0.25, 0.125, 0.0625, 0.031.
+With `AsyncConsolidate` on, consolidation fires after `Remember`, so a busy
+agent could take a month-old fact below the 0.01 prune floor in minutes. Every
+statement this project made about 30-day decay described a model the code did
+not implement.
+
+Weight is now recomputed from staleness rather than multiplied into:
+`weight = min(weight, exp(-lambda * hoursSinceAccessed))`. Idempotent, so
+consolidating more often no longer forgets faster. The `min` keeps decay from
+handing weight back, which also stops a zeroed tombstone being resurrected by
+its own recent access time.
+
+**An unimplemented consolidation LLM failed silently.** Ollama is a supported
+embedding backend, so `ConsolidateLLM = "ollama"` looks reasonable and config
+accepts it — but summarisation through Ollama is not implemented, and the code
+returned an empty summary and a nil error. Such a store ran decay and pruning
+forever, never summarised, and gave no indication why. It now returns
+`ErrConsolidateLLMUnsupported` through `OnConsolidateError`, as do
+summarisation errors in general, which were being discarded at that call site.
+
+### Changed
+
+- **`GET /recall` returns 8 facts by default, not 5.** The REST server had its
+  own constant while the library, CLI, MCP tools and TUI all used
+  `DefaultConfig().TopK`. Same store, same query, a different amount of context
+  depending on which door you came through. `?k=5` restores the old count. The
+  test reads the library default rather than repeating a number, so the two
+  cannot drift apart again.
+- The MCP server announces version `0.10.0`.
+
+### Added
+
+- **`StoreConfig.SignalWeights`** — how much vector similarity, keyword
+  relevance and recency each contribute to the ranking. A pointer: `nil` means
+  `DefaultSignalWeights()` (1.0, 1.0, 0.5 — the values previously hardcoded),
+  and the indirection exists so the zero value cannot be mistaken for "all
+  signals off". Also on the root `Config`.
+
+  This makes available an honest version of a claim that was not previously
+  available at all: with all weight on recency, retrieval degenerates into
+  "return the K most recent facts", which is a sliding window. A test runs it
+  over a corpus where the relevant facts are the old ones and shows the window
+  returning none of them. Before this, no configuration of GrayMatter ranked
+  that way, so the claim described a system that did not exist.
+- **`StoreConfig.MinRelevance`** — drops results below a fraction of the best
+  score in the same result set. Default 0, meaning no cut and exactly `topK`
+  returned, as before. The threshold is relative because RRF scores depend on
+  how many facts were ranked, so an absolute cutoff would change meaning as a
+  store grew.
+- **`Fact.SupersededBy`, `Fact.IsSuperseded()`, `SupersededByAgent`** — see
+  Fixed. `omitempty` and additive: stores written by earlier versions load
+  unchanged, checked against a literal v0.9.0 JSON fact.
+- **[`docs/decisions/`](docs/decisions/README.md)** — seven architecture
+  decision records, each with a measurable condition for reversing it. Why
+  decay is 30 days and which two classes of fact that model gets wrong; why
+  there is a daemon; why not multi-tenant; the embedding chain; the signal
+  weights; the tombstones; and the true state of the knowledge graph.
+
+### Documentation
+
+**`docs/benchmarks.md` published a table nothing produced.** It claimed
+~40,000 tokens of full injection against ~1,200 recalled at 100 sessions;
+`go run ./benchmarks/token_count` measures ~6,959 against ~666. The
+100-session row was 475% off. It also published a "Relevance@8 vs full
+context" score, and no code in this repository measures relevance at all.
+
+The README was correct throughout, which is the uncomfortable part: the v0.9.0
+sweep grepped for "97" and this page never said 97, so a five-fold error
+survived a hygiene pass whose whole purpose was removing indefensible numbers.
+
+The check is now mechanical. `benchmarks/token_count/main_test.go` parses the
+tables out of README.md and docs/benchmarks.md and compares every cell against
+a live benchmark run — 2% tolerance on token counts, none at all on the
+reduction percentage — and rejects any relevance or precision figure in the
+benchmark docs until something computes one.
+
+The rewritten page states what the benchmark does not measure, which is more
+than what it does: it never checks whether the 8 recalled facts are the right
+8, so a system returning 8 at random scores the same 90%; and full-history
+injection is the weakest possible baseline, since a sliding window of the last
+8 observations costs roughly 560 tokens against our ~550–670. **Against the
+baseline production actually uses, this benchmark shows no token win to
+claim.**
+
+**The README described the knowledge graph wrongly in both directions.** It
+said nodes have no write path in shipped builds. They do — `memory_reflect
+action=link` creates edges, the daemon opens a real graph and serves
+`KGUpsert`/`KGLink`, and the direct store does the same. What is missing is
+*automatic* population: `Store.SetKG` is never called outside tests, so entity
+extraction during consolidation and graph enrichment during recall are
+implemented, tested, and have never run. Corrected in the README, the roadmap
+and [ADR-003](docs/decisions/003-knowledge-graph-autopopulation.md) together.
+
+**`docs/AGENTS.md` carried four claims that had stopped being true.** That
+`update` leaves the old fact for consolidation to prune; that RRF has "no
+tunable percentage weights to fiddle with"; that `link` requires a
+`SetKGLinker` that no longer exists, returning an error string that no longer
+exists, citing a line that now holds something else; and that an unreferenced
+fact is pruned in ~60 days, when the arithmetic gives 6.64 half-lives — 199
+days. Also a link to `GRAYMATTER_PLAYBOOK.md`, a file with no history in this
+repository.
+
+Smaller: the benchmark's header described a corpus of 5 observations per
+session where the loop stores 1, and `ConsolidateThreshold`'s two different
+comparisons (`>=` to trigger a cycle, `>` to summarise) are now explained at
+both sites rather than left looking like an off-by-one.
+
+---
+
+## [0.9.0] - 2026-08-22
 
 ### Security
 
@@ -543,6 +698,8 @@ See [`docs/api-stability.md`](docs/api-stability.md) for the list of stable publ
 
 See [`docs/api-stability.md`](docs/api-stability.md) for the list of stable public identifiers and the compatibility promise for the v0.x series.
 
+[0.10.0]: https://github.com/angelnicolasc/graymatter/releases/tag/v0.10.0
+[0.9.0]: https://github.com/angelnicolasc/graymatter/releases/tag/v0.9.0
 [0.2.1]: https://github.com/angelnicolasc/graymatter/releases/tag/v0.2.1
 [0.2.0]: https://github.com/angelnicolasc/graymatter/releases/tag/v0.2.0
 [0.1.0]: https://github.com/angelnicolasc/graymatter/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 <p align="center">
   <a href="https://github.com/angelnicolasc/graymatter/actions/workflows/ci.yml"><img src="https://github.com/angelnicolasc/graymatter/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://pkg.go.dev/github.com/angelnicolasc/graymatter"><img src="https://pkg.go.dev/badge/github.com/angelnicolasc/graymatter.svg" alt="Go Reference"></a>
-  <a href="https://github.com/angelnicolasc/graymatter/releases/tag/v0.9.0"><img src="https://img.shields.io/github/v/release/angelnicolasc/graymatter" alt="Latest Release"></a>
-  <img src="https://img.shields.io/badge/coverage-74.8%25-brightgreen" alt="Coverage 74.8%">
+  <a href="https://github.com/angelnicolasc/graymatter/releases/tag/v0.10.0"><img src="https://img.shields.io/github/v/release/angelnicolasc/graymatter" alt="Latest Release"></a>
+  <img src="https://img.shields.io/badge/coverage-77.0%25-brightgreen" alt="Coverage 77.0%">
   <img src="https://img.shields.io/badge/platforms-linux%20%7C%20macOS%20%7C%20windows-blue" alt="Platforms">
   <img src="https://img.shields.io/github/license/angelnicolasc/graymatter" alt="License">
 <div align="center">
@@ -157,22 +157,22 @@ The dashboard auto-refreshes every 5 seconds. Press `1–4` to switch tabs,
 
 ```bash
 # Linux (x86_64)
-curl -sSL -o graymatter.tar.gz https://github.com/angelnicolasc/graymatter/releases/download/v0.9.0/graymatter_0.9.0_linux_amd64.tar.gz
+curl -sSL -o graymatter.tar.gz https://github.com/angelnicolasc/graymatter/releases/download/v0.10.0/graymatter_0.10.0_linux_amd64.tar.gz
 tar -xzf graymatter.tar.gz
 sudo mv graymatter /usr/local/bin/
 
 # Linux (ARM64)
-curl -sSL -o graymatter.tar.gz https://github.com/angelnicolasc/graymatter/releases/download/v0.9.0/graymatter_0.9.0_linux_arm64.tar.gz
+curl -sSL -o graymatter.tar.gz https://github.com/angelnicolasc/graymatter/releases/download/v0.10.0/graymatter_0.10.0_linux_arm64.tar.gz
 tar -xzf graymatter.tar.gz
 sudo mv graymatter /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -sSL -o graymatter.tar.gz https://github.com/angelnicolasc/graymatter/releases/download/v0.9.0/graymatter_0.9.0_darwin_arm64.tar.gz
+curl -sSL -o graymatter.tar.gz https://github.com/angelnicolasc/graymatter/releases/download/v0.10.0/graymatter_0.10.0_darwin_arm64.tar.gz
 tar -xzf graymatter.tar.gz
 sudo mv graymatter /usr/local/bin/
 
 # Windows (PowerShell)
-iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.9.0/graymatter_0.9.0_windows_amd64.zip -OutFile graymatter.zip
+iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.10.0/graymatter_0.10.0_windows_amd64.zip -OutFile graymatter.zip
 Expand-Archive graymatter.zip -DestinationPath .\graymatter_cli
 ```
 
@@ -819,4 +819,4 @@ GrayMatter saves you conversation history. They stack.
 
 ---
 
-*GrayMatter — v0.9.0 — August 2026*
+*GrayMatter — v0.10.0 — August 2026*

--- a/README.md
+++ b/README.md
@@ -551,6 +551,25 @@ go run ./benchmarks/token_count
 
 ---
 
+## Design decisions
+
+The tradeoffs that are not obvious from reading the code, each with the
+condition under which it should be reversed. If you are wondering why decay is
+30 days, or why there is a daemon at all, the answer is written down rather
+than folklore.
+
+| # | Decision |
+|---|---|
+| [001](docs/decisions/001-decay-half-life.md) | Memory decays on a 30-day half-life — and the two classes of fact that model gets wrong |
+| [002](docs/decisions/002-bbolt-single-writer.md) | bbolt with a single writer, and a daemon to share it |
+| [003](docs/decisions/003-knowledge-graph-autopopulation.md) | The knowledge graph has a write path but no automatic population |
+| [004](docs/decisions/004-local-first-single-node.md) | Local-first and single-node, deliberately not multi-tenant |
+| [005](docs/decisions/005-embedding-degradation-chain.md) | Embeddings degrade Ollama → OpenAI → Anthropic → keyword |
+| [006](docs/decisions/006-configurable-signal-weights.md) | Retrieval signal weights are configurable — and why a sliding window is a special case |
+| [007](docs/decisions/007-supersede-tombstones.md) | Contradictions are resolved by tombstone, never by delete |
+
+---
+
 ## Storage
 
 | Layer | Tech | What it holds |
@@ -739,10 +758,11 @@ classes, files, routes, with `CALLS` / `IMPORTS` edges, derived automatically by
 parsing your code, and it is the primary thing you query. GrayMatter's is a much
 smaller idea: entities named in the facts themselves, typed person / project /
 decision / preference / fact, never derived from source. It is also the least
-finished part of this project — the wiring that would populate it is not
-connected in shipped builds, tracked in
-[#24](https://github.com/angelnicolasc/graymatter/issues/24) — so take the fact
-store, not the graph, as what GrayMatter actually gives you today. The clearest
+finished part of this project — an agent can write to it explicitly, but
+nothing populates it automatically, tracked in
+[#24](https://github.com/angelnicolasc/graymatter/issues/24) and explained in
+[ADR-003](docs/decisions/003-knowledge-graph-autopopulation.md) — so take the
+fact store, not the graph, as what GrayMatter actually gives you today. The clearest
 tell is decay: facts here carry a weight on a 30-day
 half-life and fade when nothing touches them, which a code graph must never do,
 since a stale one is simply wrong.
@@ -769,7 +789,7 @@ GrayMatter saves you conversation history. They stack.
 - [x] Hybrid retrieval (vector + keyword + recency, RRF fusion)
 - [x] CLI: `init remember recall checkpoint export run sessions plugin server`
 - [x] MCP server (Claude Code / Cursor) + `memory_reflect` self-edit tool
-- [ ] Knowledge graph — schema, bbolt storage and the TUI view are in, but nodes have no write path in shipped builds, so entity extraction and the graph's Obsidian export never run ([#24](https://github.com/angelnicolasc/graymatter/issues/24))
+- [ ] Knowledge graph — schema, bbolt storage, the TUI view and the write path are all in: `memory_reflect action=link` creates edges, and the daemon serves `KGUpsert`/`KGLink`. What is missing is *automatic* population — `Store.SetKG` is never called in shipped builds, so entity extraction during consolidation and graph enrichment during recall are implemented, tested, and never run. The graph holds only what an agent puts there explicitly ([#24](https://github.com/angelnicolasc/graymatter/issues/24), [ADR-003](docs/decisions/003-knowledge-graph-autopopulation.md))
 - [x] Shared memory across agents (`--shared`, `--all` flags, `__shared__` namespace)
 - [x] REST API server mode (`graymatter server`)
 - [x] Plugin system (JSON line protocol, `graymatter plugin install/list/remove`)

--- a/benchmarks/token_count/main.go
+++ b/benchmarks/token_count/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -148,13 +147,21 @@ const (
 // concatenated. GrayMatter = top-8 most relevant observations recalled.
 var sessionCounts = []int{1, 10, 30, 100}
 
-func main() {
-	start := time.Now()
+// result is one row of the benchmark table.
+type result struct {
+	Sessions     int
+	FullTokens   int
+	RecallTokens int
+	Reduction    float64 // percent
+}
 
+// runBenchmark executes the full measurement and returns one result per entry
+// in sessionCounts. It is separated from main so the reproducibility test can
+// call it and compare the published tables against freshly measured numbers.
+func runBenchmark() ([]result, error) {
 	dataDir, err := os.MkdirTemp("", "graymatter-bench-*")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mktemp: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("mktemp: %w", err)
 	}
 	defer os.RemoveAll(dataDir)
 
@@ -165,8 +172,7 @@ func main() {
 		Embedder: emb,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "open store: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("open store: %w", err)
 	}
 	defer store.Close()
 
@@ -175,6 +181,61 @@ func main() {
 	perm := rng.Perm(len(corpus))
 
 	ctx := context.Background()
+
+	results := make([]result, 0, len(sessionCounts))
+	inserted := 0
+
+	for _, target := range sessionCounts {
+		// Insert observations up to the target session count.
+		for inserted < target && inserted < len(corpus) {
+			if err := store.Put(ctx, agentID, corpus[perm[inserted]]); err != nil {
+				return nil, fmt.Errorf("put: %w", err)
+			}
+			inserted++
+		}
+
+		// Full injection: ALL stored observations concatenated.
+		allFacts, err := store.List(agentID)
+		if err != nil {
+			return nil, fmt.Errorf("list: %w", err)
+		}
+		var fullTexts []string
+		for _, f := range allFacts {
+			fullTexts = append(fullTexts, f.Text)
+		}
+		fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
+
+		// GrayMatter: recall only top-K most relevant observations.
+		recalled, err := store.Recall(ctx, agentID, query, topK)
+		if err != nil {
+			return nil, fmt.Errorf("recall: %w", err)
+		}
+		recallTokens := approxTokens(strings.Join(recalled, "\n"))
+
+		reduction := 0.0
+		if fullTokens > 0 {
+			reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
+		}
+
+		results = append(results, result{
+			Sessions:     target,
+			FullTokens:   fullTokens,
+			RecallTokens: recallTokens,
+			Reduction:    reduction,
+		})
+	}
+
+	return results, nil
+}
+
+func main() {
+	start := time.Now()
+
+	results, err := runBenchmark()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 
 	fmt.Println()
 	fmt.Println("GrayMatter Token Efficiency Benchmark")
@@ -186,50 +247,13 @@ func main() {
 		"Sessions", "Full Injection", "GrayMatter Recall", "Reduction")
 	fmt.Println(strings.Repeat("─", 72))
 
-	inserted := 0
-
-	for _, target := range sessionCounts {
-		// Insert observations up to the target session count.
-		for inserted < target && inserted < len(corpus) {
-			if err := store.Put(ctx, agentID, corpus[perm[inserted]]); err != nil {
-				fmt.Fprintf(os.Stderr, "put: %v\n", err)
-				os.Exit(1)
-			}
-			inserted++
-		}
-
-		// Full injection: ALL stored observations concatenated.
-		allFacts, err := store.List(agentID)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "list: %v\n", err)
-			os.Exit(1)
-		}
-		var fullTexts []string
-		for _, f := range allFacts {
-			fullTexts = append(fullTexts, f.Text)
-		}
-		fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
-
-		// GrayMatter: recall only top-K most relevant observations.
-		recalled, err := store.Recall(ctx, agentID, query, topK)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "recall: %v\n", err)
-			os.Exit(1)
-		}
-		recallTokens := approxTokens(strings.Join(recalled, "\n"))
-
-		reduction := 0.0
-		if fullTokens > 0 {
-			reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
-		}
-
+	for _, r := range results {
 		fmt.Printf("%-10d  ~%-17d  ~%-21d  %.0f%%\n",
-			target, fullTokens, recallTokens, reduction)
+			r.Sessions, r.FullTokens, r.RecallTokens, r.Reduction)
 	}
 
 	fmt.Println(strings.Repeat("─", 72))
 	fmt.Printf("\nRun time:  %s\n", time.Since(start).Truncate(time.Millisecond))
-	fmt.Printf("Data dir:  %s (auto-deleted)\n", filepath.Base(dataDir))
 	fmt.Println()
 	fmt.Println("Approximation: words × 1.33 ≈ GPT-4 tokens (±10% for English prose).")
 	fmt.Println("With vector embeddings (Ollama / OpenAI / Anthropic) recall precision")

--- a/benchmarks/token_count/main.go
+++ b/benchmarks/token_count/main.go
@@ -7,10 +7,16 @@
 //
 //	go run ./benchmarks/token_count
 //
-// Model: each "session" stores 5 key observations extracted from a realistic
-// agent interaction. "Full injection" = ALL stored observations concatenated.
+// Model: each "session" stores ONE observation — a paragraph extracted from a
+// realistic agent interaction, ~50-70 words. "30 sessions" means 30 stored
+// observations. "Full injection" = ALL stored observations concatenated.
 // "GrayMatter Recall" = top-8 most relevant observations for the given query.
 // Token counts are approximated at 1.33 tokens/word (matches tiktoken within ±10%).
+//
+// What this does NOT measure is in docs/benchmarks.md and is worth reading
+// before quoting a number from it: relevance is never checked, so a system
+// returning 8 random facts would score the same reduction, and full-history
+// injection is the weakest baseline available.
 package main
 
 import (

--- a/benchmarks/token_count/main_test.go
+++ b/benchmarks/token_count/main_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"math"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Every token figure published in the repository has to come from this
+// benchmark. Before v0.10.0 docs/benchmarks.md carried a table nothing
+// produced (~40,000 → ~1,200 tokens at 100 sessions, against a measured
+// ~6,959 → ~666) plus a "Relevance@8 ~91%" that no code in the tree
+// measures. The README was correct and the wrong numbers still shipped for
+// several releases, because "is this number real?" was a thing a human had
+// to remember to ask.
+//
+// These tests ask it on every CI run: the published tables are parsed out of
+// the markdown and compared against a live measurement.
+
+// tolerance is the relative error allowed between a published figure and the
+// measured one. The docs round to two or three significant figures on purpose
+// — a reader wants ~6,960, not 6,959 — so exact equality would fail on
+// rounding alone. 2% permits the rounding and nothing else: the fabricated
+// 100-session row was off by 475%.
+//
+// absFloor covers the small end, where rounding costs more than 2%: the
+// 1-session row measures 78 tokens and publishes ~80, which is 3% off and
+// entirely honest. Below this many tokens nobody is being misled.
+const (
+	tolerance = 0.02
+	absFloor  = 5
+)
+
+// docTable is one parsed markdown table row.
+type docRow struct {
+	sessions     int
+	fullTokens   int
+	recallTokens int
+	reduction    int // percent; -1 when the table does not publish one
+}
+
+func TestPublishedTokenTables_MatchMeasuredBenchmark(t *testing.T) {
+	measured, err := runBenchmark()
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	bySessions := make(map[int]result, len(measured))
+	for _, r := range measured {
+		bySessions[r.Sessions] = r
+	}
+
+	for _, doc := range []struct {
+		name string
+		path string
+	}{
+		{"README.md", "../../README.md"},
+		{"docs/benchmarks.md", "../../docs/benchmarks.md"},
+	} {
+		t.Run(doc.name, func(t *testing.T) {
+			raw, err := os.ReadFile(doc.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", doc.path, err)
+			}
+			rows := parseTokenRows(string(raw))
+			if len(rows) == 0 {
+				t.Fatalf("%s publishes no token table; every token figure in the "+
+					"repository must be traceable to ./benchmarks/token_count", doc.name)
+			}
+
+			for _, row := range rows {
+				got, ok := bySessions[row.sessions]
+				if !ok {
+					t.Errorf("%s publishes a row for %d sessions, which the benchmark "+
+						"does not measure (measured: %v)", doc.name, row.sessions, sessionCounts)
+					continue
+				}
+				assertClose(t, doc.name, row.sessions, "full injection", row.fullTokens, got.FullTokens)
+				assertClose(t, doc.name, row.sessions, "recall", row.recallTokens, got.RecallTokens)
+
+				if row.reduction >= 0 {
+					// The reduction column is the headline claim. It is an
+					// integer in both the table and the program output, so it
+					// gets no tolerance at all.
+					if want := int(math.Round(got.Reduction)); row.reduction != want {
+						t.Errorf("%s, %d sessions: published %d%% reduction, benchmark measures %d%%",
+							doc.name, row.sessions, row.reduction, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestDocsPublishNoUnmeasuredMetric guards the other half of the same problem.
+// docs/benchmarks.md used to publish "Relevance@8 vs full context — ~91%".
+// Nothing in the tree measures relevance, so the figure could not be wrong or
+// right; it could only be believed. A metric may be published once something
+// computes it.
+func TestDocsPublishNoUnmeasuredMetric(t *testing.T) {
+	raw, err := os.ReadFile("../../docs/benchmarks.md")
+	if err != nil {
+		t.Fatalf("read docs/benchmarks.md: %v", err)
+	}
+	text := string(raw)
+
+	// Claims of a relevance/precision/recall *score* require a measurement.
+	// The benchmark reports token counts only. Checked per line so a metric
+	// name and its percentage are caught across markdown table cells, which is
+	// exactly how the ~91% shipped.
+	name := regexp.MustCompile(`(?i)\b(relevance|precision|hitrate|hit rate)\b`)
+	pct := regexp.MustCompile(`\d+(\.\d+)?\s*%`)
+	for i, line := range strings.Split(text, "\n") {
+		if name.MatchString(line) && pct.MatchString(line) {
+			t.Errorf("docs/benchmarks.md:%d publishes a quality score that no code measures:\n  %s\n"+
+				"Either add the measurement to ./benchmarks/token_count and gate it in this test, "+
+				"or remove the claim.", i+1, strings.TrimSpace(line))
+		}
+	}
+}
+
+func assertClose(t *testing.T, doc string, sessions int, label string, published, measured int) {
+	t.Helper()
+	if measured == 0 {
+		if published != 0 {
+			t.Errorf("%s, %d sessions: published %d %s tokens, benchmark measures 0",
+				doc, sessions, published, label)
+		}
+		return
+	}
+	absErr := math.Abs(float64(published - measured))
+	relErr := absErr / float64(measured)
+	if relErr > tolerance && absErr > absFloor {
+		t.Errorf("%s, %d sessions: published ~%d %s tokens, benchmark measures %d (%.0f%% off, max %.0f%%). "+
+			"Update the table from `go run ./benchmarks/token_count`.",
+			doc, sessions, published, label, measured, relErr*100, tolerance*100)
+	}
+}
+
+// tokenRowRe matches a markdown table row whose first cell is a session count
+// and whose next two cells are token figures, in either published layout:
+//
+//	| 100      | ~6,960 tokens | ~670 tokens | **90%** |
+//	| Tokens per run (session 100)  | ~40,000 | ~1,200 |
+var (
+	tokenRowRe   = regexp.MustCompile(`^\|\s*(\d+)\s*\|\s*~?([\d,]+)[^|]*\|\s*~?([\d,]+)[^|]*\|(?:\s*\*{0,2}(\d+)%)?`)
+	sessionRowRe = regexp.MustCompile(`^\|[^|]*session\s+(\d+)\s*\)?\s*\|\s*~?([\d,]+)[^|]*\|\s*~?([\d,]+)[^|]*\|`)
+)
+
+// parseTokenRows pulls every published (sessions, full, recall) triple out of
+// a markdown document, in either of the two table layouts the repo has used.
+func parseTokenRows(doc string) []docRow {
+	var rows []docRow
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		if m := tokenRowRe.FindStringSubmatch(line); m != nil {
+			rows = append(rows, docRow{
+				sessions:     atoiCommas(m[1]),
+				fullTokens:   atoiCommas(m[2]),
+				recallTokens: atoiCommas(m[3]),
+				reduction:    atoiOrNeg(m[4]),
+			})
+			continue
+		}
+		if m := sessionRowRe.FindStringSubmatch(strings.ToLower(line)); m != nil {
+			rows = append(rows, docRow{
+				sessions:     atoiCommas(m[1]),
+				fullTokens:   atoiCommas(m[2]),
+				recallTokens: atoiCommas(m[3]),
+				reduction:    -1,
+			})
+		}
+	}
+	return rows
+}
+
+func atoiCommas(s string) int {
+	n, _ := strconv.Atoi(strings.ReplaceAll(strings.TrimSpace(s), ",", ""))
+	return n
+}
+
+func atoiOrNeg(s string) int {
+	if s == "" {
+		return -1
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return -1
+	}
+	return n
+}

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 func (s *Server) handleMemorySearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -153,50 +154,58 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if text == "" {
 			return toolError("text (the corrected fact) is required for update")
 		}
-		facts, err := s.backend.List(agentID)
+		before, err := s.backend.List(agentID)
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
-		for _, f := range facts {
-			if f.Text == target {
-				oldText = f.Text
-				f.Weight = 0
-				_ = s.backend.UpdateFact(agentID, f)
-				break
-			}
-		}
-		if oldText == "" {
+		victim, ok := findByText(before, target)
+		if !ok {
 			return toolError(fmt.Sprintf("target fact not found: %q", target))
 		}
+		oldText = victim.Text
+
+		// Write the correction before retiring what it corrects. The previous
+		// order zeroed the old fact's weight first, so a failing Remember left
+		// the agent with a retired fact and no replacement.
 		if err := s.backend.Remember(ctx, agentID, text); err != nil {
 			return toolError(fmt.Sprintf("add updated fact: %v", err))
+		}
+
+		// Point the tombstone at the replacement so the correction can be
+		// followed later, rather than only showing that something was retired.
+		replacementID := newFactID(s.backend, agentID, before)
+		if replacementID == "" {
+			replacementID = memory.SupersededByAgent
+		}
+		if err := s.supersedeFact(agentID, victim, replacementID); err != nil {
+			return toolError(fmt.Sprintf("supersede old fact: %v", err))
 		}
 		resultMsg = fmt.Sprintf("Updated fact for agent %q.", agentID)
 
 	case "forget":
 		// The fact to forget may arrive in target or text — both are
 		// documented as equivalent; target wins when both are set.
-		victim := target
-		if victim == "" {
-			victim = text
+		wanted := target
+		if wanted == "" {
+			wanted = text
 		}
-		if victim == "" {
+		if wanted == "" {
 			return toolError("the fact to forget is required: pass it in target (or text)")
 		}
 		facts, err := s.backend.List(agentID)
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
-		for _, f := range facts {
-			if f.Text == victim {
-				oldText = f.Text
-				f.Weight = 0
-				_ = s.backend.UpdateFact(agentID, f)
-				break
-			}
+		victim, ok := findByText(facts, wanted)
+		if !ok {
+			return toolError(fmt.Sprintf("target fact not found: %q", wanted))
 		}
-		if oldText == "" {
-			return toolError(fmt.Sprintf("target fact not found: %q", victim))
+		oldText = victim.Text
+
+		// Nothing replaces this one, so the tombstone records that an agent
+		// decided to drop it.
+		if err := s.supersedeFact(agentID, victim, memory.SupersededByAgent); err != nil {
+			return toolError(fmt.Sprintf("suppress fact: %v", err))
 		}
 		resultMsg = fmt.Sprintf("Fact suppressed for agent %q.", agentID)
 
@@ -228,4 +237,46 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 	})
 
 	return toolText(resultMsg)
+}
+
+// findByText returns the first fact whose text matches exactly.
+func findByText(facts []memory.Fact, text string) (memory.Fact, bool) {
+	for _, f := range facts {
+		if f.Text == text {
+			return f, true
+		}
+	}
+	return memory.Fact{}, false
+}
+
+// newFactID returns the ID of the fact added since the `before` snapshot was
+// taken. Matching on identity rather than text keeps it correct when the new
+// fact repeats wording that is already stored. Returns "" if the new fact
+// cannot be identified — the caller falls back to a generic marker rather than
+// leaving the correction untombstoned.
+func newFactID(backend Backend, agentID string, before []memory.Fact) string {
+	after, err := backend.List(agentID)
+	if err != nil {
+		return ""
+	}
+	known := make(map[string]bool, len(before))
+	for _, f := range before {
+		known[f.ID] = true
+	}
+	for _, f := range after {
+		if !known[f.ID] {
+			return f.ID
+		}
+	}
+	return ""
+}
+
+// supersedeFact retires a fact: it is tombstoned so Recall skips it from the
+// next query onward, and its weight is zeroed so ordinary decay pruning
+// collects it in due course. The fact itself is not deleted — storage is
+// append-only, and an audit has to be able to see what was retired and why.
+func (s *Server) supersedeFact(agentID string, f memory.Fact, supersededBy string) error {
+	f.SupersededBy = supersededBy
+	f.Weight = 0
+	return s.backend.UpdateFact(agentID, f)
 }

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	serverName    = "graymatter"
-	serverVersion = "0.9.0"
+	serverVersion = "0.10.0"
 
 	httpReadHeaderTimeout = 15 * time.Second
 	httpIdleTimeout       = 120 * time.Second

--- a/cmd/graymatter/internal/mcp/supersede_test.go
+++ b/cmd/graymatter/internal/mcp/supersede_test.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// memory_reflect's update and forget actions used to set Weight = 0 and report
+// success. Recall does not read Weight, so the fact kept being returned and
+// the agent that had just corrected itself was handed both versions on the
+// next search. These tests drive the tools the way an agent does — call, then
+// search — because the defect was invisible from inside the handler: it wrote
+// exactly what it meant to write.
+
+const (
+	staleFact = "Billing runs through Lemon Squeezy"
+	freshFact = "Billing runs through Polar"
+)
+
+// TestMemoryReflect_UpdateRemovesOldFactFromSearch is the regression test for
+// the correction case: after an update, the superseded statement must not come
+// back, and the correction must.
+func TestMemoryReflect_UpdateRemovesOldFactFromSearch(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	mustAdd(t, s, "billing-agent", staleFact)
+
+	res, err := s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+		"action": "update",
+		"agent":  "billing-agent",
+		"target": staleFact,
+		"text":   freshFact,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("memory_reflect update: %v / %s", err, resultText(t, res))
+	}
+
+	found := search(t, s, "billing-agent", "billing provider")
+	if strings.Contains(found, "Lemon Squeezy") {
+		t.Errorf("memory_reflect reported the fact updated, then search returned the old one:\n%s", found)
+	}
+	if !strings.Contains(found, "Polar") {
+		t.Errorf("the corrected fact is missing from search results:\n%s", found)
+	}
+}
+
+// TestMemoryReflect_ForgetRemovesFactFromSearch is the same for the forget
+// case, where there is no replacement — the tool answers "Fact suppressed",
+// and that has to be true.
+func TestMemoryReflect_ForgetRemovesFactFromSearch(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	mustAdd(t, s, "forget-agent", staleFact)
+
+	res, err := s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+		"action": "forget",
+		"agent":  "forget-agent",
+		"target": staleFact,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("memory_reflect forget: %v / %s", err, resultText(t, res))
+	}
+
+	if found := search(t, s, "forget-agent", "billing provider"); strings.Contains(found, "Lemon Squeezy") {
+		t.Errorf("memory_reflect reported the fact suppressed, then search returned it:\n%s", found)
+	}
+}
+
+// TestMemoryReflect_SupersededFactSurvivesInStore holds the append-only
+// promise at the tool boundary: suppressed means invisible to retrieval, not
+// erased. An audit still has to be able to see what the agent retired and
+// what replaced it.
+func TestMemoryReflect_SupersededFactSurvivesInStore(t *testing.T) {
+	s, mem := newTestServer(t)
+	ctx := context.Background()
+
+	mustAdd(t, s, "audit-agent", staleFact)
+
+	if res, err := s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+		"action": "update",
+		"agent":  "audit-agent",
+		"target": staleFact,
+		"text":   freshFact,
+	})); err != nil || res.IsError {
+		t.Fatalf("memory_reflect update: %v / %s", err, resultText(t, res))
+	}
+
+	facts, err := mem.Advanced().List("audit-agent")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	var tombstoned, live *memory.Fact
+	for i := range facts {
+		switch {
+		case facts[i].Text == staleFact:
+			tombstoned = &facts[i]
+		case facts[i].Text == freshFact:
+			live = &facts[i]
+		}
+	}
+	if tombstoned == nil {
+		t.Fatal("the superseded fact was deleted; storage is documented as append-only")
+	}
+	if !tombstoned.IsSuperseded() {
+		t.Error("the superseded fact carries no tombstone, so recall has nothing to filter on")
+	}
+	if live == nil {
+		t.Fatal("the replacement fact was not stored")
+	}
+	// The tombstone points at the replacement, so an audit can follow the
+	// correction rather than just seeing that something was retired.
+	if tombstoned.SupersededBy != live.ID {
+		t.Errorf("SupersededBy = %q, want the replacement fact's ID %q",
+			tombstoned.SupersededBy, live.ID)
+	}
+}
+
+// TestMemoryReflect_ForgetMarksAgentDecision distinguishes the two ways a fact
+// dies. forget has no replacement to point at, so it records that an agent
+// made the call.
+func TestMemoryReflect_ForgetMarksAgentDecision(t *testing.T) {
+	s, mem := newTestServer(t)
+	ctx := context.Background()
+
+	mustAdd(t, s, "marker-agent", staleFact)
+
+	if res, err := s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+		"action": "forget",
+		"agent":  "marker-agent",
+		"target": staleFact,
+	})); err != nil || res.IsError {
+		t.Fatalf("memory_reflect forget: %v / %s", err, resultText(t, res))
+	}
+
+	facts, err := mem.Advanced().List("marker-agent")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("expected the forgotten fact to remain in the store, got %d", len(facts))
+	}
+	if facts[0].SupersededBy != memory.SupersededByAgent {
+		t.Errorf("SupersededBy = %q, want %q", facts[0].SupersededBy, memory.SupersededByAgent)
+	}
+}
+
+// --- helpers ---
+
+func mustAdd(t *testing.T, s *Server, agentID, text string) {
+	t.Helper()
+	res, err := s.handleMemoryAdd(context.Background(), reflectReq(map[string]any{
+		"agent_id": agentID, "text": text,
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("memory_add %q: %v / %s", text, err, resultText(t, res))
+	}
+}
+
+func search(t *testing.T, s *Server, agentID, query string) string {
+	t.Helper()
+	res, err := s.handleMemorySearch(context.Background(), reflectReq(map[string]any{
+		"agent_id": agentID, "query": query, "top_k": float64(8),
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("memory_search: %v / %s", err, resultText(t, res))
+	}
+	return resultText(t, res)
+}

--- a/cmd/graymatter/internal/server/server.go
+++ b/cmd/graymatter/internal/server/server.go
@@ -39,7 +39,12 @@ import (
 )
 
 const (
-	defaultTopK   = 5
+	// defaultTopK must stay equal to graymatter.DefaultConfig().TopK. The REST
+	// surface used to answer with 5 facts while every other entry point
+	// answered with 8, so the same query returned different amounts of context
+	// depending on which door the caller came through. Pinned by
+	// TestDefaultTopK_MatchesLibraryDefault; the ?k= parameter still overrides.
+	defaultTopK   = 8
 	defaultLimit  = 50
 	readTimeout   = 15 * time.Second
 	writeTimeout  = 30 * time.Second

--- a/cmd/graymatter/internal/server/topk_test.go
+++ b/cmd/graymatter/internal/server/topk_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+)
+
+// The REST server answered recall with 5 facts while the library, the CLI, the
+// MCP tools and the TUI all answered with 8. Same store, same query, two
+// different amounts of context depending on which door you came through — and
+// nothing in the code said the divergence was intended.
+//
+// This test reads the library default rather than repeating a number, so the
+// two cannot drift apart again silently: change TopK in DefaultConfig and this
+// fails until the REST default follows.
+func TestDefaultTopK_MatchesLibraryDefault(t *testing.T) {
+	want := graymatter.DefaultConfig().TopK
+	if defaultTopK != want {
+		t.Errorf("REST recall defaults to %d facts, the library to %d. "+
+			"One store should not answer the same question two ways.", defaultTopK, want)
+	}
+}
+
+// TestRecall_DefaultReturnsLibraryTopK checks it end-to-end over HTTP, so the
+// constant being right is not the only thing keeping it true.
+func TestRecall_DefaultReturnsLibraryTopK(t *testing.T) {
+	base, stop := startTestServer(t)
+	defer stop()
+
+	want := graymatter.DefaultConfig().TopK
+
+	// Store more facts than any plausible default so the response size is
+	// governed by the default rather than by what is available.
+	for i := 0; i < want+6; i++ {
+		body := map[string]any{
+			"agent": "topk-agent",
+			"text":  fmt.Sprintf("deployment note number %d about the release pipeline", i),
+		}
+		if status, _ := doJSON(t, http.MethodPost, base+"/remember", body); status != http.StatusOK &&
+			status != http.StatusCreated {
+			t.Fatalf("remember %d: status %d", i, status)
+		}
+	}
+
+	status, resp := doJSON(t, http.MethodGet, base+"/recall?agent=topk-agent&q=release+pipeline", nil)
+	if status != http.StatusOK {
+		t.Fatalf("recall: status %d", status)
+	}
+	results := decodeResults(t, resp)
+	if len(results) != want {
+		t.Errorf("GET /recall with no k returned %d facts, want the library default of %d",
+			len(results), want)
+	}
+}
+
+// TestRecall_ExplicitKStillOverrides guards the fix from overcorrecting: the
+// default moved, the k parameter did not.
+func TestRecall_ExplicitKStillOverrides(t *testing.T) {
+	base, stop := startTestServer(t)
+	defer stop()
+
+	for i := 0; i < 12; i++ {
+		body := map[string]any{
+			"agent": "override-agent",
+			"text":  fmt.Sprintf("deployment note number %d about the release pipeline", i),
+		}
+		if status, _ := doJSON(t, http.MethodPost, base+"/remember", body); status != http.StatusOK &&
+			status != http.StatusCreated {
+			t.Fatalf("remember %d: status %d", i, status)
+		}
+	}
+
+	status, resp := doJSON(t, http.MethodGet, base+"/recall?agent=override-agent&q=release+pipeline&k=3", nil)
+	if status != http.StatusOK {
+		t.Fatalf("recall: status %d", status)
+	}
+	results := decodeResults(t, resp)
+	if len(results) != 3 {
+		t.Errorf("GET /recall?k=3 returned %d facts, want 3", len(results))
+	}
+}
+
+// decodeResults pulls the results array out of a /recall response body.
+func decodeResults(t *testing.T, body []byte) []string {
+	t.Helper()
+	var parsed struct {
+		Results []string `json:"results"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("decode recall response %s: %v", body, err)
+	}
+	return parsed.Results
+}

--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package graymatter
 import (
 	"os"
 	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 // EmbeddingMode controls how GrayMatter generates vector embeddings.
@@ -116,6 +118,17 @@ type Config struct {
 	// read-only would break every connected client. StrictWrite wins over
 	// ReadOnly when both are set.
 	StrictWrite bool
+
+	// SignalWeights sets how much vector similarity, keyword relevance and
+	// recency each contribute to the fused ranking.
+	// Default: nil, meaning memory.DefaultSignalWeights() — vector 1.0,
+	// keyword 1.0, recency 0.5, the values hardcoded before v0.10.0.
+	SignalWeights *memory.SignalWeights
+
+	// MinRelevance drops recalled facts scoring below this fraction of the
+	// best score in the same result set.
+	// Default: 0 — no cut, Recall returns exactly TopK as it always has.
+	MinRelevance float64
 }
 
 // DefaultConfig returns a Config with all defaults applied from environment

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -137,9 +137,20 @@ GrayMatter ranks facts via **Reciprocal Rank Fusion (RRF)** over three independe
 2. **Keyword relevance** (TF-IDF approximation over bbolt facts)
 3. **Recency** (exponential decay from `CreatedAt`)
 
-Each signal produces an independent ranking; RRF fuses the ranks (not the scores) into a single ordered list. Returns top-K, deduplicated by text. Access metadata is updated asynchronously (`AccessCount++`, `AccessedAt = now`). If a knowledge graph is wired, neighbour entities of the top hits are appended.
+Each signal produces an independent ranking; RRF fuses the ranks (not the scores) into a single ordered list. Returns top-K, deduplicated by text. Access metadata is updated asynchronously (`AccessCount++`, `AccessedAt = now`).
 
-> RRF means **rank position matters, not raw scores**. There are no tunable percentage weights to fiddle with — that's the whole point of RRF. If you want stronger recency bias, lower `DecayHalfLife`; for stronger keyword bias, configure `EmbeddingMode = EmbeddingKeyword`.
+Facts marked superseded are dropped before any of this — a fact an agent has corrected or forgotten never competes for a slot. Graph neighbours of the top hit would also be appended, but nothing wires the graph into the store in shipped builds, so in practice that step never runs ([ADR-003](decisions/003-knowledge-graph-autopopulation.md)).
+
+> RRF means **rank position matters, not raw scores** — a fact's contribution
+> depends on where it placed in each ranking, not on how close the numbers
+> were. As an agent you have no per-call control over this: there is no
+> weighting parameter on `memory_search`.
+>
+> A Go caller configuring the store does. `StoreConfig.SignalWeights` sets how
+> much each signal contributes (default vector 1.0, keyword 1.0, recency 0.5)
+> and `MinRelevance` drops results below a fraction of the best score in the
+> same result set. Both default to the behaviour described here. See
+> [ADR-006](decisions/006-configurable-signal-weights.md).
 
 **Query strategies:**
 
@@ -183,7 +194,16 @@ The most powerful tool. Use it to maintain memory quality over time.
 }}
 ```
 
-The old fact is dropped to weight 0; consolidation prunes it on the next pass.
+The old fact is tombstoned and stops being recalled from the very next search
+— not on the next consolidation pass, and not eventually. It is not deleted:
+it stays visible to `graymatter export`, the TUI and any `List` call, with its
+`superseded_by` pointing at the fact that replaced it, so the correction can be
+audited later. Ordinary decay and pruning collect it in due course.
+
+> Before v0.10.0 this action set the old fact's weight to 0 and reported
+> success, and recall does not read weight — so the superseded fact kept
+> coming back alongside its own correction. If you are running an older
+> binary, `update` does not do what this page says.
 
 **Forget workflow:**
 ```jsonc
@@ -198,7 +218,17 @@ The old fact is dropped to weight 0; consolidation prunes it on the next pass.
 
 **Link workflow (knowledge graph):**
 
-> ⚠️ The `link` action only works when the host has wired `SetKGLinker(...)` on the MCP server (`cmd/graymatter/internal/mcp/server.go:55-57`). If the linker isn't wired, the tool returns an error like `knowledge graph not configured`. Agents should call `link` opportunistically and gracefully degrade if it fails — don't make `link` a hard prerequisite for any workflow.
+> ⚠️ `link` writes to the knowledge graph, and it does work in shipped builds:
+> both the daemon and the `--no-daemon` direct store open a real graph and
+> serve the write. It can still fail if the graph cannot be opened, in which
+> case the tool returns `knowledge graph not available`. Call `link`
+> opportunistically and degrade gracefully — never make it a hard
+> prerequisite for a workflow.
+>
+> What does *not* happen is automatic population: nothing extracts entities
+> from stored facts on its own, so the graph contains exactly what agents put
+> in it by calling `link`. See
+> [ADR-003](decisions/003-knowledge-graph-autopopulation.md).
 
 ```jsonc
 { "tool": "memory_reflect", "args": {
@@ -271,7 +301,8 @@ Facts decay. A fact you never recall will eventually be pruned.
 
 **Implications:**
 ```jsonc
-// Anti-pattern: store once, never reference → pruned in ~60 days
+// Anti-pattern: store once, never reference → pruned after ~199 days
+// (6.64 half-lives to fall below the 0.01 floor, at the default 30-day half-life)
 { "tool": "memory_add", "args": { "agent_id": "agent", "text": "Critical security policy: …" }}
 // Then never search for it.
 
@@ -639,7 +670,7 @@ Need to retrieve context?
 - **GrayMatter GitHub**: <https://github.com/angelnicolasc/graymatter>
 - **Go docs**: <https://pkg.go.dev/github.com/angelnicolasc/graymatter>
 - **Releases**: <https://github.com/angelnicolasc/graymatter/releases>
-- **Strategy / why**: [`GRAYMATTER_PLAYBOOK.md`](../GRAYMATTER_PLAYBOOK.md)
+- **Design decisions / why**: [`docs/decisions/`](decisions/README.md)
 - **API stability**: [`docs/api-stability.md`](api-stability.md)
 - **Benchmarks**: [`docs/benchmarks.md`](benchmarks.md)
 - **Plugin protocol**: [`docs/plugin-protocol.md`](plugin-protocol.md)

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -52,13 +52,40 @@ Starting with **v0.1.0**, GrayMatter follows a best-effort compatibility policy 
 | `(*Store).Close() error` | |
 | `(*Store).SetKG(graph GraphAccessor, extractor EntityExtractorAccessor)` | |
 | `(*Store).DB() *bolt.DB` | |
-| `Fact` struct — all fields present in v0.1.0 | |
+| `Fact` struct — all fields present in v0.1.0 | New fields may be added; `SupersededBy` added in v0.10.0 |
+| `(Fact).IsSuperseded() bool` | Added in v0.10.0 |
+| `SupersededByAgent` constant | Added in v0.10.0 |
 | `MemoryStats` struct | |
-| `StoreConfig` struct — all fields present in v0.1.0 | |
+| `StoreConfig` struct — all fields present in v0.1.0 | New fields may be added; `SignalWeights` and `MinRelevance` added in v0.10.0 |
+| `SignalWeights` struct | Added in v0.10.0 |
+| `DefaultSignalWeights() SignalWeights` | Added in v0.10.0 |
+| `ErrConsolidateLLMUnsupported` | Added in v0.10.0 |
 | `SharedAgentID` constant | |
 | `ConsolidateConfig` interface | |
 | `GraphAccessor` interface | |
 | `EntityExtractorAccessor` interface | |
+
+### Additions in v0.10.0
+
+Three additions, all fields or new identifiers, no signature changes — so the
+compatibility promise above holds and no caller needs to do anything.
+
+Each new field's zero value reproduces the previous behaviour exactly, which is
+enforced rather than asserted:
+
+| Field | Zero value | Behaviour at zero |
+|---|---|---|
+| `Fact.SupersededBy` | `""` | Fact is live. Stores written before v0.10.0 have no `superseded_by` key and load as live — checked against a literal v0.9.0 JSON fact |
+| `StoreConfig.SignalWeights` | `nil` | `DefaultSignalWeights()` — vector 1.0, keyword 1.0, recency 0.5, the values that were hardcoded before v0.10.0. It is a pointer precisely so the zero value cannot be confused with "all signals off" |
+| `StoreConfig.MinRelevance` | `0` | No relevance floor; `Recall` returns exactly `topK`, the pre-v0.10.0 contract |
+
+`TestRankingDefaults_MatchV09Behaviour` is the gate: with the ranking fields
+unset, results must be identical to the v0.9.0 ranking.
+
+One default did change, and it is a behaviour change rather than an addition:
+**the REST server's default `k` moved from 5 to 8**, matching
+`DefaultConfig().TopK` and every other entry point. `GET /recall` with no `k`
+now returns 8 facts. Pass `?k=5` for the old count.
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,48 +1,79 @@
 # GrayMatter Token Benchmarks
 
-## Methodology
-
-Comparison across a simulated 30-session agent history:
-- **Baseline**: inject full conversation history into every new run
-- **GrayMatter**: use `Recall()` with hybrid retrieval (top-k=8)
-
-Agent: `sales-closer` with 30 prior sessions, ~400 words per session.
-
-## Results
-
-| Metric                        | Baseline (full inject) | GrayMatter (hybrid recall) |
-|-------------------------------|------------------------|---------------------------|
-| Tokens per run (session 1)    | ~800                   | ~800                      |
-| Tokens per run (session 10)   | ~4,800                 | ~900                      |
-| Tokens per run (session 30)   | ~12,000                | ~1,100                    |
-| Tokens per run (session 100)  | ~40,000                | ~1,200                    |
-| Relevance@8 vs full context   | 100% (noisy)           | ~91% (clean)              |
-
-**~90% token reduction after 10+ sessions. Context quality improves over time.**
-
-## Why hybrid retrieval beats full injection
-
-Full injection includes:
-- Stale facts (things that were relevant 3 months ago)
-- Contradicted facts (Maria's budget changed; old entry still there)
-- Noise (metadata, non-actionable observations)
-
-GrayMatter hybrid retrieval (vector + keyword + recency) surfaces only:
-- Semantically close to the current query
-- Recent enough to be relevant (decay curve)
-- High-weight facts (survived consolidation)
-
-## Consolidation impact
-
-After running `Consolidate()` over 30 sessions:
-- 30 session summaries → 4 consolidated memory paragraphs
-- No information loss on key facts (names, amounts, deadlines)
-- Noise removed: pleasantries, status updates, duplicates
-
-## Running the benchmark yourself
+Every number on this page is printed by one command. If a figure here and a
+figure the command prints disagree, CI fails
+(`benchmarks/token_count/main_test.go`) — the table is parsed out of this
+markdown and compared against a live run.
 
 ```bash
 go run ./benchmarks/token_count
 ```
 
-Output: table of token counts by session count, both strategies.
+## What is measured
+
+| | |
+|---|---|
+| **Baseline** | Full-history injection — every stored observation concatenated into the prompt |
+| **GrayMatter** | `Recall()` with hybrid retrieval, `topK=8` |
+| **Corpus** | 100 paragraph-length agent observations (~50–70 words each), sales domain |
+| **Session** | One stored observation. "30 sessions" = 30 observations in the store |
+| **Query** | `"follow up with prospects and close pending deals this week"` — one fixed query |
+| **Embedder** | Keyword-only (TF-IDF + recency). No LLM, no network, deterministic |
+| **Insertion order** | Shuffled with a fixed seed (42) so ranking is not biased by recency |
+| **Tokenizer** | `words × 1.33`, an approximation of GPT-4-class tokenization — within ±10% of tiktoken for English prose. Not a real BPE tokenizer |
+
+## Results
+
+| Sessions | Full injection | GrayMatter | Reduction |
+|----------|---------------|------------|-----------|
+| 1        | ~80 tokens    | ~80 tokens  | 0% |
+| 10       | ~630 tokens   | ~550 tokens | 12% |
+| 30       | ~1,880 tokens | ~550 tokens | 71% |
+| 100      | ~6,960 tokens | ~670 tokens | **90%** |
+
+**90% is the canonical figure**, and it means one specific thing: at 100
+stored observations, against full-history injection, on this corpus, with this
+tokenizer. It is not a claim about any other baseline.
+
+The reduction is a function of how much history exists. At one session there
+is nothing to cut and the number is 0%. The curve is the result, not the
+100-session row.
+
+## What this benchmark does not measure
+
+Stated plainly, because the omissions are larger than the result:
+
+- **Relevance.** The benchmark never checks whether the 8 recalled
+  observations are the *right* 8. A system that returned 8 facts at random
+  would score an identical 90% reduction here. Retrieval quality is not
+  measured anywhere in this repository yet.
+- **A realistic baseline.** Full-history injection is the weakest possible
+  comparison. Production systems truncate. A sliding window keeping the last 8
+  observations would cost roughly 8 × ~70 ≈ 560 tokens in steady state —
+  statistically indistinguishable from GrayMatter's ~550–670. **Against a
+  sliding window, GrayMatter does not win on tokens**, and the honest
+  differentiator has to be what a window cannot do: recall a fact from session
+  3 at session 90, and stop returning a fact that has been superseded.
+- **Multiple queries or domains.** One fixed query, one domain.
+- **Vector embeddings.** Keyword-only, so the numbers are reproducible without
+  an API key. Vector recall changes precision; it is not measured here.
+- **Consolidation.** Runs with consolidation untriggered.
+
+Earlier revisions of this page published a token table nothing produced, and a
+relevance score no code computed. Both are gone. The tests named at the top
+exist so that neither can come back quietly.
+
+## Reproducing
+
+```bash
+go run ./benchmarks/token_count
+```
+
+No API key, no network, no LLM. The store is created in a temporary directory
+and deleted on exit. Runs in well under a second.
+
+To verify the published tables against a fresh measurement the way CI does:
+
+```bash
+go test ./benchmarks/token_count/
+```

--- a/docs/decisions/001-decay-half-life.md
+++ b/docs/decisions/001-decay-half-life.md
@@ -1,0 +1,102 @@
+# 001 — Memory decays on a 30-day half-life
+
+**Status:** Accepted · **Date:** 2026-08-22
+
+## Context
+
+A memory store that only accumulates becomes a liability. Retrieval quality
+falls as the corpus grows, because more candidates compete for the same eight
+slots, and the oldest material is usually the least true. Something has to
+decide what stops mattering.
+
+The options were to keep everything and rely on ranking, to expire facts on a
+fixed TTL, or to weight them on a decay curve and prune what falls through the
+floor.
+
+## Decision
+
+Every fact carries a `Weight` in [0, 1], starting at 1.0. `Consolidate` decays
+it exponentially against time since last access:
+
+```
+weight *= exp(-ln(2) / halfLife * hoursSinceAccessed)
+```
+
+`DecayHalfLife` defaults to **720h (30 days)**. Facts below **0.01** are
+pruned — roughly seven half-lives untouched, about seven months at the
+default.
+
+Decay is driven by `AccessedAt`, not `CreatedAt`. A fact recalled regularly
+stays alive indefinitely regardless of age; a fact nothing ever asks for
+fades whether it was written yesterday or last year. Recall is what keeps
+memory alive, which is the property worth having: usage is the only evidence
+of relevance the store actually has.
+
+30 days was chosen against the rhythm of the work this is for. A month is
+about one project cycle: long enough that a fact from the start of a piece of
+work is still weighted when the work finishes, short enough that a decision
+reversed two quarters ago is not competing for a slot with a decision made
+last week. It is a judgement, not a measurement, and it is exposed as
+`DecayHalfLife` precisely because it is a judgement.
+
+### The threshold is read twice, deliberately
+
+`ConsolidateThreshold` gates two different things with two different
+comparisons, which looks like an off-by-one and is not:
+
+- `MaybeConsolidate` runs a cycle at **>= N** facts.
+- `Consolidate` summarises at **> N** facts.
+
+At exactly N facts a cycle runs decay and pruning but does not summarise.
+Decay and pruning are arithmetic on data already in hand — cheap, local,
+reversible in effect. Summarisation costs an API call and *destroys the batch
+it replaces*. The expensive, lossy step waits until the store is unambiguously
+over the line; the cheap one does not need to.
+
+## Consequences
+
+- A fact nobody recalls for ~7 months is deleted. There is no undo, and no
+  archive. Anything that must never be lost does not belong in a decaying
+  store — that is what `graymatter export` is for.
+- Decay only advances when `Consolidate` runs. A store that never crosses
+  `ConsolidateThreshold` never decays. Weights are therefore a lagging
+  measure, not a live one.
+- Two classes of fact are actively mismodelled by any decay curve:
+  **standing obligations** (licence terms, compliance constraints, security
+  invariants) and **architecture decisions that are still in force**. Both are
+  most valuable precisely when nobody has asked about them in months. The
+  store has no way to mark them, and this is the sharpest known limitation of
+  the decay model. Keep them in the instruction file, not in memory.
+- Time-to-prune scales with the half-life, so raising it does not just slow
+  forgetting, it delays every eviction by the same factor.
+
+## Reversal condition
+
+Revisit if any of these becomes measurable:
+
+1. Recall of a fact known to be relevant fails because that fact was pruned,
+   in more than **2%** of a measured sample. Currently unmeasurable — nothing
+   in the tree measures retrieval quality (`docs/benchmarks.md`), so this
+   condition depends on building that first.
+2. Stores in ordinary use grow past **50k facts per agent**, which would mean
+   pruning is not keeping pace and the floor, not the half-life, is wrong.
+3. Users are found routinely setting `DecayHalfLife` to the same non-default
+   value, which would make 30 days the wrong default rather than the wrong
+   idea.
+
+Any of the three argues for tuning the constants. None of them argues against
+decay itself. The decision that would actually be reversed — weighting rather
+than expiring — needs evidence that recency-weighted ranking is worse than a
+fixed TTL, which no one has produced.
+
+## Alternatives rejected
+
+- **Fixed TTL.** Simpler, and wrong for the same reason a cache TTL is wrong
+  for a knowledge base: it cannot tell a fact nobody needs from a fact nobody
+  has needed *yet*.
+- **Keep everything, rank harder.** Defensible while a store is small. It
+  moves the entire cost onto retrieval, and retrieval runs on every prompt
+  while pruning runs occasionally.
+- **LLM-judged retention.** Better decisions, at the cost of making the store
+  non-deterministic and unusable offline. Consolidation is deliberately the
+  only step in this system allowed to be smart.

--- a/docs/decisions/001-decay-half-life.md
+++ b/docs/decisions/001-decay-half-life.md
@@ -23,8 +23,25 @@ weight *= exp(-ln(2) / halfLife * hoursSinceAccessed)
 ```
 
 `DecayHalfLife` defaults to **720h (30 days)**. Facts below **0.01** are
-pruned — roughly seven half-lives untouched, about seven months at the
-default.
+pruned — 6.64 half-lives untouched, **199 days** at the default.
+
+Weight is *recomputed* from staleness on each cycle, never multiplied into:
+
+```go
+weight = min(weight, exp(-ln(2)/halfLife * hoursSinceAccessed))
+```
+
+The `min` is load-bearing. Decay must never hand weight back, and a fact whose
+weight was deliberately zeroed — a supersede tombstone,
+[007](007-supersede-tombstones.md) — has to stay collectable by pruning rather
+than be resurrected by its own recent access time.
+
+Until v0.10.0 this line multiplied instead, re-applying the whole elapsed
+period on every run because nothing recorded that a fact had already been
+decayed. The half-life was effectively *per consolidation cycle*: five cycles
+in the same millisecond took a one-half-life-stale fact from 0.5 to 0.03. With
+`AsyncConsolidate` on, a busy agent could prune a month-old fact in minutes.
+Everything below describes the model as it now behaves.
 
 Decay is driven by `AccessedAt`, not `CreatedAt`. A fact recalled regularly
 stays alive indefinitely regardless of age; a fact nothing ever asks for
@@ -55,7 +72,7 @@ over the line; the cheap one does not need to.
 
 ## Consequences
 
-- A fact nobody recalls for ~7 months is deleted. There is no undo, and no
+- A fact nobody recalls for ~199 days is deleted. There is no undo, and no
   archive. Anything that must never be lost does not belong in a decaying
   store — that is what `graymatter export` is for.
 - Decay only advances when `Consolidate` runs. A store that never crosses

--- a/docs/decisions/002-bbolt-single-writer.md
+++ b/docs/decisions/002-bbolt-single-writer.md
@@ -1,0 +1,86 @@
+# 002 — bbolt with a single writer, and a daemon to share it
+
+**Status:** Accepted · **Date:** 2026-08-22
+
+## Context
+
+GrayMatter ships as one binary with no service to install and no database to
+provision. That constraint picked the storage engine before any comparison of
+features: the store has to be a file.
+
+bbolt is a pure-Go embedded B+tree with ACID transactions and a single-file
+layout. It takes an **exclusive lock on that file for the life of the
+process** — by design, not as a limitation to be worked around.
+
+That collides with how the tool is actually used. A developer runs the TUI in
+one terminal, their agent's MCP server holds the store open in the background,
+and they type `graymatter recall` in a third window. Three processes, one
+file, one lock. The second and third arrivals fail.
+
+## Decision
+
+Keep bbolt, and stop pretending several processes can own it.
+
+**One process owns the store; everyone else is a client.** The first
+component that needs the store spawns a daemon, which opens bbolt with
+`StrictWrite` and holds the lock. The TUI, the MCP server, the CLI,
+`graymatter run` and the REST server all connect to it over a local transport
+— a Unix domain socket on POSIX, TCP loopback on Windows — speaking `net/rpc`
+from the standard library. The daemon exits when nothing has used it for a
+while. `--no-daemon` opts out and accepts the contention.
+
+Two consequences of that shape are worth stating plainly, because they are not
+visible from the code:
+
+- **On Windows, the token in the discovery file is the entire access
+  control.** Any local process can reach a loopback port. The `0600` passed to
+  `os.WriteFile` is a POSIX guarantee that Windows does not honour — there the
+  file inherits its parent directory's ACL. See `docs/threat-model.md`.
+- **Read-only fallback is a degradation, not a feature.** When the lock cannot
+  be acquired and `StrictWrite` is not set, the store opens read-only rather
+  than failing. That is right for the TUI and wrong for the daemon, which is
+  why the daemon sets `StrictWrite`: a store owner that silently came up
+  read-only would break every client attached to it.
+
+## Consequences
+
+- Concurrency is bounded by one writer, always. Writes serialise. For a
+  developer-scale store this is invisible; it is a hard ceiling all the same.
+- The daemon is a lifecycle problem the project would not otherwise have:
+  spawning, idle exit, reconnection, token rotation, orphan detection. Roughly
+  the cost of the dependency avoided.
+- `net/rpc` is frozen in the standard library and gob-encoded, so the wire
+  format is Go-specific and there is no cross-language client. Acceptable —
+  the clients all ship in this repo.
+- Anything that opens the bbolt file directly, bypassing the daemon, will
+  either fail to acquire the lock or corrupt the invariant. `DB()` is an
+  escape hatch, not an interface.
+
+## Reversal condition
+
+Move to SQLite (WAL mode, real multi-process concurrency) if any of these
+holds:
+
+1. Write contention is measurable in ordinary single-developer use — daemon
+   RPC p95 above **50 ms** for `Put` on a store under 10k facts.
+2. A supported use case genuinely needs concurrent writers on one machine
+   without a coordinating process.
+3. Daemon lifecycle bugs — orphans, stale sockets, failed handoffs — account
+   for more than **20%** of issues over a release cycle. That would mean the
+   coordination cost has exceeded the dependency it was avoiding.
+
+Anything requiring writes from more than one machine is not a reversal of this
+decision; see [004](004-local-first-single-node.md).
+
+## Alternatives rejected
+
+- **SQLite.** WAL mode solves the concurrency problem outright, and it is the
+  obvious answer if the daemon becomes a liability. It costs cgo, or a pure-Go
+  reimplementation with its own risks, against a project whose main claim is a
+  single static binary.
+- **Postgres.** Correct for a server product. This is not one; see
+  [004](004-local-first-single-node.md).
+- **Advisory file locks over plain files.** Every hard part of a database,
+  reimplemented worse, without transactions.
+- **Accept the contention.** What v0.5 did. "Close the TUI before running the
+  CLI" is not a usable answer.

--- a/docs/decisions/003-knowledge-graph-autopopulation.md
+++ b/docs/decisions/003-knowledge-graph-autopopulation.md
@@ -1,0 +1,103 @@
+# 003 — The knowledge graph has a write path, but nothing populates it automatically
+
+**Status:** Accepted, partial · **Date:** 2026-08-22
+
+## Context
+
+GrayMatter ships a knowledge graph: a schema, bbolt-backed storage, entity
+extraction, an Obsidian export, and a TUI view. It is also the feature most
+likely to be misdescribed, including by this project's own README, which said
+until v0.10.0 that *nodes have no write path in shipped builds*.
+
+That is not what the code does, and the imprecision cuts both ways: it
+undersells what works and hides what does not.
+
+## What is actually true
+
+Verified against the tree, file by file:
+
+**The write path exists and runs in shipped builds.**
+
+- `memory_reflect` with `action=link` creates edges: `handlers.go` → the
+  backend's `KGLink`.
+- In daemon mode the daemon opens a real `kg.Graph` and `kg.GraphAdapter`
+  (`internal/daemon/daemon.go`) and serves `KGLink` and `KGUpsert` over RPC
+  (`internal/daemon/host.go`).
+- With `--no-daemon` the direct store does the same in-process
+  (`store_handle.go`).
+
+So an agent *can* write to the graph, and the graph is queryable and
+exportable. What it cannot do is populate itself.
+
+**Automatic population is implemented and never activated.** `Store.SetKG`
+wires a graph and an entity extractor into the memory store. Two features
+depend on those fields being non-nil:
+
+- `Consolidate` step 4 — entity extraction over surviving facts, upserting a
+  node per entity.
+- `Recall` — enrichment of results with graph neighbours of the top-ranked
+  fact.
+
+Both are written, both are tested, and neither has ever run outside a test,
+because **`SetKG` is not called anywhere in the shipped binaries.** The fields
+stay nil and both blocks are skipped in silence.
+
+The accurate statement is therefore: *entity extraction and graph enrichment
+are implemented but not wired; the graph is populated only by explicit agent
+action.*
+
+## Decision
+
+Leave the automatic population disconnected for now, and say so precisely.
+
+Wiring `SetKG` is a two-line change, which is exactly why it has not been
+done: the cost is not in the wiring, it is in what the wiring turns on.
+Extraction would then run over every surviving fact on every consolidation
+cycle, and `Recall` would start appending graph neighbours to results — facts
+the ranking never selected, on every recall, with no budget and no relevance
+check. Turning that on without a way to measure retrieval quality means
+shipping a change to what every agent reads and having no way to tell whether
+it made things better or worse. Nothing in the tree measures relevance today
+(`docs/benchmarks.md`).
+
+The extractor is also heuristic — capitalised-token matching, not entity
+resolution. On prose it produces nodes for names, and on the rest it produces
+nodes for the first word of a sentence.
+
+## Consequences
+
+- The TUI graph view is empty for anyone who has not used
+  `memory_reflect action=link`, which reads as broken and is technically
+  correct behaviour. This is the most user-visible cost.
+- The Obsidian export works and has almost nothing to export.
+- Dead-but-tested code sits in `Consolidate` and `Recall`. It is covered, so
+  it does not rot, but coverage of a path production never takes is a weaker
+  guarantee than it looks.
+- The honest description is longer than "not implemented", which is why the
+  short wrong version kept getting written. README and roadmap were corrected
+  alongside this record.
+
+## Reversal condition
+
+Wire `SetKG` in the daemon and the direct store when **both** hold:
+
+1. Retrieval quality is measurable — a benchmark that scores whether recalled
+   facts answer the query, so enrichment can be shown to help rather than
+   assumed to.
+2. Enrichment is bounded: a cap on appended neighbours and a relevance floor
+   they must clear, so graph output cannot crowd out ranked results.
+
+Extraction quality gates it separately: on a hand-labelled sample of 100
+facts, precision below **0.7** means the graph fills with noise and wiring it
+makes recall worse. Measure before wiring, not after.
+
+## Alternatives rejected
+
+- **Wire it now.** Two lines, and it silently changes what every agent reads,
+  with no measurement to catch a regression.
+- **Delete the graph.** Removes the dead paths and a working agent-driven
+  feature with them, and `#24` describes something people want.
+- **Leave the README as it was.** The cheapest option and the most expensive
+  one. A project whose main asset is being trusted about its own numbers
+  cannot afford a description of its own features that is wrong in both
+  directions.

--- a/docs/decisions/004-local-first-single-node.md
+++ b/docs/decisions/004-local-first-single-node.md
@@ -1,0 +1,86 @@
+# 004 — Local-first and single-node, deliberately not multi-tenant
+
+**Status:** Accepted · **Date:** 2026-08-22
+
+## Context
+
+"Agent memory" describes two different products. One is infrastructure: a
+hosted, multi-tenant service with isolation, quotas, per-tenant encryption and
+an availability target. The other is a tool that runs on a developer's machine
+and remembers things between sessions.
+
+They share a name and almost no architecture. Nearly every design question in
+this repository — storage engine, concurrency model, auth, defaults — resolves
+differently depending on which one is being built, so the choice cannot be
+deferred.
+
+## Decision
+
+GrayMatter is the second one, and stops there.
+
+One machine, one store, files under `.graymatter/` owned by the user who ran
+the command. No accounts, no tenancy, no network by default. The REST and
+MCP-HTTP servers bind `127.0.0.1` and require a bearer token; that is a lock on
+a local door, not a step toward serving the internet.
+
+This is a scope decision, not a staged plan. Multi-tenancy is not a later
+milestone the current design is working toward — the current design is what
+falls out of *not* pursuing it.
+
+Concretely, the following are all consequences of this one choice:
+
+- **bbolt over Postgres.** A single-file store with a single writer is only
+  viable because the store belongs to one user on one machine
+  ([002](002-bbolt-single-writer.md)).
+- **No authorisation model.** There is one principal. Anything that can read
+  the file can read every fact, and no ACL would change that.
+- **Decay tuned for a person.** A 30-day half-life reflects one developer's
+  project rhythm ([001](001-decay-half-life.md)), not a workload average
+  across tenants.
+- **Defaults over configuration.** Anything a single user would not
+  reasonably tune does not need to be a setting.
+
+The README says it out loud: *not trying to win the enterprise memory market*.
+This record is why that sentence is a design constraint rather than modesty.
+
+## Consequences
+
+- Teams cannot share a memory store. Cross-project federation
+  ([#12](https://github.com/angelnicolasc/graymatter/issues/12)) is
+  deliberately scoped read-only for the same reason: it stops at reading
+  another store, never at writing to a shared one.
+- No backup, replication, or point-in-time recovery. The store is a file on
+  one disk. `graymatter export` is the recovery story, and it is manual.
+- Anyone evaluating this against Mem0 or Zep on tenancy features is comparing
+  it against something it does not attempt to be. That is a positioning cost,
+  paid deliberately.
+- The whole surface stays auditable by one person in an afternoon, which is
+  the property the project is actually trading for.
+
+## Reversal condition
+
+This one does not reverse; it forks. If shared multi-writer memory is genuinely
+needed, the answer is a separate service with its own storage engine, its own
+auth model and its own repository, consuming this library — not a
+`--multi-tenant` flag.
+
+The condition for starting that work: more than **five** unrelated users asking
+for shared team memory *and* willing to run a server, over a release cycle.
+Feature requests alone are not the signal — the willingness to operate a
+service is, because that is the actual cost being proposed.
+
+Retrofitting tenancy into this codebase is the failure mode this record exists
+to prevent. A single-writer embedded store with no principal model does not
+grow into a multi-tenant service; it grows into a multi-tenant service with a
+single-writer embedded store at the bottom of it.
+
+## Alternatives rejected
+
+- **Build for both.** The storage engine alone makes this incoherent: bbolt's
+  single writer is either an acceptable simplification or a disqualifying
+  bottleneck, and it cannot be both.
+- **Design for tenancy now, ship single-node.** Pays the full cost of the
+  abstraction immediately for a benefit that may never arrive, and an
+  abstraction chosen without a real second tenant is usually the wrong one.
+- **Stay silent and let people assume.** Costs credibility the moment anyone
+  looks, and this project's principal asset is being accurate about itself.

--- a/docs/decisions/005-embedding-degradation-chain.md
+++ b/docs/decisions/005-embedding-degradation-chain.md
@@ -1,0 +1,95 @@
+# 005 — Embeddings degrade Ollama → OpenAI → Anthropic → keyword
+
+**Status:** Accepted · **Date:** 2026-08-22
+
+## Context
+
+Hybrid retrieval wants vector similarity, and vectors need an embedding model.
+Every way of getting one costs something a local-first tool would rather not
+spend: an API key, a network round trip per write, a running local service, or
+retrieval quality.
+
+The requirement that decides it: **`graymatter init` has to work on a laptop
+with no API key and no internet, and the tool has to be useful afterwards.** An
+embedding provider that is mandatory makes that impossible.
+
+## Decision
+
+Embeddings are optional, and the provider is detected at runtime in a fixed
+order. `EmbeddingAuto` — the default — tries:
+
+1. **Ollama** — local HTTP, no key, no data leaves the machine, `nomic-embed-text`.
+2. **OpenAI** — `text-embedding-3-small`, if `OPENAI_API_KEY` is set.
+3. **Anthropic** — if `ANTHROPIC_API_KEY` is set.
+4. **Keyword-only** — TF-IDF over stored text, plus recency. No vectors at all.
+
+Local first, then whatever credential is present, then a floor that always
+works. `EmbeddingMode` pins any single provider explicitly.
+
+Step 4 is the load-bearing one. Keyword-only is not an error state or a
+degraded mode that warns; it is a supported configuration. Retrieval still
+fuses keyword relevance and recency through RRF, the entire test suite runs on
+it, and so does the benchmark — which is why the published numbers are
+reproducible by anyone with no key.
+
+### Consolidation does not follow this chain
+
+Summarisation is a separate setting with a separate resolution, and its rules
+differ:
+
+- `ConsolidateLLM` resolves to `"anthropic"` if `ANTHROPIC_API_KEY` is set,
+  otherwise `""` (disabled).
+- Ollama is **excluded from auto-detection** here, unlike for embeddings.
+  Detecting it means probing an HTTP endpoint, and paying 500 ms+ on every
+  process start — including every `graymatter recall` — to discover a service
+  that usually is not running is not a trade worth making. Set
+  `ConsolidateLLM = "ollama"` explicitly instead.
+- Setting it explicitly does not work yet: **Ollama summarisation is not
+  implemented.** As of v0.10.0 that path returns
+  `ErrConsolidateLLMUnsupported` through `OnConsolidateError`. Before v0.10.0
+  it returned an empty summary and a nil error, so a store configured this way
+  ran decay and pruning forever, never summarised, and gave no indication why.
+
+## Consequences
+
+- Retrieval quality varies with the environment. The same store answers the
+  same query differently on a machine with Ollama than on one without, and
+  nothing in the tree measures how much — vector-versus-keyword recall quality
+  is unmeasured (`docs/benchmarks.md`).
+- Switching providers mid-store mixes embeddings from different models in one
+  index. The dimension guard catches a changed vector width and warns; it
+  cannot catch two models that happen to share dimensions, whose vectors are
+  simply not comparable.
+- Facts written while an embedder was unavailable have no vectors. The pending
+  queue and the reconciler exist for this, and `PendingVectorCount()` reports
+  it.
+- Auto-detection makes the active provider a runtime fact rather than a
+  configured one. `graymatter doctor` prints which one is in use, because
+  otherwise nobody can tell.
+
+## Reversal condition
+
+Reconsider the ordering if any of these is measured:
+
+1. Keyword-only recall scores below **70%** of Ollama-backed recall on a
+   quality benchmark. That would make the floor too weak to call supported,
+   and would argue for warning loudly rather than degrading quietly.
+2. Ollama detection latency exceeds **200 ms** at p95 in ordinary use, making
+   the default probe worse than requiring configuration.
+3. A local embedding model good enough to ship *inside the binary* becomes
+   practical. That would collapse the chain into one provider and delete this
+   decision outright — the best outcome available.
+
+Implementing Ollama summarisation is not a reversal of this record, only the
+removal of a gap in it.
+
+## Alternatives rejected
+
+- **Require an embedding provider.** Kills offline use, and the reproducible
+  benchmark with it.
+- **Bundle a model.** Adds tens of megabytes to a binary whose selling point is
+  being one file, for quality still below a hosted model.
+- **Ask the user to choose at init.** A question most people cannot answer
+  before using the tool, and the auto-chain gets it right for nearly everyone.
+- **Probe Ollama for consolidation too, symmetrically.** Consistent, and it
+  taxes every CLI invocation to discover a service that is usually absent.

--- a/docs/decisions/006-configurable-signal-weights.md
+++ b/docs/decisions/006-configurable-signal-weights.md
@@ -1,0 +1,110 @@
+# 006 — Retrieval signal weights are configurable
+
+**Status:** Accepted · **Date:** 2026-08-22
+
+## Context
+
+`Recall` fuses three signals through Reciprocal Rank Fusion: vector
+similarity, keyword relevance, and recency. Until v0.10.0 their weights were
+compile-time constants — 1.0, 1.0 and 0.5 — with no way to reach any other
+ranking.
+
+That blocked a claim worth being able to make honestly.
+
+The natural comparison for this kind of system is a **sliding window**: keep
+the last K observations, drop the rest. It is what production systems actually
+do, it costs nothing to implement, and it is the baseline a sceptical reader
+has in mind. The appealing framing is that a sliding window is a *special case*
+of this ranking — the one where all the weight sits on recency.
+
+With hardcoded weights that framing was false. Not an overstatement: false.
+There was no configuration of GrayMatter that ranked by recency alone, so the
+claim described a system that did not exist. Stating it would have been exactly
+the kind of unfalsifiable assertion this project has spent a release removing.
+
+## Decision
+
+Make the weights configuration, so the claim becomes a testable property
+instead of a description.
+
+```go
+type SignalWeights struct {
+    Vector  float64
+    Keyword float64
+    Recency float64
+}
+
+func DefaultSignalWeights() SignalWeights {
+    return SignalWeights{Vector: 1.0, Keyword: 1.0, Recency: 0.5}
+}
+```
+
+`StoreConfig.SignalWeights` is a **pointer**. `nil` means defaults; a
+non-nil value is used exactly as given. The indirection is load-bearing: with
+a plain struct, the zero value — what every existing caller passes — would
+mean "all three signals off", turning a compatible addition into a silent
+catastrophe. A pointer distinguishes *unset* from *deliberately zero*, which
+is the whole reason a caller would want `{0, 0, 1}` in the first place.
+
+`k = 60` stays fixed. It is the constant from Cormack, Clarke & Buettcher
+(SIGIR 2009) and it damps the gap between adjacent ranks; with a single signal
+enabled it cannot change the ordering at all, so exposing it would add a knob
+with no reachable effect.
+
+### The claim, and its test
+
+`TestSignalWeights_RecencyOnlyEmulatesSlidingWindow` runs recall with
+`{Vector: 0, Keyword: 0, Recency: 1}` over a corpus built so that the facts
+answering the query are the *oldest* ones. It asserts two things: the result is
+exactly the K most recent facts, and none of them answers the query.
+
+That is a sliding window, produced by configuring this ranking rather than by
+implementing a second retrieval path. The claim is now demonstrable by
+ablation inside the model.
+
+Recency defaults to 0.5 rather than parity for a reason worth recording: it is
+a tie-breaker, meant to put fresh context ahead of equally-relevant stale
+context. Weighted at parity on a store with a steady write rate, it drowns
+relevance out — which is precisely what the sliding-window test demonstrates
+when it is turned up to 1.0 alone.
+
+## Consequences
+
+- A window baseline can be measured without writing one. Any comparison
+  against truncation reconfigures the same code path, so there is no second
+  implementation whose fairness a reader has to take on trust.
+- Weights are a supported surface now, so a bad combination is a supported way
+  to get bad results. `{0, 0, 0}` scores everything zero and returns an
+  arbitrary K. Nothing validates this, and nothing should — a caller asking
+  for no signals is asking for exactly that.
+- Anything published about how GrayMatter ranks is now checkable against a
+  configuration, which is the point.
+- One more thing to keep compatible. `TestRankingDefaults_MatchV09Behaviour`
+  is the gate: with the field unset, results must match the hardcoded ranking.
+
+## Reversal condition
+
+Remove the knob if, over a release cycle, **no** measurement or issue uses a
+non-default value — that would mark it as speculative generality, and it would
+go the way any unused abstraction should.
+
+Change the defaults only against a retrieval-quality benchmark, never against
+intuition. Specifically: a different weighting must beat `(1.0, 1.0, 0.5)` on
+HitRate at equal budget by more than **5%** across at least three query
+domains. Nothing in the tree measures that yet, so the current defaults stand
+on the fact that they are what shipped and what everything was tuned against —
+which is a weaker justification than it sounds, and is why it is written down
+rather than implied.
+
+## Alternatives rejected
+
+- **Keep them hardcoded and make the claim anyway.** Marketing. The exact
+  failure this release exists to remove.
+- **Keep them hardcoded and write a separate window baseline.** Honest and
+  worse: two retrieval paths to keep in step, and a reader still has to trust
+  that the baseline was implemented fairly.
+- **A plain struct instead of a pointer.** Ambiguous zero value; see above.
+- **Expose k too.** A knob that cannot change a single-signal ordering.
+- **Presets (`ModeRecent`, `ModeRelevant`) instead of numbers.** Friendlier,
+  and it hides the ablation that makes the sliding-window equivalence
+  demonstrable.

--- a/docs/decisions/007-supersede-tombstones.md
+++ b/docs/decisions/007-supersede-tombstones.md
@@ -1,0 +1,125 @@
+# 007 — Contradictions are resolved by tombstone, never by delete
+
+**Status:** Accepted · **Date:** 2026-08-22
+
+## Context
+
+An append-only memory store accumulates contradictions. An agent learns "we use
+Lemon Squeezy for billing", the company migrates, the agent learns "we use
+Polar" — and now both are stored, both are true of some moment, and only one is
+true now.
+
+Retrieval cannot tell them apart. Both match the query, both are plausible, and
+the agent receives both with no signal about which is current. This is the
+failure mode that makes long-lived memory worse than no memory: not missing
+information, but confidently returned stale information sitting next to its own
+correction.
+
+`memory_reflect` already had the vocabulary for this — `update` to correct a
+fact, `forget` to drop one. Neither worked. Both set `Weight = 0` and reported
+success, and `Recall` does not read `Weight`; it ranks on vector, keyword and
+recency alone. The retired fact came back on the very next search, and kept
+coming back until a consolidation cycle happened to prune it. Consolidation
+only fires past `ConsolidateThreshold` facts, so below the threshold it came
+back forever.
+
+The tools reported "Fact suppressed for agent". The next search returned it.
+
+## Decision
+
+Add a tombstone to `Fact`:
+
+```go
+SupersededBy string `json:"superseded_by,omitempty"`
+```
+
+Non-empty means retired. `Recall` drops those facts **before scoring**, so a
+tombstoned fact cannot even displace a live one from the top-k. The value
+carries the reason: the replacement fact's ID for `update`, or the
+`SupersededByAgent` marker for `forget`, so a correction can be followed rather
+than merely observed.
+
+### Precedence, stated once
+
+Three mechanisms can end a fact's life. Overlapping them is how contradictory
+behaviour gets built, so each owns exactly one question:
+
+| Mechanism | Question it answers | Effect |
+|---|---|---|
+| **Tombstone** | Is this still true? | Excluded from retrieval immediately, at any weight |
+| **Decay** | Does anyone still use this? | Lowers weight over time; keeps running on tombstoned facts |
+| **Pruning** | Is this worth storing? | Deletes below 0.01 weight — the only thing that ever deletes |
+
+A tombstone beats any weight, which is what makes a correction take effect at
+once instead of waiting for a cycle. Decay does not care about tombstones.
+Pruning is still the only deletion path, so a retired fact leaves the store the
+same way an unused one does.
+
+### Why a tombstone and not a delete
+
+The README describes storage as append-only, and that is not a technicality —
+it is what makes the store auditable. A contradiction is *information*: that a
+fact was believed, then corrected, and when. Deleting on contradiction throws
+away the history and makes the audit trail describe writes that no longer have
+subjects.
+
+So `List`, `export` and the TUI still show retired facts. Only retrieval skips
+them.
+
+### Explicit only, for now
+
+Tombstones are written by explicit agent action through `memory_reflect`.
+Nothing detects contradictions automatically, and specifically **nothing does
+so in `Put`**. Put is the hot path — every `Remember` goes through it — and it
+is deliberately cheap and deterministic. Adding contradiction detection there
+would mean an embedding comparison, or an LLM call, on every write, and would
+break the property the README states outright: *consolidation is the only
+"smart" step; everything else is deterministic.*
+
+## Consequences
+
+- `update` and `forget` do what they have always claimed to do. This is a bug
+  fix wearing a feature's clothes.
+- The field is additive and `omitempty`, so stores written by earlier versions
+  load unchanged, with no migration. Asserted against a literal v0.9.0 JSON
+  fact, because "it should be fine" is not a test.
+- A tombstoned fact still occupies disk and still costs a decay update per
+  cycle until pruning collects it. At the default half-life that is months.
+  Acceptable: the alternative is deleting, which is the thing being avoided.
+- `update` writes the replacement *before* retiring the original. The previous
+  order zeroed the weight first, so a failing `Remember` left an agent with a
+  retired fact and nothing in its place.
+- The tombstone is enforced in `Recall` only. Anything reading facts through
+  `List` sees retired ones and must filter for itself — correct for export and
+  the TUI, a trap for any future caller that wants "current" facts.
+
+## Reversal condition
+
+Reconsider if tombstoned facts exceed **20%** of a typical store, which would
+mean corrections are common enough that carrying the history costs more than
+it is worth, and that pruning should collect them on a shorter horizon than
+live facts.
+
+Automatic contradiction detection unlocks under both of:
+
+1. It lives inside `Consolidate` — the one step already permitted to be smart
+   and to require an LLM — and never in `Put`.
+2. It is gated on `ConsolidateLLM` being configured, so a store running
+   keyword-only stays fully deterministic.
+
+A false positive here silently deletes a true fact from an agent's working
+memory, which is worse than the staleness being fixed. Precision on a
+hand-labelled sample must exceed **0.95** before it is enabled by default.
+
+## Alternatives rejected
+
+- **Delete the old fact.** Simplest, and it breaks the append-only property
+  and the audit trail with it.
+- **Make `Recall` respect `Weight`.** Would have fixed the reported bug with a
+  one-line change, and it conflates two questions: a fact can be unused
+  (low weight) without being untrue, and untrue without being unused. The
+  Lemon Squeezy fact was recent, frequently accessed, and wrong.
+- **A separate `tombstones` bucket.** Keeps `Fact` clean at the cost of a
+  second lookup on every recall and a consistency problem between two buckets.
+- **Automatic detection now.** Latency on the hot path, non-determinism in the
+  core, and a failure mode that quietly deletes true facts.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,30 @@
+# Architecture Decision Records
+
+Each record covers one decision that is not obvious from reading the code, and
+states the condition under which it should be reversed. The reversal condition
+is the part that matters: a decision without one is a preference, and a
+preference nobody can argue with is how a codebase ossifies.
+
+Format is [MADR](https://adr.github.io/madr/)-shaped: context, decision,
+consequences, reversal condition.
+
+| # | Decision | Status |
+|---|---|---|
+| [001](001-decay-half-life.md) | Memory decays on a 30-day half-life | Accepted |
+| [002](002-bbolt-single-writer.md) | bbolt with a single writer, and a daemon to share it | Accepted |
+| [003](003-knowledge-graph-autopopulation.md) | The knowledge graph has a write path but no automatic population | Accepted, partial |
+| [004](004-local-first-single-node.md) | Local-first and single-node, deliberately not multi-tenant | Accepted |
+| [005](005-embedding-degradation-chain.md) | Embeddings degrade Ollama → OpenAI → Anthropic → keyword | Accepted |
+| [006](006-configurable-signal-weights.md) | Retrieval signal weights are configurable | Accepted |
+| [007](007-supersede-tombstones.md) | Contradictions are resolved by tombstone, never by delete | Accepted |
+
+## Writing a new one
+
+Copy the shape of an existing record. Two rules:
+
+1. **The reversal condition has to be checkable.** "If it becomes a problem"
+   is not a condition. "If p95 recall latency exceeds 50 ms on a 100k-fact
+   store" is.
+2. **Record what was rejected and why.** The alternatives are most of the
+   value; a decision with no alternatives listed reads as though there were
+   none.

--- a/graymatter.go
+++ b/graymatter.go
@@ -100,6 +100,8 @@ func NewWithConfig(cfg Config) (*Memory, error) {
 		VectorReconcileInterval: cfg.VectorReconcileInterval,
 		ReadOnly:                cfg.ReadOnly,
 		StrictWrite:             cfg.StrictWrite,
+		SignalWeights:           cfg.SignalWeights,
+		MinRelevance:            cfg.MinRelevance,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("graymatter: open store: %w", err)

--- a/graymatter_test.go
+++ b/graymatter_test.go
@@ -3,7 +3,10 @@ package graymatter
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 // TestNew_HealthyOnSuccess verifies that a successful New() returns a Memory
@@ -70,5 +73,86 @@ func TestDefaultConfig_ConsolidateThreshold(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.ConsolidateThreshold != 20 {
 		t.Fatalf("ConsolidateThreshold default: got %d, want 20", cfg.ConsolidateThreshold)
+	}
+}
+
+// TestConfig_RankingFieldsReachTheStore covers the plumbing rather than the
+// behaviour: a Config field that is accepted, documented, and then dropped on
+// the way to StoreConfig is worse than not having it, because it fails
+// silently. Both new fields are exercised through the public constructor.
+func TestConfig_RankingFieldsReachTheStore(t *testing.T) {
+	ctx := context.Background()
+
+	// Recency-only weights make the effect unmistakable: the ranking must
+	// ignore keyword relevance entirely and return the newest fact first.
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.EmbeddingMode = EmbeddingKeyword
+	cfg.SignalWeights = &memory.SignalWeights{Vector: 0, Keyword: 0, Recency: 1}
+
+	mem, err := NewWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	defer mem.Close()
+
+	if err := mem.Remember(ctx, "cfg", "kubernetes deployment pipeline notes"); err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	if err := mem.Remember(ctx, "cfg", "the coffee machine takes whole beans"); err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+
+	got, err := mem.Recall(ctx, "cfg", "kubernetes deployment pipeline")
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("Recall returned nothing")
+	}
+	if !strings.Contains(got[0], "coffee") {
+		t.Errorf("Config.SignalWeights did not reach the store: recency-only ranking "+
+			"put %q first, expected the newest fact", got[0])
+	}
+}
+
+// TestConfig_MinRelevanceReachesTheStore does the same for the relevance floor.
+func TestConfig_MinRelevanceReachesTheStore(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.EmbeddingMode = EmbeddingKeyword
+	cfg.MinRelevance = 0.9
+
+	mem, err := NewWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	defer mem.Close()
+
+	if err := mem.Remember(ctx, "cfg", "kubernetes deployment pipeline notes"); err != nil {
+		t.Fatalf("Remember: %v", err)
+	}
+	for _, filler := range []string{
+		"the coffee machine takes whole beans",
+		"parking permits renew through the portal",
+		"lunch is catered on fridays",
+	} {
+		if err := mem.Remember(ctx, "cfg", filler); err != nil {
+			t.Fatalf("Remember: %v", err)
+		}
+	}
+
+	got, err := mem.Recall(ctx, "cfg", "kubernetes deployment pipeline")
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("MinRelevance trimmed the best match")
+	}
+	if len(got) == 4 {
+		t.Errorf("Config.MinRelevance did not reach the store: all %d facts were "+
+			"returned despite a 0.9 floor: %v", len(got), got)
 	}
 }

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -13,6 +13,19 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 )
 
+// ErrConsolidateLLMUnsupported is returned when ConsolidateLLM names a
+// provider that can embed but cannot yet summarise. Today that is "ollama":
+// it is a supported embedding backend, and configuring it as the consolidation
+// LLM is accepted by config but does nothing.
+//
+// It used to do nothing quietly. A store configured this way would run decay
+// and pruning forever and never summarise, with no error and no log line to
+// explain why memory kept growing. It now reaches OnConsolidateError like any
+// other consolidation failure.
+var ErrConsolidateLLMUnsupported = errors.New(
+	"consolidation LLM \"ollama\" is not implemented: Ollama works as an embedding " +
+		"backend but cannot summarise yet; set ConsolidateLLM to \"anthropic\" or \"\"")
+
 // ConsolidateConfig is the subset of configuration used by consolidation.
 // Defined as an interface to avoid a circular import with the root package.
 type ConsolidateConfig interface {
@@ -46,6 +59,15 @@ func (s *Store) LaunchAsyncConsolidate(agentID string, cfg ConsolidateConfig) {
 
 // MaybeConsolidate triggers consolidation only when the fact count for
 // agentID meets or exceeds the threshold. Safe to call concurrently.
+//
+// The threshold is read twice on the way through, with deliberately different
+// comparisons, and the difference is load-bearing rather than an oversight:
+// this function fires at >= N, while the LLM summarisation step inside
+// Consolidate fires at > N. At exactly N facts a cycle therefore runs decay
+// and pruning but does not summarise. Decay and pruning are cheap, local and
+// worth doing at the boundary; summarisation costs an API call and destroys
+// the batch it replaces, so it waits until the store is unambiguously over
+// the line. See docs/decisions/001-decay-half-life.md.
 func (s *Store) MaybeConsolidate(ctx context.Context, agentID string, cfg ConsolidateConfig) error {
 	facts, err := s.List(agentID)
 	if err != nil {
@@ -90,11 +112,21 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 	}
 
 	// Step 2: LLM summarisation when enabled and threshold exceeded.
+	// Strictly greater, unlike MaybeConsolidate's >= — see the note there.
 	if len(facts) > cfg.GetConsolidateThreshold() && cfg.GetConsolidateLLM() != "" {
 		sort.Slice(facts, func(i, j int) bool { return facts[i].Weight < facts[j].Weight })
 		batch := facts[:len(facts)/2]
 
 		summary, err := summariseFacts(ctx, batch, cfg)
+		if err != nil && s.cfg.OnConsolidateError != nil {
+			// Report rather than swallow. Summarisation failing is not fatal —
+			// the facts are still there and decay still runs — but a caller
+			// who configured an LLM and is getting no summaries has no other
+			// way to find out. ErrConsolidateLLMUnsupported arrives here too,
+			// which is how a store configured for Ollama summarisation learns
+			// that it is not implemented instead of quietly doing nothing.
+			s.cfg.OnConsolidateError(agentID, err)
+		}
 		if err == nil && summary != "" {
 			// Only delete the batch if Put of the summary succeeds — never lose data.
 			if putErr := s.Put(ctx, agentID, summary); putErr == nil {
@@ -160,9 +192,11 @@ func summariseFacts(ctx context.Context, facts []Fact, cfg ConsolidateConfig) (s
 	case "anthropic":
 		return consolidateViaAnthropic(ctx, prompt, cfg)
 	case "ollama":
-		// Ollama text generation not yet implemented; skip silently.
-		return "", nil
+		return "", ErrConsolidateLLMUnsupported
 	default:
+		// Consolidation LLM disabled. Decay and pruning still run; only
+		// summarisation is skipped, and that is the configured behaviour
+		// rather than a failure.
 		return "", nil
 	}
 }

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -99,10 +99,23 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 	lambda := math.Log(2) / halfLife.Hours()
 
 	// Step 1: decay all facts. Accumulate errors rather than silently dropping.
+	//
+	// Weight is recomputed from staleness, not multiplied into. Multiplying
+	// re-applied the entire elapsed period on every run — nothing recorded
+	// that a fact had already been decayed — so weight halved once per
+	// consolidation cycle rather than once per half-life. Five cycles in the
+	// same millisecond took a one-half-life-stale fact from 0.5 to 0.03, and
+	// with AsyncConsolidate on, a busy agent could prune a month-old fact in
+	// minutes. The half-life was per run, not per 30 days.
+	//
+	// min() rather than plain assignment, for two reasons: decay must never
+	// hand weight back, and a fact whose weight was deliberately zeroed —
+	// a supersede tombstone (ADR-007) — must stay collectable by pruning
+	// instead of being resurrected by its own recent access time.
 	var decayErrs []error
 	for i := range facts {
 		hours := time.Since(facts[i].AccessedAt).Hours()
-		facts[i].Weight *= math.Exp(-lambda * hours)
+		facts[i].Weight = math.Min(facts[i].Weight, math.Exp(-lambda*hours))
 		if err := s.UpdateFact(agentID, facts[i]); err != nil {
 			decayErrs = append(decayErrs, fmt.Errorf("decay fact %s: %w", facts[i].ID, err))
 		}

--- a/pkg/memory/consolidate_test.go
+++ b/pkg/memory/consolidate_test.go
@@ -2,12 +2,15 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
 )
 
 // testConsolidateCfg is a minimal ConsolidateConfig for unit tests.
@@ -267,5 +270,85 @@ func TestConsolidate_PutBeforeDelete(t *testing.T) {
 	// Without a real LLM no summarisation fires; original n facts intact.
 	if len(facts) != n {
 		t.Errorf("expected %d facts, got %d", n, len(facts))
+	}
+}
+
+// TestConsolidate_OllamaSummariserReportsUnsupported covers a misconfiguration
+// that used to be invisible. Ollama is a supported embedding backend, so
+// setting ConsolidateLLM="ollama" looks reasonable and is accepted by config —
+// but summarisation via Ollama is not implemented, and the code returned an
+// empty summary and no error. Consolidation then ran forever doing decay and
+// pruning only, with nothing anywhere to explain why memory kept growing.
+func TestConsolidate_OllamaSummariserReportsUnsupported(t *testing.T) {
+	var reported []error
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+		OnConsolidateError: func(_ string, err error) {
+			reported = append(reported, err)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	cfg := &testConsolidateCfg{threshold: 3, halfLife: 720 * time.Hour, llm: "ollama"}
+	for i := 0; i < 5; i++ { // over the threshold, so summarisation is attempted
+		if err := s.Put(ctx, "ollama-agent", fmt.Sprintf("observation number %d", i)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	if err := s.Consolidate(ctx, "ollama-agent", cfg); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	var found bool
+	for _, e := range reported {
+		if errors.Is(e, ErrConsolidateLLMUnsupported) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("configuring an unimplemented consolidation LLM reported nothing; got %v", reported)
+	}
+}
+
+// TestConsolidate_DisabledLLMReportsNothing is the other half: an empty
+// ConsolidateLLM means summarisation is off by choice, not broken, and must
+// stay silent.
+func TestConsolidate_DisabledLLMReportsNothing(t *testing.T) {
+	var reported []error
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+		OnConsolidateError: func(_ string, err error) {
+			reported = append(reported, err)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	cfg := &testConsolidateCfg{threshold: 3, halfLife: 720 * time.Hour, llm: ""}
+	for i := 0; i < 5; i++ {
+		if err := s.Put(ctx, "quiet-agent", fmt.Sprintf("observation number %d", i)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	if err := s.Consolidate(ctx, "quiet-agent", cfg); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if len(reported) != 0 {
+		t.Errorf("consolidation with the LLM disabled reported errors: %v", reported)
 	}
 }

--- a/pkg/memory/consolidate_test.go
+++ b/pkg/memory/consolidate_test.go
@@ -352,3 +352,137 @@ func TestConsolidate_DisabledLLMReportsNothing(t *testing.T) {
 		t.Errorf("consolidation with the LLM disabled reported errors: %v", reported)
 	}
 }
+
+// TestConsolidate_DecayIsIdempotent is the regression test for a decay model
+// that did not decay on the schedule it documented.
+//
+// Consolidate computed weight *= exp(-lambda * hoursSinceAccessed) using the
+// FULL time since last access on every run, rather than the time since the
+// last decay. Nothing tracked that a fact had already been decayed, so each
+// cycle re-applied the whole elapsed period. A fact one half-life stale went
+// 0.5, 0.25, 0.125, 0.0625 across four cycles that ran in the same
+// millisecond — the half-life was effectively "per consolidation run", not
+// per 30 days, and with AsyncConsolidate on a busy agent could prune a
+// month-old fact in minutes.
+func TestConsolidate_DecayIsIdempotent(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "idem", "a fact nobody recalls"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	facts, err := s.List("idem")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	f := facts[0]
+	// Exactly one half-life since last access.
+	f.AccessedAt = time.Now().UTC().Add(-720 * time.Hour)
+	f.CreatedAt = f.AccessedAt
+	if err := s.UpdateFact("idem", f); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	cfg := defaultTestCfg()
+	for run := 1; run <= 5; run++ {
+		if err := s.Consolidate(ctx, "idem", cfg); err != nil {
+			t.Fatalf("Consolidate run %d: %v", run, err)
+		}
+		got, err := s.List("idem")
+		if err != nil {
+			t.Fatalf("List run %d: %v", run, err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("fact was pruned after %d consolidation runs; at one half-life "+
+				"stale its weight should be 0.5 no matter how often consolidation runs", run)
+		}
+		if math.Abs(got[0].Weight-0.5) > 0.01 {
+			t.Errorf("after %d consolidation runs weight is %.6f, want ~0.5. "+
+				"Elapsed time has not changed between runs, so the weight must not either.",
+				run, got[0].Weight)
+		}
+	}
+}
+
+// TestConsolidate_DecayStillTracksElapsedTime guards the fix from the obvious
+// overcorrection: making decay idempotent must not make it stop happening.
+func TestConsolidate_DecayStillTracksElapsedTime(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "elapsed", "a fact nobody recalls"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	cfg := defaultTestCfg()
+
+	for _, tc := range []struct {
+		halfLives int
+		want      float64
+	}{{1, 0.5}, {2, 0.25}, {3, 0.125}} {
+		facts, err := s.List("elapsed")
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		f := facts[0]
+		f.AccessedAt = time.Now().UTC().Add(-time.Duration(tc.halfLives) * 720 * time.Hour)
+		if err := s.UpdateFact("elapsed", f); err != nil {
+			t.Fatalf("UpdateFact: %v", err)
+		}
+
+		if err := s.Consolidate(ctx, "elapsed", cfg); err != nil {
+			t.Fatalf("Consolidate: %v", err)
+		}
+		got, err := s.List("elapsed")
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("fact pruned at %d half-lives, expected weight ~%.3f", tc.halfLives, tc.want)
+		}
+		if math.Abs(got[0].Weight-tc.want) > 0.01 {
+			t.Errorf("at %d half-lives stale: weight %.6f, want ~%.3f",
+				tc.halfLives, got[0].Weight, tc.want)
+		}
+	}
+}
+
+// TestConsolidate_DecayNeverRaisesWeight covers the interaction with the
+// tombstones from ADR-007. A superseded fact has its weight zeroed so ordinary
+// pruning collects it; decay recomputing weight from elapsed time must never
+// hand that weight back, or a retired fact would sit in the store forever.
+func TestConsolidate_DecayNeverRaisesWeight(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "retired", "a fact the agent retired"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	facts, err := s.List("retired")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	f := facts[0]
+	f.SupersededBy = SupersededByAgent
+	f.Weight = 0
+	// Freshly accessed: elapsed time alone would compute a weight near 1.0.
+	f.AccessedAt = time.Now().UTC()
+	if err := s.UpdateFact("retired", f); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	if err := s.Consolidate(ctx, "retired", defaultTestCfg()); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	got, err := s.List("retired")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) > 0 && got[0].Weight > 0.01 {
+		t.Errorf("consolidation raised a retired fact's weight from 0 to %.6f; "+
+			"it would never be pruned", got[0].Weight)
+	}
+}

--- a/pkg/memory/fact.go
+++ b/pkg/memory/fact.go
@@ -20,7 +20,35 @@ type Fact struct {
 	// New facts start at 1.0 and decay over time via the forgetting curve.
 	Weight    float64   `json:"weight"`
 	Embedding []float32 `json:"embedding,omitempty"`
+
+	// SupersededBy marks this fact as retired. Empty means live.
+	//
+	// A non-empty value excludes the fact from Recall immediately and
+	// unconditionally — regardless of Weight, and without waiting for a
+	// consolidation cycle. It holds the ID of the fact that replaced this one
+	// when there is a replacement, or SupersededByAgent when an agent retired
+	// it with nothing to put in its place.
+	//
+	// This is a tombstone, not a delete. The fact stays in the store, stays
+	// visible to List, export and the TUI, and keeps decaying; pruning by
+	// weight remains the only thing that ever removes it. That is what keeps
+	// the storage model append-only while still letting a contradiction take
+	// effect at once — see docs/decisions/007-supersede-tombstones.md.
+	//
+	// Added in v0.10.0. Facts written by earlier versions have no
+	// superseded_by key and load as live.
+	SupersededBy string `json:"superseded_by,omitempty"`
 }
+
+// SupersededByAgent is the SupersededBy marker for a fact an agent retired
+// without a replacement — memory_reflect's forget action. Any non-empty value
+// excludes a fact from recall; this one records that the removal was a
+// deliberate agent decision rather than a correction pointing at a newer fact.
+const SupersededByAgent = "agent"
+
+// IsSuperseded reports whether the fact has been retired and must be kept out
+// of retrieval.
+func (f Fact) IsSuperseded() bool { return f.SupersededBy != "" }
 
 // newFact creates a Fact with a new ULID and weight=1.0.
 func newFact(agentID, text string, embedding []float32) Fact {

--- a/pkg/memory/ranking_test.go
+++ b/pkg/memory/ranking_test.go
@@ -1,0 +1,296 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+)
+
+// SignalWeights and MinRelevance are opt-in by construction: every default
+// reproduces v0.9.0 exactly. The first test in this file is the one that
+// matters — it is the anti-regression gate the whole design rests on. If it
+// fails, both knobs are wrong regardless of how well they work when set.
+
+// rankingStore opens a store with an explicit StoreConfig so each test can
+// vary the ranking fields.
+func rankingStore(t *testing.T, mutate func(*StoreConfig)) (*Store, func()) {
+	t.Helper()
+	cfg := StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return s, func() { _ = s.Close() }
+}
+
+// rankingCorpus is a fixed corpus with staggered creation times, so recency
+// and keyword relevance disagree and the weights are actually observable.
+// Written oldest first; the last entry is both newest and least relevant to
+// the query used below.
+var rankingCorpus = []string{
+	"the deployment pipeline runs on kubernetes with argo rollouts",
+	"database migrations are applied by atlas during deployment",
+	"the staging deployment cluster is shared between all teams",
+	"lunch is catered on fridays in the office kitchen",
+	"parking permits are renewed through the facilities portal",
+	"the coffee machine on floor two takes whole beans only",
+}
+
+const rankingQuery = "deployment pipeline"
+
+func seedRanking(t *testing.T, s *Store) {
+	t.Helper()
+	ctx := context.Background()
+	for i, text := range rankingCorpus {
+		if err := s.Put(ctx, "rank", text); err != nil {
+			t.Fatalf("Put %d: %v", i, err)
+		}
+		// Age the facts so recency is a signal that can disagree with keyword
+		// relevance: earlier entries are older.
+		facts, err := s.List("rank")
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		for j := range facts {
+			if facts[j].Text != text {
+				continue
+			}
+			age := time.Duration(len(rankingCorpus)-i) * 240 * time.Hour
+			facts[j].CreatedAt = time.Now().UTC().Add(-age)
+			if err := s.UpdateFact("rank", facts[j]); err != nil {
+				t.Fatalf("UpdateFact: %v", err)
+			}
+		}
+	}
+}
+
+// TestRankingDefaults_MatchV09Behaviour is the regression gate. Both new
+// fields are left at their zero value, which is what every existing caller
+// passes, and the result must be identical to the hardcoded ranking v0.9.0
+// shipped: RRF over vector 1.0, keyword 1.0, recency 0.5, returning exactly
+// topK with no threshold.
+func TestRankingDefaults_MatchV09Behaviour(t *testing.T) {
+	// The v0.9.0 ranking, recomputed here from the same inputs rather than
+	// pasted in as a golden string, so the comparison stays meaningful if the
+	// corpus changes.
+	want := rankWithV09Algorithm(t)
+
+	s, cleanup := rankingStore(t, nil) // zero value: no SignalWeights, no MinRelevance
+	defer cleanup()
+	seedRanking(t, s)
+
+	got, err := s.Recall(context.Background(), "rank", rankingQuery, 4)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	assertSameOrder(t, got, want)
+}
+
+// TestSignalWeights_ExplicitDefaultsAreIdentical checks the documented default
+// values really are the hardcoded ones. Someone reading DefaultSignalWeights()
+// has to be able to trust that setting them changes nothing.
+func TestSignalWeights_ExplicitDefaultsAreIdentical(t *testing.T) {
+	base, cleanupBase := rankingStore(t, nil)
+	defer cleanupBase()
+	seedRanking(t, base)
+	want, err := base.Recall(context.Background(), "rank", rankingQuery, 4)
+	if err != nil {
+		t.Fatalf("Recall base: %v", err)
+	}
+
+	w := DefaultSignalWeights()
+	explicit, cleanup := rankingStore(t, func(c *StoreConfig) { c.SignalWeights = &w })
+	defer cleanup()
+	seedRanking(t, explicit)
+	got, err := explicit.Recall(context.Background(), "rank", rankingQuery, 4)
+	if err != nil {
+		t.Fatalf("Recall explicit: %v", err)
+	}
+	assertSameOrder(t, got, want)
+}
+
+// TestSignalWeights_RecencyOnlyEmulatesSlidingWindow is the test that earns
+// ADR-006 its claim. With all weight on recency, hybrid retrieval degenerates
+// into "return the K most recent facts" — which is exactly a sliding window of
+// size K. That makes truncation a special case of this ranking rather than a
+// different design, and it means a sliding-window baseline can be measured by
+// reconfiguring the model instead of writing a second retrieval path.
+//
+// The claim was not true before this change: the weights were compile-time
+// constants and there was no way to reach recency-only.
+func TestSignalWeights_RecencyOnlyEmulatesSlidingWindow(t *testing.T) {
+	s, cleanup := rankingStore(t, func(c *StoreConfig) {
+		c.SignalWeights = &SignalWeights{Vector: 0, Keyword: 0, Recency: 1}
+	})
+	defer cleanup()
+	seedRanking(t, s)
+
+	const window = 3
+	got, err := s.Recall(context.Background(), "rank", rankingQuery, window)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+
+	// The newest `window` facts, by construction of seedRanking: the corpus is
+	// written oldest first, so the tail is newest.
+	want := rankingCorpus[len(rankingCorpus)-window:]
+	reversed := make([]string, 0, window)
+	for i := len(want) - 1; i >= 0; i-- {
+		reversed = append(reversed, want[i])
+	}
+	assertSameOrder(t, got, reversed)
+
+	// And the point of the comparison: the window returns none of the facts
+	// that actually answer the query, because none of them are recent.
+	for _, g := range got {
+		if strings.Contains(g, "deployment") {
+			t.Errorf("recency-only recall returned a relevant fact %q; the corpus was "+
+				"built so the relevant facts are the old ones, which is the whole "+
+				"failure mode a sliding window has", g)
+		}
+	}
+}
+
+// TestSignalWeights_KeywordOnlyRanksByRelevance is the mirror image: all
+// weight on keyword relevance surfaces the facts that answer the query,
+// regardless of age.
+func TestSignalWeights_KeywordOnlyRanksByRelevance(t *testing.T) {
+	s, cleanup := rankingStore(t, func(c *StoreConfig) {
+		c.SignalWeights = &SignalWeights{Vector: 0, Keyword: 1, Recency: 0}
+	})
+	defer cleanup()
+	seedRanking(t, s)
+
+	got, err := s.Recall(context.Background(), "rank", rankingQuery, 3)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("keyword-only recall returned nothing")
+	}
+	if !strings.Contains(got[0], "deployment") {
+		t.Errorf("keyword-only recall put %q first; expected a deployment fact", got[0])
+	}
+}
+
+// TestMinRelevance_ZeroReturnsExactlyTopK pins the v0.9.0 contract: Recall
+// returns topK results, padding with weak matches rather than cutting.
+func TestMinRelevance_ZeroReturnsExactlyTopK(t *testing.T) {
+	s, cleanup := rankingStore(t, nil)
+	defer cleanup()
+	seedRanking(t, s)
+
+	got, err := s.Recall(context.Background(), "rank", rankingQuery, 5)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) != 5 {
+		t.Errorf("MinRelevance unset must return exactly topK; got %d results: %v", len(got), got)
+	}
+}
+
+// TestMinRelevance_TrimsWeakMatches shows the knob doing its job: with a
+// threshold set, obviously irrelevant facts stop padding the result.
+func TestMinRelevance_TrimsWeakMatches(t *testing.T) {
+	s, cleanup := rankingStore(t, func(c *StoreConfig) { c.MinRelevance = 0.9 })
+	defer cleanup()
+	seedRanking(t, s)
+
+	got, err := s.Recall(context.Background(), "rank", rankingQuery, 5)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) >= 5 {
+		t.Fatalf("MinRelevance 0.9 returned the full topK (%d); nothing was trimmed: %v", len(got), got)
+	}
+	if len(got) == 0 {
+		t.Fatal("MinRelevance 0.9 trimmed everything, including the best match")
+	}
+	for _, g := range got {
+		if strings.Contains(g, "coffee") || strings.Contains(g, "parking") || strings.Contains(g, "lunch") {
+			t.Errorf("a fact unrelated to the query survived the threshold: %q", g)
+		}
+	}
+}
+
+// TestMinRelevance_IsRelativeNotAbsolute documents why the threshold is a
+// fraction of the best score in the result set rather than a fixed number.
+// RRF scores depend on how many facts were ranked — the same fact scores
+// differently in a 6-fact store and a 600-fact one — so an absolute cutoff
+// would silently mean something different as a store grows. A relative
+// threshold keeps the top match by definition, at any store size.
+func TestMinRelevance_IsRelativeNotAbsolute(t *testing.T) {
+	for _, size := range []int{6, 60} {
+		t.Run(fmt.Sprintf("store-of-%d", size), func(t *testing.T) {
+			s, cleanup := rankingStore(t, func(c *StoreConfig) { c.MinRelevance = 0.5 })
+			defer cleanup()
+
+			ctx := context.Background()
+			if err := s.Put(ctx, "scale", "the deployment pipeline runs on kubernetes"); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			for i := 0; i < size; i++ {
+				if err := s.Put(ctx, "scale", fmt.Sprintf("unrelated office note number %d", i)); err != nil {
+					t.Fatalf("Put filler: %v", err)
+				}
+			}
+
+			got, err := s.Recall(ctx, "scale", "deployment pipeline kubernetes", 8)
+			if err != nil {
+				t.Fatalf("Recall: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatalf("the best match was trimmed in a store of %d facts; the "+
+					"threshold is behaving as an absolute cutoff", size)
+			}
+			if !strings.Contains(got[0], "deployment") {
+				t.Errorf("top result in a store of %d is %q, expected the deployment fact", size, got[0])
+			}
+		})
+	}
+}
+
+// --- helpers ---
+
+// rankWithV09Algorithm reproduces the v0.9.0 ranking with its constants
+// written out literally, against a store that uses the new code path. It is
+// the independent expectation the defaults are checked against.
+func rankWithV09Algorithm(t *testing.T) []string {
+	t.Helper()
+	s, cleanup := rankingStore(t, func(c *StoreConfig) {
+		// The exact constants recall.go carried before they were configurable.
+		c.SignalWeights = &SignalWeights{Vector: 1.0, Keyword: 1.0, Recency: 0.5}
+		c.MinRelevance = 0.0
+	})
+	defer cleanup()
+	seedRanking(t, s)
+
+	got, err := s.Recall(context.Background(), "rank", rankingQuery, 4)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	return got
+}
+
+func assertSameOrder(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("result count changed: got %d %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("result %d differs:\n got:  %q\n want: %q", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -99,7 +99,17 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	}
 
 	// --- RRF fusion ---
+	//
+	// k=60 is the constant from Cormack, Clarke & Buettcher (SIGIR 2009). It
+	// stays fixed: it damps the difference between adjacent ranks, and with a
+	// single signal enabled it cannot change the ordering at all, so making it
+	// configurable would add a knob with no reachable effect.
 	const k = 60.0
+	w := s.cfg.SignalWeights
+	if w == nil {
+		d := DefaultSignalWeights()
+		w = &d
+	}
 	type scored struct {
 		id    string
 		score float64
@@ -108,13 +118,13 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	for _, f := range facts {
 		rrf := 0.0
 		if r, ok := vectorRank[f.ID]; ok {
-			rrf += 1.0 / (k + float64(r))
+			rrf += w.Vector / (k + float64(r))
 		}
 		if r, ok := kwRank[f.ID]; ok {
-			rrf += 1.0 / (k + float64(r))
+			rrf += w.Keyword / (k + float64(r))
 		}
 		if r, ok := recRank[f.ID]; ok {
-			rrf += 0.5 / (k + float64(r)) // recency gets half weight
+			rrf += w.Recency / (k + float64(r))
 		}
 		candidates[f.ID] = rrf
 	}
@@ -124,6 +134,21 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 		allScored = append(allScored, scored{id, sc})
 	}
 	sort.Slice(allScored, func(i, j int) bool { return allScored[i].score > allScored[j].score })
+
+	// Optional relevance floor, relative to the best score in this result set.
+	// At the default of 0 every score clears the bar and the slice is
+	// untouched, which is the pre-v0.10.0 contract of returning exactly topK.
+	if s.cfg.MinRelevance > 0 && len(allScored) > 0 {
+		floor := s.cfg.MinRelevance * allScored[0].score
+		cut := len(allScored)
+		for i, sc := range allScored {
+			if sc.score < floor {
+				cut = i
+				break
+			}
+		}
+		allScored = allScored[:cut]
+	}
 
 	// Build fact lookup.
 	factByID := make(map[string]*Fact, len(facts))
@@ -254,4 +279,28 @@ func tokenize(text string) []string {
 		}
 	}
 	return result
+}
+
+// SignalWeights sets the relative contribution of each retrieval signal to the
+// fused ranking. Zero disables a signal entirely.
+//
+// The defaults are the values that were compile-time constants before v0.10.0.
+// Recency is deliberately weighted below the other two: it is a tie-breaker
+// that keeps fresh context ahead of equally-relevant stale context, not a
+// ranking criterion of its own. Weighted at parity it drowns relevance out on
+// any store with a steady write rate.
+type SignalWeights struct {
+	// Vector weights cosine similarity from the vector store. Ignored when no
+	// embedder is configured, since there are no vector ranks to weight.
+	Vector float64
+	// Keyword weights the TF-IDF approximation over stored text.
+	Keyword float64
+	// Recency weights the exponential decay from CreatedAt.
+	Recency float64
+}
+
+// DefaultSignalWeights returns the weights Recall uses when StoreConfig leaves
+// SignalWeights nil: vector 1.0, keyword 1.0, recency 0.5.
+func DefaultSignalWeights() SignalWeights {
+	return SignalWeights{Vector: 1.0, Keyword: 1.0, Recency: 0.5}
 }

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -19,9 +19,35 @@ import (
 // Returns the top-k fact texts, ready to inject into a system prompt.
 func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
 	start := time.Now()
-	facts, err := s.List(agentID)
-	if err != nil || len(facts) == 0 {
+	stored, err := s.List(agentID)
+	if err != nil || len(stored) == 0 {
 		return nil, err
+	}
+
+	// Drop superseded facts before anything is scored. Filtering here rather
+	// than at the end means a tombstoned fact cannot displace a live one from
+	// the top-k, and the three signals below rank only what is still true.
+	//
+	// The vector index is deliberately not filtered: it can still return a
+	// superseded ID, but the fusion loop iterates over facts, so such an ID
+	// only ever contributes a rank nobody reads.
+	facts := make([]Fact, 0, len(stored))
+	var supersededTexts map[string]bool
+	for _, f := range stored {
+		if f.IsSuperseded() {
+			if supersededTexts == nil {
+				supersededTexts = make(map[string]bool)
+			}
+			supersededTexts[f.Text] = true
+			continue
+		}
+		facts = append(facts, f)
+	}
+	if len(facts) == 0 {
+		if s.cfg.OnRecall != nil {
+			s.cfg.OnRecall(agentID, query, 0, time.Since(start))
+		}
+		return nil, nil
 	}
 
 	// --- Signal 1: vector similarity ---
@@ -142,7 +168,10 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 				break
 			}
 			for _, nt := range neighborTexts {
-				if !seen[nt] {
+				// The graph stores node labels, not fact IDs, so a superseded
+				// fact's text can still be reachable as a neighbour. Skip it:
+				// the tombstone has to hold on every path into the result.
+				if !seen[nt] && !supersededTexts[nt] {
 					seen[nt] = true
 					result = append(result, nt)
 				}

--- a/pkg/memory/rpc/supersede_test.go
+++ b/pkg/memory/rpc/supersede_test.go
@@ -1,0 +1,118 @@
+package rpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// Daemon mode is the default: the MCP server, the TUI and the CLI all reach
+// the store through this RPC boundary rather than opening bbolt themselves. A
+// tombstone that survived an in-process UpdateFact but was dropped in transit
+// would leave the fix working in tests and failing in production, so the wire
+// gets its own regression test.
+func TestSupersedeSurvivesRPCRoundTrip(t *testing.T) {
+	dataDir, _ := startServer(t, "test-token")
+	c := dialT(t, dataDir)
+	defer c.Close()
+
+	ctx := context.Background()
+	const (
+		dead = "Deployments go through the legacy Jenkins pipeline"
+		live = "Deployments go through GitHub Actions"
+	)
+
+	if err := c.Put(ctx, "rpc-agent", dead); err != nil {
+		t.Fatalf("Put dead: %v", err)
+	}
+	if err := c.Put(ctx, "rpc-agent", live); err != nil {
+		t.Fatalf("Put live: %v", err)
+	}
+
+	facts, err := c.List("rpc-agent")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	var replacementID string
+	for _, f := range facts {
+		if f.Text == live {
+			replacementID = f.ID
+		}
+	}
+	if replacementID == "" {
+		t.Fatal("replacement fact not found over RPC")
+	}
+
+	for _, f := range facts {
+		if f.Text != dead {
+			continue
+		}
+		f.SupersededBy = replacementID
+		if err := c.UpdateFact("rpc-agent", f); err != nil {
+			t.Fatalf("UpdateFact over RPC: %v", err)
+		}
+	}
+
+	// The tombstone has to have been carried to the store, not just accepted.
+	back, err := c.List("rpc-agent")
+	if err != nil {
+		t.Fatalf("List after supersede: %v", err)
+	}
+	var checked bool
+	for _, f := range back {
+		if f.Text != dead {
+			continue
+		}
+		checked = true
+		if f.SupersededBy != replacementID {
+			t.Errorf("SupersededBy did not survive the round-trip: got %q, want %q",
+				f.SupersededBy, replacementID)
+		}
+	}
+	if !checked {
+		t.Fatal("the superseded fact vanished from List; it should be tombstoned, not deleted")
+	}
+
+	// And the store the daemon owns must actually exclude it from recall.
+	got, err := c.Recall(ctx, "rpc-agent", "deployment pipeline", 8)
+	if err != nil {
+		t.Fatalf("Recall over RPC: %v", err)
+	}
+	for _, g := range got {
+		if strings.Contains(g, "Jenkins") {
+			t.Errorf("superseded fact recalled through the daemon: %v", got)
+		}
+	}
+}
+
+// TestSupersedeMarkerConstantCrossesRPC covers the forget case, whose marker
+// is a package constant rather than a fact ID.
+func TestSupersedeMarkerConstantCrossesRPC(t *testing.T) {
+	dataDir, _ := startServer(t, "test-token")
+	c := dialT(t, dataDir)
+	defer c.Close()
+
+	ctx := context.Background()
+	if err := c.Put(ctx, "marker", "a fact the agent later drops"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	facts, err := c.List("marker")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	facts[0].SupersededBy = memory.SupersededByAgent
+	if err := c.UpdateFact("marker", facts[0]); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	got, err := c.Recall(ctx, "marker", "fact", 8)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("forgotten fact still recalled through the daemon: %v", got)
+	}
+}

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -81,6 +81,28 @@ type StoreConfig struct {
 	// with ReadOnly (StrictWrite wins).
 	StrictWrite bool
 
+	// SignalWeights sets how much each retrieval signal contributes to the
+	// fused ranking. nil — the zero value, and what every caller before
+	// v0.10.0 passes — means DefaultSignalWeights(), which is bit-for-bit the
+	// behaviour that was hardcoded until then.
+	//
+	// Set it to run the ranking as something other than a hybrid: all weight
+	// on Recency turns Recall into a sliding window over the K most recent
+	// facts, all weight on Keyword ignores age entirely. See
+	// docs/decisions/006-configurable-signal-weights.md.
+	SignalWeights *SignalWeights
+
+	// MinRelevance drops results scoring below this fraction of the best
+	// score in the same result set. 0 — the zero value — disables the cut
+	// and returns exactly topK, which is the pre-v0.10.0 contract.
+	//
+	// The threshold is relative because RRF scores are not comparable across
+	// stores: the same fact scores differently depending on how many facts
+	// were ranked alongside it, so an absolute cutoff would quietly mean
+	// something different as a store grows. 0.5 keeps results at least half as
+	// strong as the best match; the best match always survives.
+	MinRelevance float64
+
 	// OnRecall, if non-nil, is called after each Recall with timing and count.
 	OnRecall func(agentID, query string, resultCount int, duration time.Duration)
 

--- a/pkg/memory/supersede_test.go
+++ b/pkg/memory/supersede_test.go
@@ -1,0 +1,272 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The scenario these tests defend against, in full:
+//
+// An agent learns "we use Lemon Squeezy for billing". Months later the company
+// migrates and the agent calls memory_reflect with action=update to correct
+// it. The tool reports success. On the next recall the agent is handed both
+// statements and has no way to tell which one is current.
+//
+// Before v0.10.0 that is exactly what happened. memory_reflect's update and
+// forget actions set Weight = 0 and reported "Fact suppressed", and Recall
+// never read Weight — it ranks by vector, keyword and recency only. The
+// retired fact kept being returned until a consolidation cycle happened to
+// prune it, which requires the agent to have crossed ConsolidateThreshold
+// facts. On a store below the threshold it was returned forever.
+
+const (
+	deadFact = "We use Lemon Squeezy for billing and payments"
+	liveFact = "We use Polar for billing and payments"
+)
+
+// TestRecall_ExcludesSupersededFact is the regression test for that scenario.
+func TestRecall_ExcludesSupersededFact(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "billing", deadFact); err != nil {
+		t.Fatalf("put dead: %v", err)
+	}
+	if err := s.Put(ctx, "billing", liveFact); err != nil {
+		t.Fatalf("put live: %v", err)
+	}
+
+	supersede(t, s, "billing", deadFact, "the Polar fact")
+
+	got, err := s.Recall(ctx, "billing", "billing provider", 8)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	assertAbsent(t, got, "Lemon Squeezy")
+	assertPresent(t, got, "Polar")
+}
+
+// TestRecall_SupersededExcludedRegardlessOfWeight pins the precedence rule
+// between the three mechanisms that can end a fact's life. A tombstone wins
+// over weight: a superseded fact stays out of retrieval even at full weight,
+// which is what makes the exclusion immediate rather than dependent on when
+// decay and pruning next run.
+func TestRecall_SupersededExcludedRegardlessOfWeight(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "weights", deadFact); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	facts, err := s.List("weights")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	facts[0].SupersededBy = "some-newer-fact-id"
+	facts[0].Weight = 1.0 // maximum weight, freshly created
+	if err := s.UpdateFact("weights", facts[0]); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	got, err := s.Recall(ctx, "weights", "billing provider", 8)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a superseded fact at weight 1.0 was recalled: %v", got)
+	}
+}
+
+// TestList_RetainsSupersededFact holds the append-only promise the README
+// makes about storage. A contradiction is not a deletion: the tombstoned fact
+// is still in the store, still visible to List, export and the TUI. Only
+// retrieval skips it, and only pruning by decay ever removes it.
+func TestList_RetainsSupersededFact(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "history", deadFact); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	supersede(t, s, "history", deadFact, "replacement")
+
+	facts, err := s.List("history")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("expected the superseded fact to survive in the store, got %d facts", len(facts))
+	}
+	if facts[0].SupersededBy == "" {
+		t.Error("SupersededBy did not persist through the store round-trip")
+	}
+	if facts[0].Text != deadFact {
+		t.Errorf("stored text changed: %q", facts[0].Text)
+	}
+}
+
+// TestRecallShared_ExcludesSupersededFact covers the shared namespace, which
+// reaches retrieval through the same path.
+func TestRecallShared_ExcludesSupersededFact(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.PutShared(ctx, deadFact); err != nil {
+		t.Fatalf("PutShared: %v", err)
+	}
+	supersede(t, s, SharedAgentID, deadFact, "replacement")
+
+	got, err := s.RecallShared(ctx, "billing provider", 8)
+	if err != nil {
+		t.Fatalf("RecallShared: %v", err)
+	}
+	assertAbsent(t, got, "Lemon Squeezy")
+}
+
+// TestRecallAll_ExcludesSupersededFact covers the merged agent+shared path.
+func TestRecallAll_ExcludesSupersededFact(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.PutShared(ctx, deadFact); err != nil {
+		t.Fatalf("PutShared: %v", err)
+	}
+	if err := s.Put(ctx, "merged", liveFact); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	supersede(t, s, SharedAgentID, deadFact, "replacement")
+
+	got, err := s.RecallAll(ctx, "merged", "billing provider", 8)
+	if err != nil {
+		t.Fatalf("RecallAll: %v", err)
+	}
+	assertAbsent(t, got, "Lemon Squeezy")
+	assertPresent(t, got, "Polar")
+}
+
+// TestConsolidate_DecayAndPruneStillOwnSupersededFacts completes the
+// precedence rule from the other end. The tombstone governs retrieval and
+// nothing else: decay keeps running on a superseded fact, and pruning is
+// still what finally removes it. One mechanism per question, no overlap.
+func TestConsolidate_DecayAndPruneStillOwnSupersededFacts(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "decayed", deadFact); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	facts, _ := s.List("decayed")
+	f := facts[0]
+	f.SupersededBy = "replacement"
+	// Backdate well past the pruning horizon: many half-lives of no access.
+	f.AccessedAt = time.Now().UTC().Add(-365 * 24 * time.Hour)
+	if err := s.UpdateFact("decayed", f); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	if err := s.Consolidate(ctx, "decayed", defaultTestCfg()); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	remaining, err := s.List("decayed")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("expected pruning to remove the decayed superseded fact, %d remain (weight %v)",
+			len(remaining), remaining[0].Weight)
+	}
+}
+
+// TestFact_SupersededByIsBackwardCompatible checks the field is additive on
+// disk. Stores written by earlier versions have no superseded_by key, and must
+// load as live facts rather than failing or arriving tombstoned.
+func TestFact_SupersededByIsBackwardCompatible(t *testing.T) {
+	// A fact exactly as v0.9.0 and earlier serialised it.
+	legacy := `{"id":"01H000000000000000000000","agent_id":"a","text":"old fact",` +
+		`"created_at":"2026-01-01T00:00:00Z","accessed_at":"2026-01-01T00:00:00Z",` +
+		`"access_count":3,"weight":0.8}`
+
+	f, err := unmarshalFact([]byte(legacy))
+	if err != nil {
+		t.Fatalf("a v0.9.0 fact no longer unmarshals: %v", err)
+	}
+	if f.SupersededBy != "" {
+		t.Errorf("legacy fact loaded as superseded (%q); every stored fact would vanish from recall", f.SupersededBy)
+	}
+	if f.Text != "old fact" || f.AccessCount != 3 {
+		t.Errorf("legacy fields did not survive: %+v", f)
+	}
+
+	// And a live fact must not start writing the key.
+	raw, err := Fact{ID: "x", Text: "t"}.marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "superseded_by") {
+		t.Errorf("omitempty is not holding; live facts write the key: %s", raw)
+	}
+
+	// A tombstoned fact must round-trip.
+	raw, err = Fact{ID: "x", Text: "t", SupersededBy: "y"}.marshal()
+	if err != nil {
+		t.Fatalf("marshal tombstoned: %v", err)
+	}
+	var back Fact
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal tombstoned: %v", err)
+	}
+	if back.SupersededBy != "y" {
+		t.Errorf("SupersededBy did not round-trip: %+v", back)
+	}
+}
+
+// --- helpers ---
+
+// supersede tombstones the fact whose text matches, the way a caller is
+// expected to: read, set the field, write it back through UpdateFact.
+func supersede(t *testing.T, s *Store, agentID, text, by string) {
+	t.Helper()
+	facts, err := s.List(agentID)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, f := range facts {
+		if f.Text == text {
+			f.SupersededBy = by
+			if err := s.UpdateFact(agentID, f); err != nil {
+				t.Fatalf("UpdateFact: %v", err)
+			}
+			return
+		}
+	}
+	t.Fatalf("fact to supersede not found: %q", text)
+}
+
+func assertAbsent(t *testing.T, got []string, needle string) {
+	t.Helper()
+	for _, g := range got {
+		if strings.Contains(g, needle) {
+			t.Errorf("superseded fact still recalled: %q\nfull result: %v", g, got)
+		}
+	}
+}
+
+func assertPresent(t *testing.T, got []string, needle string) {
+	t.Helper()
+	for _, g := range got {
+		if strings.Contains(g, needle) {
+			return
+		}
+	}
+	t.Errorf("expected a fact containing %q, got %v", needle, got)
+}


### PR DESCRIPTION
Every number this project publishes and every behaviour it describes, checked
against what the code does. Where they disagreed: the code fixed, or the claim
withdrawn.

Three of the disagreements turned out to be bugs. One had been shipping since
the feature existed.

## The bugs

**Forgetting a fact did not stop it being recalled.** `memory_reflect` with
`action="forget"` or `"update"` set the fact's weight to 0 and answered *"Fact
suppressed for agent"*. `Recall` never reads weight — it ranks on vector,
keyword and recency. The fact came back on the very next search:

```
Found 2 relevant memories for agent "billing-agent":
1. Billing runs through Polar
2. Billing runs through Lemon Squeezy
```

An agent that had just corrected itself got both versions with nothing to say
which was current. Nothing resolved it until a consolidation cycle happened to
prune the zero-weight fact, and consolidation only fires past
`ConsolidateThreshold` facts — so on a smaller store, never.

The existing tests passed throughout. They asserted the handler wrote what it
meant to write, and never asked whether a later search agreed.

**Decay ran on a half-life of one consolidation cycle, not 30 days.**
`Consolidate` computed `weight *= exp(-lambda * hoursSinceAccessed)` with the
full elapsed time on every run; nothing recorded that a fact had already been
decayed. A fact one half-life stale, across five cycles in the same
millisecond:

```
run 1: 0.500000
run 2: 0.250000
run 3: 0.125000
run 4: 0.062500
run 5: 0.031250
```

No time passed between those runs. With `AsyncConsolidate` on, consolidation
fires after `Remember` — so a busy agent could take a month-old fact below the
0.01 prune floor in minutes. Every statement this project has made about
30-day decay described a model the code did not implement.

Found while writing ADR-001, because stating the model precisely meant
checking it.

**An unimplemented consolidation LLM failed silently.** Ollama is a supported
embedding backend, so `ConsolidateLLM = "ollama"` looks reasonable and config
accepts it. Summarisation through Ollama is not implemented, and the code
returned an empty summary and a nil error. Such a store ran decay and pruning
forever, never summarised, and gave no indication why.

## The claims

**`docs/benchmarks.md` published a table nothing produced** — ~40,000 tokens
of full injection against ~1,200 recalled at 100 sessions, where the benchmark
measures ~6,959 against ~666. The 100-session row was 475% off. It also
published a relevance score, and no code in this repository measures relevance
at all.

The README was correct throughout, which is the uncomfortable part. The v0.9.0
sweep grepped for "97" and this page never said 97, so a five-fold error
survived a hygiene pass whose entire purpose was removing indefensible
numbers. Grepping for a known-bad string only finds the claim you already know
about.

So the check is mechanical now. `benchmarks/token_count/main_test.go` parses
the tables out of README.md and docs/benchmarks.md and compares every cell
against a live run — 2% tolerance on token counts, none on the reduction
percentage — and rejects any relevance or precision figure in the benchmark
docs until something computes one.

**The README described the knowledge graph wrongly in both directions.** It
said nodes have no write path in shipped builds. They do: `memory_reflect
action=link` creates edges, the daemon opens a real graph and serves
`KGUpsert`/`KGLink`, the direct store does the same. What is missing is
*automatic* population — `Store.SetKG` is never called outside tests, so
entity extraction during consolidation and graph enrichment during recall are
implemented, tested, and have never run. The old wording oversold what is
broken and hid what works.

**`docs/AGENTS.md` carried four claims that had stopped being true**, including
a warning that `link` needs a `SetKGLinker` that no longer exists, returning an
error string that no longer exists, citing a line that now holds something
else. And "pruned in ~60 days" where the arithmetic gives 199.

## What is new

`SignalWeights` makes the RRF weights configurable — they were compile-time
constants. That was blocking a claim worth making honestly: that a sliding
window is a special case of this ranking, the one where all the weight sits on
recency. With hardcoded weights no configuration ranked that way, so the claim
described a system that did not exist.
`TestSignalWeights_RecencyOnlyEmulatesSlidingWindow` now runs it over a corpus
where the relevant facts are the old ones and shows the window returning none
of them.

`MinRelevance` cuts results below a fraction of the best score in the same
result set. Relative, not absolute: RRF scores depend on how many facts were
ranked, so a fixed cutoff would quietly change meaning as a store grew.

`docs/decisions/` — seven ADRs, each with a measurable condition for reversing
it. "If it becomes a problem" is not a condition; "if p95 recall latency
exceeds 50 ms on a 100k-fact store" is. Several are deliberately uncomfortable:
001 names the two classes of fact the decay model actively mismodels and says
to keep them out of memory; 003 corrects this repo's own README.

## Compatibility

Additive fields only, no signature changes. Every new field's zero value
reproduces v0.9.0 exactly, and `TestRankingDefaults_MatchV09Behaviour` is the
gate — it compares against an expectation recomputed from the same corpus
rather than a pasted golden string. `superseded_by` is `omitempty`; stores
written by earlier versions load as live, checked against a literal v0.9.0
JSON fact.

One observable change: **`GET /recall` returns 8 facts by default, not 5.** The
REST server had its own constant while the library, CLI, MCP tools and TUI all
used `DefaultConfig().TopK` — the same query returning different amounts of
context depending on which door you came through. `?k=5` restores the old
count.

## Verification

Every fix has a regression test that fails without it; I confirmed each failed
first, then passed. The supersede fix is tested at three levels — store, tool
boundary, and daemon RPC round-trip, since daemon mode is the default path and
a tombstone dropped in transit would work in tests and fail in production.

- Both modules green, `-count=1`, Linux/macOS/Windows matrix in CI
- `go vet` clean on both modules
- Coverage: core **77.0%** (gate 70%), CLI module **73.6%** (gate 65%)
- Benchmark output byte-identical to before the refactor: 0% / 12% / 71% / 90%
- Zero broken relative links across all docs

## What this deliberately does not include

The retrieval-quality benchmark with a sliding-window baseline and
pre-registered predictions, and the `doctor --audit` tool. Both are real work,
neither belongs in a PR about making existing claims true. `SignalWeights`
landing here is what makes the window baseline cheap to build next — it needs
no second retrieval path.

`docs/benchmarks.md` now states plainly that against a sliding window this
benchmark shows no token win to claim.
