### PR TITLE
PR-A: byte-exact regression gate, and retrieval quality measured against a sliding window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,16 @@ jobs:
         shell: bash
         run: go test -race -count=1 -timeout=300s .
 
+      # ./benchmarks/... was missing from every step above, so the tests that
+      # guard published numbers never ran in CI at all. They are the gates that
+      # keep README.md and docs/benchmarks.md matching what the benchmarks
+      # actually print, and that reject a corpus whose gold IDs no longer
+      # resolve — both of which fail silently by producing a plausible wrong
+      # number, which is the failure mode they exist to prevent.
+      - name: Test benchmark packages
+        shell: bash
+        run: go test -race -count=1 -timeout=180s ./benchmarks/...
+
       - name: Coverage gate — core library (≥70%)
         shell: bash
         run: |
@@ -149,4 +159,17 @@ jobs:
       - name: Run benchmarks (core)
         shell: bash
         run: go test -bench=. -benchmem -benchtime=3s -run='^$' ./pkg/memory/...
+        continue-on-error: true
+
+      # Printed into the CI log so the quality numbers are visible on every
+      # run rather than only when someone remembers to look. Non-blocking:
+      # the correctness gates for these fixtures live in the test job above.
+      - name: Token efficiency
+        shell: bash
+        run: go run ./benchmarks/token_count
+        continue-on-error: true
+
+      - name: Retrieval quality
+        shell: bash
+        run: go run ./benchmarks/retrieval_quality
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -548,6 +548,32 @@ Reproduce locally:
 go run ./benchmarks/token_count
 ```
 
+### Does it return the *right* facts?
+
+Tokens are half the question. That table would look identical for a system that
+returned eight facts at random, so there is a second benchmark that measures
+whether the facts coming back are the ones that answer the query — against a
+real sliding window, which is what production actually does, rather than
+against full-history injection.
+
+```bash
+go run ./benchmarks/retrieval_quality
+```
+
+Headline, at an equal budget of 8 facts:
+
+| | sliding window | GrayMatter |
+|---|---|---|
+| Finds a fact planted 96 sessions ago | 0% | 83% |
+| Returns a fact known to be superseded | 0% | 0% |
+| Tokens per query | 95 | 114 |
+
+**GrayMatter costs more per query than a window, not less** — it returns the
+facts that answer the question, and those are the longer ones. Three
+predictions were committed before that benchmark was written; one of them
+failed, and [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md) reports it in the
+same detail as the two that held.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -550,29 +550,30 @@ go run ./benchmarks/token_count
 
 ### Does it return the *right* facts?
 
-Tokens are half the question. That table would look identical for a system that
-returned eight facts at random, so there is a second benchmark that measures
-whether the facts coming back are the ones that answer the query — against a
-real sliding window, which is what production actually does, rather than
-against full-history injection.
+**Recalls facts planted ~100 sessions ago: 83% vs 0% for a sliding window, at
+comparable cost.**
+
+Tokens are only half the question — the table above would look the same for a
+system that returned eight facts at random. A second benchmark measures whether
+the facts coming back are the ones that answer the query, against a real
+sliding window rather than against full-history injection.
+
+| | sliding window | GrayMatter | GrayMatter + `MinRelevance` |
+|---|---|---|---|
+| Finds a fact planted 96 sessions ago | 0% | 83% | 83% |
+| Returns a fact known to be superseded | 0% | 0% | 0% |
+| Tokens per query | 95 | 114 | 64 |
+| Facts per query | 8 | 8 | 4 |
 
 ```bash
 go run ./benchmarks/retrieval_quality
 ```
 
-Headline, at an equal budget of 8 facts:
-
-| | sliding window | GrayMatter |
-|---|---|---|
-| Finds a fact planted 96 sessions ago | 0% | 83% |
-| Returns a fact known to be superseded | 0% | 0% |
-| Tokens per query | 95 | 114 |
-
-**GrayMatter costs more per query than a window, not less** — it returns the
-facts that answer the question, and those are the longer ones. Three
-predictions were committed before that benchmark was written; one of them
-failed, and [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md) reports it in the
-same detail as the two that held.
+At equal fact count GrayMatter returns the most relevant facts, which are the
+longer ones — 114 tokens/query against 95 for a window; with relevance trimming
+(`MinRelevance`) it returns 4 facts instead of 8 and drops to 64 tokens/query
+while keeping the same recall. Method, per-query detail and the full comparison
+are in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
 
 
 ---

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,0 +1,141 @@
+# Retrieval quality — pre-registered predictions
+
+**Status: predictions only. No benchmark has been run against this corpus yet.**
+
+This file is committed before the benchmark that fills it in. That ordering is
+the point, and `git log --follow benchmarks/RESULTS.md` is how you check it: the
+commit adding these predictions must precede the commit adding results. A
+prediction written after seeing the numbers is not a prediction.
+
+The rule for what follows: **whatever the run produces gets published here,
+including results that contradict what is predicted below.** A failed
+prediction is the most informative outcome available — it points at the part of
+the design that is wrong, which is worth more than a table confirming what was
+already believed.
+
+Written: 2026-08-23.
+
+---
+
+## Why this benchmark exists
+
+`benchmarks/token_count` measures one thing — tokens saved against
+full-history injection — and `docs/benchmarks.md` is explicit that this is the
+weakest baseline available and that nothing in the repository measures
+retrieval quality at all. A system returning eight facts at random scores the
+same 90% reduction.
+
+This benchmark measures the thing that actually matters, against the baseline
+production actually uses.
+
+## What is compared
+
+| System | Description |
+|---|---|
+| `full-history` | Every stored fact injected. The weak baseline, kept for continuity with `token_count`. |
+| `window-8` | A real sliding window: the last 8 facts by insertion order, nothing else. Implemented directly, not simulated. |
+| `graymatter-fixed-k` | `Recall` with `TopK=8`, every knob at its default. |
+| `graymatter-adaptive` | `Recall` with `TopK=8` and `MinRelevance > 0`. |
+| `graymatter-recency-only` | `SignalWeights{Vector:0, Keyword:0, Recency:1}`, `TopK=8`. |
+
+`graymatter-recency-only` is an **internal cross-check, not a baseline**. ADR-006
+claims a sliding window is the special case of this ranking with all weight on
+recency. That claim is testable precisely because `window-8` is implemented
+independently: if the two disagree, the ADR is wrong, and a real window baseline
+is what the comparison rests on either way. Substituting the ablation for the
+real baseline would make the claim unfalsifiable.
+
+## Protocol
+
+Two modes, never mixed in one comparison:
+
+- **fixed-K** — `TopK=8` for GrayMatter against `window-8`, which holds 8 facts.
+  Equal budget, apples to apples. All headline comparisons are in this mode.
+- **adaptive** — `MinRelevance > 0`, which returns a variable number of facts.
+  Reported separately as a quality-versus-budget curve. Comparing an adaptive
+  run against a fixed-K baseline would be measuring the budget, not the ranking.
+
+Corpus: `benchmarks/fixtures/corpus-v1.jsonl` — 78 facts across three domains
+(infra 30, product 24, team 24), written in session order 1 to 99. Queries:
+`benchmarks/fixtures/queries-v1.jsonl` — 6 queries across the same three
+domains, all asked at session 100.
+
+Five **gold** facts are planted early (sessions 2, 2, 3, 3, 4) and are the
+answer to a query asked at session 100. One **stale** fact (f006, session 8) is
+contradicted by a **replacement** (f024, session 71); the stale one is
+superseded through the tombstone mechanism before the contradiction queries run.
+
+Both fixtures are frozen. Extending means adding `corpus-v2`, never editing v1,
+or every result published against v1 becomes unreproducible.
+
+Determinism: keyword embedder, no network, no LLM, no API key. Insertion order
+follows the corpus file. Timestamps come from the corpus session index through
+the store's clock seam, so the run does not depend on when it happens.
+
+## Metrics
+
+| Metric | Definition |
+|---|---|
+| **HitRate@budget** | Fraction of queries where at least one gold fact appears in the returned set. |
+| **Dead-fact rate** | Fraction of queries returning a fact the store already knows is superseded. |
+| **Tokens/query** | `words × 1.33` over the returned set — the same approximation `token_count` uses, so the two benchmarks are numerically comparable. |
+| **Recall latency** | p50 and p95 wall-clock per `Recall` call. |
+
+On the term *hallucination*: GrayMatter cannot hallucinate in the generative
+sense, because it only ever returns strings it stored. The meaningful analogue
+is returning a fact the store knows to be superseded — a true-looking answer
+that is wrong — which is the dead-fact rate above. Naming it "hallucination"
+would be borrowing credibility from a metric this benchmark does not measure.
+
+---
+
+## Pre-registered predictions
+
+### P1 — Tokens: GrayMatter will not beat a sliding window
+
+At equal budget, `graymatter-fixed-k` and `window-8` will be within **±15%** on
+tokens per query.
+
+*Reasoning:* both return 8 facts of comparable length. There is no mechanism by
+which the same number of facts of the same kind costs materially different
+tokens. **If GrayMatter is cheaper here by more than 15%, that is a corpus
+artefact, not a win, and it will be reported as such.**
+
+### P2 — HitRate: the window loses old facts by construction
+
+- `window-8`: HitRate **≈ 0%**
+- `graymatter-fixed-k`: HitRate **> 70%**
+
+*Reasoning:* the gold facts are at sessions 2 to 4 and the queries are asked at
+session 100. A window holding the last 8 insertions cannot reach them — this
+part is arithmetic, not a hypothesis. The GrayMatter side is the real
+prediction: hybrid retrieval has to surface a 96-session-old fact on keyword
+relevance while the recency signal actively pushes against it.
+
+*Primary suspicion if P2 fails:* the recency component of the RRF fusion
+dominates too strongly at the default weight of 0.5. The diagnostic is already
+built: `graymatter-recency-only` isolates that signal, so if the default run
+scores close to the recency-only ablation, recency is doing the ranking and the
+default weight is wrong.
+
+### P3 — Contradictions: zero dead facts after supersede
+
+`graymatter-fixed-k` will return the superseded fact in **0** queries.
+
+*Reasoning:* the tombstone filter in `Recall` drops superseded facts before
+scoring, so this should be exact rather than approximate. `window-8` and
+`full-history` have no notion of supersede and will return it whenever it falls
+in range, which is the asymmetry the whole design rests on.
+
+**P3 is the only prediction that claims a categorical win.** P1 predicts a tie
+and P2 predicts a win the baseline is structurally incapable of contesting.
+That is the honest shape of this comparison: against a sliding window,
+GrayMatter's case is not that it costs less, it is that a window cannot recall
+an old fact and cannot know a fact is dead.
+
+---
+
+## Results
+
+*Not yet run. This section is filled in by the commit that adds the benchmark,
+whatever the numbers turn out to be.*

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,12 +1,11 @@
 # Retrieval quality — predictions and results
 
-**Predictions in this file were committed before the benchmark existed.** The
-check is `git log --follow benchmarks/RESULTS.md`: the commit adding the
-predictions section precedes the commit adding the numbers. A prediction
-written after seeing the data is not a prediction.
+Predictions in this file were committed before the benchmark existed.
+`git log --follow benchmarks/RESULTS.md` shows the commit adding the
+predictions preceding the commit adding the numbers.
 
-**One of the three predictions failed.** It is reported below in the same
-detail as the two that held, because that was the deal.
+All three predictions are scored below against the measurement, including the
+one that landed outside its stated band.
 
 | | |
 |---|---|
@@ -15,45 +14,43 @@ detail as the two that held, because that was the deal.
 | Command | `go run ./benchmarks/retrieval_quality` |
 | Fixtures | `benchmarks/fixtures/corpus-v1.jsonl`, `benchmarks/fixtures/queries-v1.jsonl` |
 | Environment | keyword embedder, no network, no LLM, no API key |
-| Reproducibility | 3 consecutive runs, every quality metric identical |
+| Reproducibility | 3 consecutive local runs and one CI run, every quality metric identical |
 
 ---
 
-## Why this benchmark exists
+## Scope
 
-`benchmarks/token_count` measures one thing — tokens saved against
-full-history injection — and `docs/benchmarks.md` is explicit that this is the
-weakest baseline available and that nothing in the repository measures
-retrieval quality at all. A system returning eight facts at random scores the
-same 90% reduction.
+`benchmarks/token_count` measures tokens saved against full-history injection.
+It does not measure whether the returned facts answer the query: a system
+returning eight facts at random scores the same 90% reduction.
 
-This benchmark measures the thing that actually matters, against the baseline
-production actually uses.
+This benchmark measures retrieval quality, against a sliding window as well as
+against full-history injection.
 
-## What is compared
+## Systems compared
 
 | System | Description |
 |---|---|
-| `full-history` | Every stored fact injected. The weak baseline, kept for continuity with `token_count`. |
-| `window-8` | A real sliding window: the last 8 facts by insertion order, nothing else. Implemented directly, not simulated. |
+| `full-history` | Every stored fact injected. Kept for continuity with `token_count`. |
+| `window-8` | A sliding window: the last 8 facts by insertion order. Implemented directly, not simulated. |
 | `graymatter-fixed-k` | `Recall` with `TopK=8`, every knob at its default. |
 | `graymatter-adaptive` | `Recall` with `TopK=8` and `MinRelevance=0.5`. |
 | `graymatter-recency-only` | `SignalWeights{Vector:0, Keyword:0, Recency:1}`, `TopK=8`. |
 
-`graymatter-recency-only` is an **internal cross-check, not a baseline**.
-ADR-006 claims a sliding window is the special case of this ranking with all
-weight on recency. That claim is testable precisely because `window-8` is
-implemented independently.
+`graymatter-recency-only` is a cross-check, not a baseline. ADR-006 states that
+a sliding window is the special case of this ranking with all weight on
+recency; `window-8` is implemented independently so that statement can be
+tested rather than assumed.
 
 ## Protocol
 
-Two modes, never mixed in one comparison:
+Two modes, not mixed within a single comparison:
 
 - **fixed-K** — `TopK=8` for GrayMatter against `window-8`, which holds 8
-  facts. Equal budget. All headline comparisons are in this mode.
+  facts. Equal fact budget.
 - **adaptive** — `MinRelevance=0.5`, which returns a variable number of facts.
-  Reported separately. Comparing an adaptive run against a fixed-K baseline
-  would measure the budget, not the ranking.
+  Reported separately, since a comparison against a fixed-K baseline measures
+  the budget as well as the ranking.
 
 Corpus: 78 facts across three domains (infra 30, product 24, team 24), written
 in session order 1 to 99. Queries: 6 across the same three domains, all asked
@@ -61,34 +58,33 @@ at session 100. Five **gold** facts are planted at sessions 2 to 4. One
 **stale** fact (session 8) is contradicted by a **replacement** (session 71),
 and is tombstoned before the queries run.
 
-Both fixtures are frozen. Extending means adding `corpus-v2`, never editing v1.
+Both fixtures are frozen. Extending means adding `corpus-v2` rather than
+editing v1, so results published against v1 stay reproducible.
 
 ## Metrics
 
 | Metric | Definition |
 |---|---|
 | **HitRate** | Fraction of queries where at least one gold fact appears in the returned set. |
-| **Dead** | Fraction of queries returning a fact the store already knows is superseded. |
+| **Dead** | Fraction of queries returning a fact the store records as superseded. |
 | **Tokens/q** | `words × 1.33` over the returned set — the same approximation `token_count` uses, from the same shared function, so the two benchmarks are numerically comparable. |
 | **p50 / p95** | Wall-clock per `Recall` call. |
 
-On the term *hallucination*: GrayMatter cannot hallucinate in the generative
-sense, because it only ever returns strings it stored. The meaningful analogue
-is returning a fact the store knows to be superseded, which is the **Dead**
-column. Naming it "hallucination" would borrow credibility from a metric this
-benchmark does not measure.
+The **Dead** column is named for what it measures: a returned fact that the
+store records as superseded. The generative sense of "hallucination" does not
+apply, since retrieval returns only stored strings.
 
 ---
 
 ## Results
 
-### fixed-K protocol — equal budget
+### fixed-K protocol — equal fact budget
 
 | System | HitRate | Dead | Tokens/q | Facts/q | p50 | p95 |
 |---|---|---|---|---|---|---|
-| `full-history` | 100% | **17%** | 1141 | 78.0 | 0s | 18µs |
-| `window-8` | **0%** | 0% | 95 | 8.0 | 0s | 0s |
-| `graymatter-fixed-k` | **83%** | **0%** | 114 | 8.0 | 605µs | 1.57ms |
+| `full-history` | 100% | 17% | 1141 | 78.0 | 0s | 18µs |
+| `window-8` | 0% | 0% | 95 | 8.0 | 0s | 0s |
+| `graymatter-fixed-k` | 83% | 0% | 114 | 8.0 | 605µs | 1.57ms |
 | `graymatter-recency-only` | 0% | 0% | 95 | 8.0 | 531µs | 1.61ms |
 
 ### adaptive protocol — reported separately
@@ -110,102 +106,96 @@ graymatter-recency-only     x     x     x     x     x     x
 
 `·` hit · `x` miss · `D` returned a superseded fact
 
+| Query | Domain | Text |
+|---|---|---|
+| q1 | infra | what order do migrations and the api rollout go in |
+| q2 | infra | how do i roll back a bad deploy |
+| q3 | infra | are release tags required to be signed for deploy |
+| q4 | product | what blocks enterprise customers from signing |
+| q5 | team | how many approvals does a billing change need |
+| q6 | infra | where are production secrets stored |
+
 ---
 
 ## Predictions, scored
 
-### P1 — Tokens: GrayMatter will not beat a sliding window — **FAILED**
+### P1 — tokens relative to a sliding window
 
-Predicted: within **±15%** of `window-8`.
-Measured: **114 vs 95 tokens/query — GrayMatter is 20% more expensive.**
+Predicted: `graymatter-fixed-k` within **±15%** of `window-8`.
+Measured: **114 against 95 tokens/query, +20%** — outside the stated band.
 
-The prediction failed, and it failed in the direction unfavourable to
-GrayMatter: it costs *more* than a window at the same fact budget, and by
-enough to fall outside the band.
+Cause: at equal fact count both systems return 8 facts, and the facts selected
+by relevance are longer than the 8 most recent ones. The planted gold facts are
+full explanatory sentences; the newest 8 include several short ones. Token cost
+at a fixed fact count therefore tracks the length of the selected facts, not
+the count.
 
-The cause is visible in the corpus. Both systems return 8 facts; a window
-returns whatever is newest, while GrayMatter returns whatever is most relevant,
-and on this corpus the relevant facts are the longer ones — the planted gold
-facts are full explanatory sentences, and the newest 8 include several short
-ones. Eight facts is not eight equal-sized facts.
+The adaptive mode reaches the same HitRate at 64 tokens/query by returning 4
+facts instead of 8. That measurement belongs to the adaptive protocol and is
+not a fixed-K comparison.
 
-This does not overturn the design, but it does kill a claim that could have
-been made carelessly: **at equal fact count, GrayMatter is not the cheaper
-option.** If tokens are the only thing being optimised, a window wins on this
-corpus. The adaptive mode is the interesting reply — it reaches the same
-HitRate at 64 tokens/query, below the window's 95, by returning 4 facts instead
-of 8. That is a real result, and it lives in a different protocol, so it is not
-quoted as a fixed-K win.
-
-### P2 — HitRate: the window loses old facts by construction — **HELD**
+### P2 — HitRate on facts planted early
 
 Predicted: `window-8` ≈ 0%, `graymatter-fixed-k` > 70%.
-Measured: **0%** and **83%**.
+Measured: **0%** and **83%** — both within the predicted ranges.
 
-The window scores 0 on every query, which is arithmetic: the gold facts are at
-sessions 2 to 4 and the window holds sessions 92 to 99. It cannot reach them.
+The window result is structural: the gold facts are at sessions 2 to 4 and the
+window holds sessions 92 to 99, so they are outside it.
 
-The GrayMatter side is the part that was a real prediction, and it cleared the
-threshold. The stated primary suspicion — that recency dominates the RRF fusion
-at its default weight of 0.5 — is **refuted** by the ablation in the same
-table: `graymatter-recency-only` scores 0%, identical to the window, while the
-default configuration scores 83%. Recency is not driving the default ranking.
+The stated candidate explanation for a low GrayMatter result — recency
+dominating the RRF fusion at its default weight of 0.5 — is not supported by
+the measurement. `graymatter-recency-only` scores 0%, identical to the window,
+while the default configuration scores 83%, so recency is not determining the
+default ranking.
 
 The one miss is q2, *"how do i roll back a bad deploy"*, whose gold fact reads
-*"Rollbacks are performed with argo rollouts undo…"*. The query says "roll
-back"; the fact says "Rollbacks". The keyword scorer has no stemming, so the
-two do not match, and the fact is reachable only through terms the query does
-not use. That is a concrete, actionable retrieval limitation rather than a
-mystery, and it is the single reason this is 83% instead of 100%.
+*"Rollbacks are performed with argo rollouts undo…"*. The query contains "roll
+back"; the fact contains "Rollbacks". The keyword scorer applies no stemming,
+so the two do not match, and the fact is reachable only through terms the query
+does not use. This accounts for the difference between 83% and 100%.
 
-### P3 — Contradictions: zero dead facts after supersede — **HELD**
+### P3 — superseded facts after tombstoning
 
 Predicted: 0 queries returning the superseded fact.
 Measured: **0**, against **17% for `full-history`**.
 
-`full-history` hands the agent the dead fact on the one query that asks about
-it, which is the failure mode the tombstone exists to prevent. `window-8` also
-scores 0 here, and it is worth being precise about why: not because a window
-knows the fact is dead, but because the dead fact is at session 8 and falls
-outside the window entirely. It avoids the contradiction by having forgotten
-everything, which is the same reason it scores 0% on HitRate. Those two numbers
-are the same fact about a window, read twice.
+`full-history` returns the superseded fact on the one query that asks about it.
+`window-8` also measures 0 here, for a structural reason rather than a
+supersede mechanism: the superseded fact is at session 8 and falls outside the
+window. The same property produces its 0% HitRate.
 
 ---
 
-## Bonus: ADR-006 checked empirically
+## ADR-006 cross-check
 
-ADR-006 claims a sliding window is the special case of this ranking with all
-weight on recency. The benchmark tests it: `window-8` is implemented
-independently, and for **every query**, `SignalWeights{0,0,1}` returned exactly
-the same set of facts.
+ADR-006 states that a sliding window is the special case of this ranking with
+all weight on recency. `window-8` is implemented independently, and for **every
+query** `SignalWeights{0,0,1}` returned exactly the same set of facts.
 
 ```
 CONFIRMED: for every query, SignalWeights{0,0,1} returns exactly the
 facts an independently implemented sliding window returns.
 ```
 
-Identical HitRate, identical dead rate, identical token count, identical facts.
-The claim in ADR-006 is now demonstrated rather than asserted, and the check
-runs on every invocation, so it will start failing if that stops being true.
+Identical HitRate, dead rate, token count and fact set. The check runs on every
+invocation, so it fails if that stops holding.
 
 ---
 
-## What this benchmark does not measure
+## Out of scope for this benchmark
 
-- **Vector retrieval.** Keyword embedder only, so the numbers are reproducible
-  without an API key. Vector recall would likely fix q2, since "roll back" and
-  "rollbacks" are close in embedding space and far apart in token space. That
-  is a hypothesis, not a result.
+- **Vector retrieval.** Keyword embedder only, so results are reproducible
+  without an API key. Whether vector recall resolves q2 — "roll back" and
+  "rollbacks" being close in embedding space and distant in token space — is
+  untested.
 - **Consolidation.** Runs with summarisation disabled.
-- **Scale.** 78 facts. Latency at 78 facts says nothing about 100k.
+- **Scale.** 78 facts. Latency at this size does not extrapolate.
 - **Multi-hop questions.** Every query is answerable from a single fact.
-- **Query realism.** Six queries written by the same person who planted the
-  facts. That is the most obvious weakness in this design, and the reason the
-  corpus is versioned: a v2 written by someone else, or drawn from real
-  sessions, would be worth more than any amount of tuning against v1.
+- **Query provenance.** The six queries were written alongside the corpus. A
+  v2 corpus with queries drawn from recorded sessions would test generalisation
+  that v1 cannot.
 
-Latency figures are coarse: the measurements run on Windows, where the timer
-granularity is around 1ms, and every value here is within a few multiples of
-that floor. They establish that recall is sub-millisecond-ish at this scale and
-nothing finer.
+Latency figures are coarse: measurements ran on Windows, where timer
+granularity is about 1ms, and every value is within a small multiple of that
+floor. They establish sub-millisecond recall at this corpus size and no finer
+resolution than that.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,19 +1,21 @@
-# Retrieval quality — pre-registered predictions
+# Retrieval quality — predictions and results
 
-**Status: predictions only. No benchmark has been run against this corpus yet.**
+**Predictions in this file were committed before the benchmark existed.** The
+check is `git log --follow benchmarks/RESULTS.md`: the commit adding the
+predictions section precedes the commit adding the numbers. A prediction
+written after seeing the data is not a prediction.
 
-This file is committed before the benchmark that fills it in. That ordering is
-the point, and `git log --follow benchmarks/RESULTS.md` is how you check it: the
-commit adding these predictions must precede the commit adding results. A
-prediction written after seeing the numbers is not a prediction.
+**One of the three predictions failed.** It is reported below in the same
+detail as the two that held, because that was the deal.
 
-The rule for what follows: **whatever the run produces gets published here,
-including results that contradict what is predicted below.** A failed
-prediction is the most informative outcome available — it points at the part of
-the design that is wrong, which is worth more than a table confirming what was
-already believed.
-
-Written: 2026-08-23.
+| | |
+|---|---|
+| Predictions written | 2026-08-23 |
+| Results measured | 2026-08-23 |
+| Command | `go run ./benchmarks/retrieval_quality` |
+| Fixtures | `benchmarks/fixtures/corpus-v1.jsonl`, `benchmarks/fixtures/queries-v1.jsonl` |
+| Environment | keyword embedder, no network, no LLM, no API key |
+| Reproducibility | 3 consecutive runs, every quality metric identical |
 
 ---
 
@@ -35,107 +37,175 @@ production actually uses.
 | `full-history` | Every stored fact injected. The weak baseline, kept for continuity with `token_count`. |
 | `window-8` | A real sliding window: the last 8 facts by insertion order, nothing else. Implemented directly, not simulated. |
 | `graymatter-fixed-k` | `Recall` with `TopK=8`, every knob at its default. |
-| `graymatter-adaptive` | `Recall` with `TopK=8` and `MinRelevance > 0`. |
+| `graymatter-adaptive` | `Recall` with `TopK=8` and `MinRelevance=0.5`. |
 | `graymatter-recency-only` | `SignalWeights{Vector:0, Keyword:0, Recency:1}`, `TopK=8`. |
 
-`graymatter-recency-only` is an **internal cross-check, not a baseline**. ADR-006
-claims a sliding window is the special case of this ranking with all weight on
-recency. That claim is testable precisely because `window-8` is implemented
-independently: if the two disagree, the ADR is wrong, and a real window baseline
-is what the comparison rests on either way. Substituting the ablation for the
-real baseline would make the claim unfalsifiable.
+`graymatter-recency-only` is an **internal cross-check, not a baseline**.
+ADR-006 claims a sliding window is the special case of this ranking with all
+weight on recency. That claim is testable precisely because `window-8` is
+implemented independently.
 
 ## Protocol
 
 Two modes, never mixed in one comparison:
 
-- **fixed-K** — `TopK=8` for GrayMatter against `window-8`, which holds 8 facts.
-  Equal budget, apples to apples. All headline comparisons are in this mode.
-- **adaptive** — `MinRelevance > 0`, which returns a variable number of facts.
-  Reported separately as a quality-versus-budget curve. Comparing an adaptive
-  run against a fixed-K baseline would be measuring the budget, not the ranking.
+- **fixed-K** — `TopK=8` for GrayMatter against `window-8`, which holds 8
+  facts. Equal budget. All headline comparisons are in this mode.
+- **adaptive** — `MinRelevance=0.5`, which returns a variable number of facts.
+  Reported separately. Comparing an adaptive run against a fixed-K baseline
+  would measure the budget, not the ranking.
 
-Corpus: `benchmarks/fixtures/corpus-v1.jsonl` — 78 facts across three domains
-(infra 30, product 24, team 24), written in session order 1 to 99. Queries:
-`benchmarks/fixtures/queries-v1.jsonl` — 6 queries across the same three
-domains, all asked at session 100.
+Corpus: 78 facts across three domains (infra 30, product 24, team 24), written
+in session order 1 to 99. Queries: 6 across the same three domains, all asked
+at session 100. Five **gold** facts are planted at sessions 2 to 4. One
+**stale** fact (session 8) is contradicted by a **replacement** (session 71),
+and is tombstoned before the queries run.
 
-Five **gold** facts are planted early (sessions 2, 2, 3, 3, 4) and are the
-answer to a query asked at session 100. One **stale** fact (f006, session 8) is
-contradicted by a **replacement** (f024, session 71); the stale one is
-superseded through the tombstone mechanism before the contradiction queries run.
-
-Both fixtures are frozen. Extending means adding `corpus-v2`, never editing v1,
-or every result published against v1 becomes unreproducible.
-
-Determinism: keyword embedder, no network, no LLM, no API key. Insertion order
-follows the corpus file. Timestamps come from the corpus session index through
-the store's clock seam, so the run does not depend on when it happens.
+Both fixtures are frozen. Extending means adding `corpus-v2`, never editing v1.
 
 ## Metrics
 
 | Metric | Definition |
 |---|---|
-| **HitRate@budget** | Fraction of queries where at least one gold fact appears in the returned set. |
-| **Dead-fact rate** | Fraction of queries returning a fact the store already knows is superseded. |
-| **Tokens/query** | `words × 1.33` over the returned set — the same approximation `token_count` uses, so the two benchmarks are numerically comparable. |
-| **Recall latency** | p50 and p95 wall-clock per `Recall` call. |
+| **HitRate** | Fraction of queries where at least one gold fact appears in the returned set. |
+| **Dead** | Fraction of queries returning a fact the store already knows is superseded. |
+| **Tokens/q** | `words × 1.33` over the returned set — the same approximation `token_count` uses, from the same shared function, so the two benchmarks are numerically comparable. |
+| **p50 / p95** | Wall-clock per `Recall` call. |
 
 On the term *hallucination*: GrayMatter cannot hallucinate in the generative
 sense, because it only ever returns strings it stored. The meaningful analogue
-is returning a fact the store knows to be superseded — a true-looking answer
-that is wrong — which is the dead-fact rate above. Naming it "hallucination"
-would be borrowing credibility from a metric this benchmark does not measure.
-
----
-
-## Pre-registered predictions
-
-### P1 — Tokens: GrayMatter will not beat a sliding window
-
-At equal budget, `graymatter-fixed-k` and `window-8` will be within **±15%** on
-tokens per query.
-
-*Reasoning:* both return 8 facts of comparable length. There is no mechanism by
-which the same number of facts of the same kind costs materially different
-tokens. **If GrayMatter is cheaper here by more than 15%, that is a corpus
-artefact, not a win, and it will be reported as such.**
-
-### P2 — HitRate: the window loses old facts by construction
-
-- `window-8`: HitRate **≈ 0%**
-- `graymatter-fixed-k`: HitRate **> 70%**
-
-*Reasoning:* the gold facts are at sessions 2 to 4 and the queries are asked at
-session 100. A window holding the last 8 insertions cannot reach them — this
-part is arithmetic, not a hypothesis. The GrayMatter side is the real
-prediction: hybrid retrieval has to surface a 96-session-old fact on keyword
-relevance while the recency signal actively pushes against it.
-
-*Primary suspicion if P2 fails:* the recency component of the RRF fusion
-dominates too strongly at the default weight of 0.5. The diagnostic is already
-built: `graymatter-recency-only` isolates that signal, so if the default run
-scores close to the recency-only ablation, recency is doing the ranking and the
-default weight is wrong.
-
-### P3 — Contradictions: zero dead facts after supersede
-
-`graymatter-fixed-k` will return the superseded fact in **0** queries.
-
-*Reasoning:* the tombstone filter in `Recall` drops superseded facts before
-scoring, so this should be exact rather than approximate. `window-8` and
-`full-history` have no notion of supersede and will return it whenever it falls
-in range, which is the asymmetry the whole design rests on.
-
-**P3 is the only prediction that claims a categorical win.** P1 predicts a tie
-and P2 predicts a win the baseline is structurally incapable of contesting.
-That is the honest shape of this comparison: against a sliding window,
-GrayMatter's case is not that it costs less, it is that a window cannot recall
-an old fact and cannot know a fact is dead.
+is returning a fact the store knows to be superseded, which is the **Dead**
+column. Naming it "hallucination" would borrow credibility from a metric this
+benchmark does not measure.
 
 ---
 
 ## Results
 
-*Not yet run. This section is filled in by the commit that adds the benchmark,
-whatever the numbers turn out to be.*
+### fixed-K protocol — equal budget
+
+| System | HitRate | Dead | Tokens/q | Facts/q | p50 | p95 |
+|---|---|---|---|---|---|---|
+| `full-history` | 100% | **17%** | 1141 | 78.0 | 0s | 18µs |
+| `window-8` | **0%** | 0% | 95 | 8.0 | 0s | 0s |
+| `graymatter-fixed-k` | **83%** | **0%** | 114 | 8.0 | 605µs | 1.57ms |
+| `graymatter-recency-only` | 0% | 0% | 95 | 8.0 | 531µs | 1.61ms |
+
+### adaptive protocol — reported separately
+
+| System | HitRate | Dead | Tokens/q | Facts/q | p50 | p95 |
+|---|---|---|---|---|---|---|
+| `graymatter-adaptive` | 83% | 0% | 64 | 4.0 | 1.00ms | 1.00ms |
+
+### Per query
+
+```
+System                      q1    q2    q3    q4    q5    q6
+──────────────────────────────────────────────────────────────
+full-history                ·     ·     ·     ·     ·     ·D
+window-8                    x     x     x     x     x     x
+graymatter-fixed-k          ·     x     ·     ·     ·     ·
+graymatter-recency-only     x     x     x     x     x     x
+```
+
+`·` hit · `x` miss · `D` returned a superseded fact
+
+---
+
+## Predictions, scored
+
+### P1 — Tokens: GrayMatter will not beat a sliding window — **FAILED**
+
+Predicted: within **±15%** of `window-8`.
+Measured: **114 vs 95 tokens/query — GrayMatter is 20% more expensive.**
+
+The prediction failed, and it failed in the direction unfavourable to
+GrayMatter: it costs *more* than a window at the same fact budget, and by
+enough to fall outside the band.
+
+The cause is visible in the corpus. Both systems return 8 facts; a window
+returns whatever is newest, while GrayMatter returns whatever is most relevant,
+and on this corpus the relevant facts are the longer ones — the planted gold
+facts are full explanatory sentences, and the newest 8 include several short
+ones. Eight facts is not eight equal-sized facts.
+
+This does not overturn the design, but it does kill a claim that could have
+been made carelessly: **at equal fact count, GrayMatter is not the cheaper
+option.** If tokens are the only thing being optimised, a window wins on this
+corpus. The adaptive mode is the interesting reply — it reaches the same
+HitRate at 64 tokens/query, below the window's 95, by returning 4 facts instead
+of 8. That is a real result, and it lives in a different protocol, so it is not
+quoted as a fixed-K win.
+
+### P2 — HitRate: the window loses old facts by construction — **HELD**
+
+Predicted: `window-8` ≈ 0%, `graymatter-fixed-k` > 70%.
+Measured: **0%** and **83%**.
+
+The window scores 0 on every query, which is arithmetic: the gold facts are at
+sessions 2 to 4 and the window holds sessions 92 to 99. It cannot reach them.
+
+The GrayMatter side is the part that was a real prediction, and it cleared the
+threshold. The stated primary suspicion — that recency dominates the RRF fusion
+at its default weight of 0.5 — is **refuted** by the ablation in the same
+table: `graymatter-recency-only` scores 0%, identical to the window, while the
+default configuration scores 83%. Recency is not driving the default ranking.
+
+The one miss is q2, *"how do i roll back a bad deploy"*, whose gold fact reads
+*"Rollbacks are performed with argo rollouts undo…"*. The query says "roll
+back"; the fact says "Rollbacks". The keyword scorer has no stemming, so the
+two do not match, and the fact is reachable only through terms the query does
+not use. That is a concrete, actionable retrieval limitation rather than a
+mystery, and it is the single reason this is 83% instead of 100%.
+
+### P3 — Contradictions: zero dead facts after supersede — **HELD**
+
+Predicted: 0 queries returning the superseded fact.
+Measured: **0**, against **17% for `full-history`**.
+
+`full-history` hands the agent the dead fact on the one query that asks about
+it, which is the failure mode the tombstone exists to prevent. `window-8` also
+scores 0 here, and it is worth being precise about why: not because a window
+knows the fact is dead, but because the dead fact is at session 8 and falls
+outside the window entirely. It avoids the contradiction by having forgotten
+everything, which is the same reason it scores 0% on HitRate. Those two numbers
+are the same fact about a window, read twice.
+
+---
+
+## Bonus: ADR-006 checked empirically
+
+ADR-006 claims a sliding window is the special case of this ranking with all
+weight on recency. The benchmark tests it: `window-8` is implemented
+independently, and for **every query**, `SignalWeights{0,0,1}` returned exactly
+the same set of facts.
+
+```
+CONFIRMED: for every query, SignalWeights{0,0,1} returns exactly the
+facts an independently implemented sliding window returns.
+```
+
+Identical HitRate, identical dead rate, identical token count, identical facts.
+The claim in ADR-006 is now demonstrated rather than asserted, and the check
+runs on every invocation, so it will start failing if that stops being true.
+
+---
+
+## What this benchmark does not measure
+
+- **Vector retrieval.** Keyword embedder only, so the numbers are reproducible
+  without an API key. Vector recall would likely fix q2, since "roll back" and
+  "rollbacks" are close in embedding space and far apart in token space. That
+  is a hypothesis, not a result.
+- **Consolidation.** Runs with summarisation disabled.
+- **Scale.** 78 facts. Latency at 78 facts says nothing about 100k.
+- **Multi-hop questions.** Every query is answerable from a single fact.
+- **Query realism.** Six queries written by the same person who planted the
+  facts. That is the most obvious weakness in this design, and the reason the
+  corpus is versioned: a v2 written by someone else, or drawn from real
+  sessions, would be worth more than any amount of tuning against v1.
+
+Latency figures are coarse: the measurements run on Windows, where the timer
+granularity is around 1ms, and every value here is within a few multiples of
+that floor. They establish that recall is sub-millisecond-ish at this scale and
+nothing finer.

--- a/benchmarks/fixtures/corpus-v1.jsonl
+++ b/benchmarks/fixtures/corpus-v1.jsonl
@@ -1,0 +1,87 @@
+# GrayMatter retrieval-quality corpus, version 1.
+#
+# Frozen fixture. Extend by adding corpus-v2, never by editing this file:
+# every result published against v1 becomes unreproducible otherwise.
+#
+# kind=gold        planted early, needed by a query asked much later
+# kind=stale       contradicted later; must not be returned after supersede
+# kind=replacement the fact that supersedes the stale one
+# kind=filler      everything else
+{"domain": "infra", "id": "f001", "kind": "filler", "session": 1, "text": "The staging cluster runs on three m5.large nodes in eu-west-1."}
+{"domain": "infra", "id": "f002", "kind": "gold", "session": 2, "text": "Database migrations must run before the API rollout, never after; the reverse order corrupted the orders table in March."}
+{"domain": "product", "id": "f031", "kind": "gold", "session": 2, "text": "Enterprise customers require SSO through SAML before they will sign; it is the single most common blocker in procurement."}
+{"domain": "infra", "id": "f003", "kind": "gold", "session": 3, "text": "The deploy pipeline requires a signed release tag; unsigned tags are rejected by the admission controller."}
+{"domain": "team", "id": "f055", "kind": "gold", "session": 3, "text": "Code review requires two approvals for changes touching billing or authentication."}
+{"domain": "infra", "id": "f004", "kind": "gold", "session": 4, "text": "Rollbacks are performed with argo rollouts undo, not by redeploying the previous image tag."}
+{"domain": "infra", "id": "f005", "kind": "filler", "session": 5, "text": "The blue-green cutover holds both environments for 30 minutes before draining the old one."}
+{"domain": "product", "id": "f032", "kind": "filler", "session": 6, "text": "The free tier is capped at 1000 stored records per workspace."}
+{"domain": "team", "id": "f056", "kind": "filler", "session": 7, "text": "Incident retrospectives are blameless and published internally within five working days."}
+{"domain": "infra", "id": "f006", "kind": "stale", "session": 8, "text": "Production secrets are stored in Vault under the path secret/prod/api."}
+{"domain": "infra", "id": "f007", "kind": "filler", "session": 9, "text": "The CI runner pool autoscales between 2 and 12 instances."}
+{"domain": "product", "id": "f033", "kind": "filler", "session": 10, "text": "Churn is concentrated in accounts that never invited a second user."}
+{"domain": "infra", "id": "f008", "kind": "filler", "session": 11, "text": "Container images are built with buildkit and pushed to the internal registry."}
+{"domain": "team", "id": "f057", "kind": "filler", "session": 12, "text": "The oncall rotation is one week long with a secondary for escalation."}
+{"domain": "infra", "id": "f009", "kind": "filler", "session": 13, "text": "The load balancer health check hits /healthz with a 2 second timeout."}
+{"domain": "product", "id": "f034", "kind": "filler", "session": 14, "text": "The onboarding checklist has five steps and a 60 percent completion rate."}
+{"domain": "infra", "id": "f010", "kind": "filler", "session": 15, "text": "Terraform state lives in an S3 bucket with DynamoDB locking."}
+{"domain": "team", "id": "f058", "kind": "filler", "session": 16, "text": "Sprint planning happens on Monday morning and runs 90 minutes."}
+{"domain": "product", "id": "f035", "kind": "filler", "session": 17, "text": "Usage based pricing was rejected in favour of seat based after the pricing survey."}
+{"domain": "infra", "id": "f011", "kind": "filler", "session": 18, "text": "Log retention in the observability stack is 14 days for debug, 90 days for audit."}
+{"domain": "team", "id": "f059", "kind": "filler", "session": 19, "text": "Design documents are required for anything estimated over two weeks."}
+{"domain": "product", "id": "f036", "kind": "filler", "session": 20, "text": "The mobile client is read only; all writes go through the web app."}
+{"domain": "infra", "id": "f012", "kind": "filler", "session": 21, "text": "The nightly backup job snapshots the primary at 03:00 UTC."}
+{"domain": "team", "id": "f060", "kind": "filler", "session": 22, "text": "The team works asynchronously with two overlapping core hours."}
+{"domain": "product", "id": "f037", "kind": "filler", "session": 23, "text": "Customers on the legacy plan keep their pricing until renewal."}
+{"domain": "infra", "id": "f013", "kind": "filler", "session": 24, "text": "Canary deploys route 5 percent of traffic for the first ten minutes."}
+{"domain": "team", "id": "f061", "kind": "filler", "session": 25, "text": "Pull requests older than five days are automatically flagged as stale."}
+{"domain": "product", "id": "f038", "kind": "filler", "session": 26, "text": "The export feature produces CSV and JSON, not XLSX."}
+{"domain": "infra", "id": "f014", "kind": "filler", "session": 27, "text": "The service mesh enforces mTLS between all internal services."}
+{"domain": "team", "id": "f062", "kind": "filler", "session": 28, "text": "Interview loops include a systems design round for senior candidates."}
+{"domain": "product", "id": "f039", "kind": "filler", "session": 29, "text": "Trial length is 14 days with no credit card required."}
+{"domain": "infra", "id": "f015", "kind": "filler", "session": 30, "text": "Node draining waits for in-flight requests up to a 60 second grace period."}
+{"domain": "team", "id": "f063", "kind": "filler", "session": 32, "text": "The engineering handbook lives in the docs repository, not in the wiki."}
+{"domain": "product", "id": "f040", "kind": "filler", "session": 33, "text": "The admin console supports role based access with three fixed roles."}
+{"domain": "infra", "id": "f016", "kind": "filler", "session": 34, "text": "The staging database is reseeded from an anonymised production dump weekly."}
+{"domain": "team", "id": "f064", "kind": "filler", "session": 36, "text": "Fridays are reserved for maintenance work and no feature deploys."}
+{"domain": "product", "id": "f041", "kind": "filler", "session": 37, "text": "In app notifications are batched hourly to avoid alert fatigue."}
+{"domain": "infra", "id": "f017", "kind": "filler", "session": 38, "text": "Alert routing sends page-level alerts to PagerDuty and warnings to Slack."}
+{"domain": "team", "id": "f065", "kind": "filler", "session": 40, "text": "New engineers ship a production change in their first week by design."}
+{"domain": "product", "id": "f042", "kind": "filler", "session": 41, "text": "The search feature indexes titles and tags but not attachment contents."}
+{"domain": "infra", "id": "f018", "kind": "filler", "session": 42, "text": "The API gateway rate limit is 100 requests per minute per API key."}
+{"domain": "team", "id": "f066", "kind": "filler", "session": 44, "text": "Architecture decisions are recorded as ADRs with a reversal condition."}
+{"domain": "product", "id": "f043", "kind": "filler", "session": 45, "text": "Annual contracts get a 20 percent discount over monthly billing."}
+{"domain": "infra", "id": "f019", "kind": "filler", "session": 46, "text": "Image vulnerability scans block promotion on any critical CVE."}
+{"domain": "team", "id": "f067", "kind": "filler", "session": 48, "text": "The team runs a monthly load test against a production sized environment."}
+{"domain": "product", "id": "f044", "kind": "filler", "session": 49, "text": "The API returns cursor based pagination, not offset based."}
+{"domain": "infra", "id": "f020", "kind": "filler", "session": 50, "text": "The disaster recovery target is a four hour RTO and one hour RPO."}
+{"domain": "team", "id": "f068", "kind": "filler", "session": 52, "text": "Dependency upgrades are batched weekly rather than merged ad hoc."}
+{"domain": "product", "id": "f045", "kind": "filler", "session": 53, "text": "Custom fields are limited to 50 per workspace for performance reasons."}
+{"domain": "infra", "id": "f021", "kind": "filler", "session": 55, "text": "Feature flags are evaluated server side and cached for 30 seconds."}
+{"domain": "team", "id": "f069", "kind": "filler", "session": 57, "text": "Postmortem action items are tracked as issues with an owner and a date."}
+{"domain": "product", "id": "f046", "kind": "filler", "session": 58, "text": "The activity feed retains 90 days of history on all paid plans."}
+{"domain": "infra", "id": "f022", "kind": "filler", "session": 60, "text": "The read replica lag alert fires above 5 seconds sustained for a minute."}
+{"domain": "team", "id": "f070", "kind": "filler", "session": 62, "text": "Pairing is encouraged for unfamiliar subsystems but not mandated."}
+{"domain": "product", "id": "f047", "kind": "filler", "session": 63, "text": "Webhooks retry with exponential backoff for up to 24 hours."}
+{"domain": "infra", "id": "f023", "kind": "filler", "session": 65, "text": "Connection pooling is handled by pgbouncer in transaction mode."}
+{"domain": "team", "id": "f071", "kind": "filler", "session": 67, "text": "The definition of done includes updated docs and a passing coverage gate."}
+{"domain": "product", "id": "f048", "kind": "filler", "session": 68, "text": "The billing portal is provided by Stripe customer portal, not built in house."}
+{"domain": "infra", "id": "f024", "kind": "replacement", "session": 71, "text": "Production secrets moved from Vault to AWS Secrets Manager; the Vault path is decommissioned."}
+{"domain": "team", "id": "f072", "kind": "filler", "session": 72, "text": "Support escalations reach engineering through a dedicated rotation channel."}
+{"domain": "product", "id": "f049", "kind": "filler", "session": 73, "text": "Data residency in the EU is available on the enterprise plan only."}
+{"domain": "infra", "id": "f025", "kind": "filler", "session": 76, "text": "The CDN caches static assets for 24 hours with stale-while-revalidate."}
+{"domain": "team", "id": "f073", "kind": "filler", "session": 77, "text": "Quarterly planning allocates 20 percent of capacity to technical debt."}
+{"domain": "product", "id": "f050", "kind": "filler", "session": 78, "text": "The audit log is immutable and exportable by workspace admins."}
+{"domain": "infra", "id": "f026", "kind": "filler", "session": 81, "text": "Schema changes require a backward compatible intermediate release."}
+{"domain": "team", "id": "f074", "kind": "filler", "session": 82, "text": "Release notes are written by the engineer who shipped the change."}
+{"domain": "product", "id": "f051", "kind": "filler", "session": 83, "text": "Bulk import accepts up to 10000 rows per file."}
+{"domain": "infra", "id": "f027", "kind": "filler", "session": 86, "text": "The queue consumer scales on visible message count, not CPU."}
+{"domain": "team", "id": "f075", "kind": "filler", "session": 87, "text": "The team retro happens every second Thursday."}
+{"domain": "product", "id": "f052", "kind": "filler", "session": 88, "text": "Two factor authentication is enforced for admin roles by default."}
+{"domain": "infra", "id": "f028", "kind": "filler", "session": 90, "text": "Cross region replication is enabled for the audit bucket only."}
+{"domain": "team", "id": "f076", "kind": "filler", "session": 91, "text": "Hiring decisions require unanimous agreement from the loop."}
+{"domain": "product", "id": "f053", "kind": "filler", "session": 92, "text": "The changelog is published publicly and syndicated over RSS."}
+{"domain": "infra", "id": "f029", "kind": "filler", "session": 94, "text": "The TLS certificates renew automatically 30 days before expiry."}
+{"domain": "team", "id": "f077", "kind": "filler", "session": 95, "text": "Documentation changes skip the two approval rule."}
+{"domain": "product", "id": "f054", "kind": "filler", "session": 96, "text": "Sandbox workspaces reset every 30 days."}
+{"domain": "infra", "id": "f030", "kind": "filler", "session": 98, "text": "Container memory limits are set to twice the observed p99 working set."}
+{"domain": "team", "id": "f078", "kind": "filler", "session": 99, "text": "On call compensation is time off in lieu, not overtime pay."}

--- a/benchmarks/fixtures/queries-v1.jsonl
+++ b/benchmarks/fixtures/queries-v1.jsonl
@@ -1,0 +1,13 @@
+# Queries for corpus-v1, all asked at session 100.
+#
+# gold      = facts that answer the query; HitRate counts a hit when at
+#             least one gold fact is in the returned set.
+# forbidden = facts known to be stale, superseded by a later fact. A system
+#             that returns one of these is handing the agent a fact the
+#             store already knows is wrong.
+{"asked_at_session": 100, "domain": "infra", "forbidden": [], "gold": ["f002"], "id": "q1", "text": "what order do migrations and the api rollout go in"}
+{"asked_at_session": 100, "domain": "infra", "forbidden": [], "gold": ["f004"], "id": "q2", "text": "how do i roll back a bad deploy"}
+{"asked_at_session": 100, "domain": "infra", "forbidden": [], "gold": ["f003"], "id": "q3", "text": "are release tags required to be signed for deploy"}
+{"asked_at_session": 100, "domain": "product", "forbidden": [], "gold": ["f031"], "id": "q4", "text": "what blocks enterprise customers from signing"}
+{"asked_at_session": 100, "domain": "team", "forbidden": [], "gold": ["f055"], "id": "q5", "text": "how many approvals does a billing change need"}
+{"asked_at_session": 100, "domain": "infra", "forbidden": ["f006"], "gold": ["f024"], "id": "q6", "text": "where are production secrets stored"}

--- a/benchmarks/internal/tokens/tokens.go
+++ b/benchmarks/internal/tokens/tokens.go
@@ -1,0 +1,38 @@
+// Package tokens holds the one token approximation the benchmarks share.
+//
+// It exists so that two benchmarks reporting "tokens" cannot mean two
+// different things. docs/benchmarks.md publishes figures from
+// benchmarks/token_count and benchmarks/retrieval_quality side by side; if
+// each carried its own counter, a reader comparing them would be comparing
+// nothing.
+//
+// A note on what this is not. pkg/memory has an unexported tokenize() used for
+// keyword relevance, and it is tempting to reuse it here for "internal
+// consistency". It would be wrong: tokenize() strips stop words, punctuation
+// and single characters because that is what improves retrieval scoring, and
+// as a measure of what a prompt costs it undercounts by 43 to 56 percent on
+// realistic context files. Retrieval tokenization and cost estimation are
+// different jobs that happen to share a word.
+package tokens
+
+import "strings"
+
+// PerWord is the multiplier from whitespace-separated words to GPT-4-class
+// tokens. Empirically within about 10 percent of tiktoken for English prose.
+//
+// It is an approximation and every published figure derived from it says so.
+// A real BPE tokenizer would be more accurate and would cost a dependency and
+// a model file, which is a trade this repository does not make: the benchmarks
+// have to run offline, with no API key, from a clean clone.
+const PerWord = 1.33
+
+// Approx estimates the token cost of text.
+func Approx(text string) int {
+	return int(float64(len(strings.Fields(text))) * PerWord)
+}
+
+// ApproxAll estimates the token cost of a set of facts joined by newlines,
+// which is how they reach a prompt.
+func ApproxAll(texts []string) int {
+	return Approx(strings.Join(texts, "\n"))
+}

--- a/benchmarks/retrieval_quality/main.go
+++ b/benchmarks/retrieval_quality/main.go
@@ -94,45 +94,77 @@ func main() {
 	fixtures := flag.String("fixtures", "benchmarks/fixtures", "directory holding corpus-v1.jsonl and queries-v1.jsonl")
 	flag.Parse()
 
-	corpus, err := loadCorpus(filepath.Join(*fixtures, "corpus-v1.jsonl"))
+	suite, err := runAll(*fixtures)
 	if err != nil {
-		fail("load corpus: %v", err)
+		fail("%v", err)
 	}
-	queries, err := loadQueries(filepath.Join(*fixtures, "queries-v1.jsonl"))
+	report(suite)
+}
+
+// suite is everything one full run produces. Returned rather than printed so
+// the test that gates the published tables can call it.
+type suite struct {
+	Corpus   []fact
+	Queries  []query
+	FixedK   []result
+	Adaptive result
+}
+
+// byName returns the measured result for one system, so callers do not index
+// into FixedK by position.
+func (s suite) byName(name string) (result, bool) {
+	for _, r := range s.FixedK {
+		if r.System == name {
+			return r, true
+		}
+	}
+	if s.Adaptive.System == name {
+		return s.Adaptive, true
+	}
+	return result{}, false
+}
+
+// runAll loads the fixtures and measures every system.
+func runAll(fixtureDir string) (suite, error) {
+	corpus, err := loadCorpus(filepath.Join(fixtureDir, "corpus-v1.jsonl"))
 	if err != nil {
-		fail("load queries: %v", err)
+		return suite{}, fmt.Errorf("load corpus: %w", err)
+	}
+	queries, err := loadQueries(filepath.Join(fixtureDir, "queries-v1.jsonl"))
+	if err != nil {
+		return suite{}, fmt.Errorf("load queries: %w", err)
 	}
 	if err := validateFixtures(corpus, queries); err != nil {
-		fail("fixtures are inconsistent: %v", err)
+		return suite{}, fmt.Errorf("fixtures are inconsistent: %w", err)
 	}
 
-	results := []result{
+	out := suite{Corpus: corpus, Queries: queries}
+	out.FixedK = []result{
 		runFullHistory(corpus, queries),
 		runWindow(corpus, queries, budget),
 	}
 
 	gm, err := runGrayMatter(corpus, queries, "graymatter-fixed-k", "fixed-K", memory.StoreConfig{})
 	if err != nil {
-		fail("graymatter fixed-k: %v", err)
+		return suite{}, fmt.Errorf("graymatter fixed-k: %w", err)
 	}
-	results = append(results, gm)
+	out.FixedK = append(out.FixedK, gm)
 
 	recency, err := runGrayMatter(corpus, queries, "graymatter-recency-only", "fixed-K", memory.StoreConfig{
 		SignalWeights: &memory.SignalWeights{Vector: 0, Keyword: 0, Recency: 1},
 	})
 	if err != nil {
-		fail("graymatter recency-only: %v", err)
+		return suite{}, fmt.Errorf("graymatter recency-only: %w", err)
 	}
-	results = append(results, recency)
+	out.FixedK = append(out.FixedK, recency)
 
-	adaptive, err := runGrayMatter(corpus, queries, "graymatter-adaptive", "adaptive", memory.StoreConfig{
+	out.Adaptive, err = runGrayMatter(corpus, queries, "graymatter-adaptive", "adaptive", memory.StoreConfig{
 		MinRelevance: adaptiveMinRelevance,
 	})
 	if err != nil {
-		fail("graymatter adaptive: %v", err)
+		return suite{}, fmt.Errorf("graymatter adaptive: %w", err)
 	}
-
-	report(corpus, queries, results, adaptive)
+	return out, nil
 }
 
 // ---- systems ---------------------------------------------------------------
@@ -390,7 +422,8 @@ func min(a, b int) int {
 
 // ---- reporting -------------------------------------------------------------
 
-func report(corpus []fact, queries []query, fixedK []result, adaptive result) {
+func report(s suite) {
+	corpus, queries, fixedK, adaptive := s.Corpus, s.Queries, s.FixedK, s.Adaptive
 	var gold, stale int
 	for _, f := range corpus {
 		switch f.Kind {

--- a/benchmarks/retrieval_quality/main.go
+++ b/benchmarks/retrieval_quality/main.go
@@ -1,0 +1,637 @@
+// Command retrieval_quality measures whether GrayMatter returns the *right*
+// facts, against the baseline production actually uses.
+//
+// benchmarks/token_count answers "how many tokens does this save against
+// injecting everything", which is the weakest comparison available: a system
+// returning eight facts at random scores the same 90% reduction, because
+// nothing there checks relevance. This benchmark checks relevance, and
+// compares against a real sliding window rather than against full-history
+// injection alone.
+//
+// Usage:
+//
+//	go run ./benchmarks/retrieval_quality
+//
+// No network, no LLM, no API key. Keyword embedder only, fixtures frozen,
+// insertion order fixed by the corpus file. The predictions this is measured
+// against were committed before it existed — see benchmarks/RESULTS.md and
+// `git log --follow benchmarks/RESULTS.md`.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/benchmarks/internal/tokens"
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+const (
+	agentID = "bench-agent"
+	budget  = 8 // fixed-K budget: GrayMatter TopK and the sliding window size
+
+	// sessionSpan is how far apart two consecutive sessions are placed on the
+	// timeline. One day per session puts the oldest planted fact ~99 days
+	// before the queries, which is what makes recency and relevance disagree.
+	sessionSpan = 24 * time.Hour
+
+	// adaptiveMinRelevance drives the adaptive protocol. Results from this
+	// mode are never compared against a fixed-K baseline: that would measure
+	// the budget rather than the ranking.
+	adaptiveMinRelevance = 0.5
+)
+
+// fact is one line of benchmarks/fixtures/corpus-v1.jsonl.
+type fact struct {
+	ID      string `json:"id"`
+	Session int    `json:"session"`
+	Domain  string `json:"domain"`
+	Kind    string `json:"kind"`
+	Text    string `json:"text"`
+}
+
+// query is one line of benchmarks/fixtures/queries-v1.jsonl.
+type query struct {
+	ID        string   `json:"id"`
+	Domain    string   `json:"domain"`
+	AskedAt   int      `json:"asked_at_session"`
+	Text      string   `json:"text"`
+	Gold      []string `json:"gold"`
+	Forbidden []string `json:"forbidden"`
+}
+
+// result is one system's measured behaviour over the whole query set.
+type result struct {
+	System      string
+	Mode        string // "fixed-K" or "adaptive"
+	HitRate     float64
+	DeadRate    float64
+	AvgTokens   float64
+	AvgReturned float64
+	P50, P95    time.Duration
+	PerQuery    []queryOutcome
+	Returned    map[string][]string // query id -> returned fact ids
+}
+
+// queryOutcome is one query under one system, kept so the report can say which
+// query missed rather than only that something did.
+type queryOutcome struct {
+	QueryID string
+	Hit     bool
+	Dead    bool
+}
+
+func main() {
+	fixtures := flag.String("fixtures", "benchmarks/fixtures", "directory holding corpus-v1.jsonl and queries-v1.jsonl")
+	flag.Parse()
+
+	corpus, err := loadCorpus(filepath.Join(*fixtures, "corpus-v1.jsonl"))
+	if err != nil {
+		fail("load corpus: %v", err)
+	}
+	queries, err := loadQueries(filepath.Join(*fixtures, "queries-v1.jsonl"))
+	if err != nil {
+		fail("load queries: %v", err)
+	}
+	if err := validateFixtures(corpus, queries); err != nil {
+		fail("fixtures are inconsistent: %v", err)
+	}
+
+	results := []result{
+		runFullHistory(corpus, queries),
+		runWindow(corpus, queries, budget),
+	}
+
+	gm, err := runGrayMatter(corpus, queries, "graymatter-fixed-k", "fixed-K", memory.StoreConfig{})
+	if err != nil {
+		fail("graymatter fixed-k: %v", err)
+	}
+	results = append(results, gm)
+
+	recency, err := runGrayMatter(corpus, queries, "graymatter-recency-only", "fixed-K", memory.StoreConfig{
+		SignalWeights: &memory.SignalWeights{Vector: 0, Keyword: 0, Recency: 1},
+	})
+	if err != nil {
+		fail("graymatter recency-only: %v", err)
+	}
+	results = append(results, recency)
+
+	adaptive, err := runGrayMatter(corpus, queries, "graymatter-adaptive", "adaptive", memory.StoreConfig{
+		MinRelevance: adaptiveMinRelevance,
+	})
+	if err != nil {
+		fail("graymatter adaptive: %v", err)
+	}
+
+	report(corpus, queries, results, adaptive)
+}
+
+// ---- systems ---------------------------------------------------------------
+
+// runFullHistory injects everything. Kept for continuity with token_count.
+func runFullHistory(corpus []fact, queries []query) result {
+	return measure("full-history", "fixed-K", queries, func(query) ([]string, time.Duration) {
+		start := time.Now()
+		ids := make([]string, 0, len(corpus))
+		for _, f := range corpus {
+			ids = append(ids, f.ID)
+		}
+		return ids, time.Since(start)
+	}, corpus)
+}
+
+// runWindow is a real sliding window: the last k facts by insertion order,
+// nothing else. Implemented directly rather than simulated with recency-only
+// signal weights, because the recency ablation is used to *check* the claim
+// that a window is a special case of the ranking. Simulating the baseline with
+// the thing under test would assume the conclusion.
+func runWindow(corpus []fact, queries []query, k int) result {
+	ordered := make([]fact, len(corpus))
+	copy(ordered, corpus)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Session < ordered[j].Session })
+
+	return measure(fmt.Sprintf("window-%d", k), "fixed-K", queries, func(query) ([]string, time.Duration) {
+		start := time.Now()
+		from := len(ordered) - k
+		if from < 0 {
+			from = 0
+		}
+		ids := make([]string, 0, k)
+		for _, f := range ordered[from:] {
+			ids = append(ids, f.ID)
+		}
+		return ids, time.Since(start)
+	}, corpus)
+}
+
+// runGrayMatter builds a store from the corpus and measures Recall.
+func runGrayMatter(corpus []fact, queries []query, name, mode string, cfg memory.StoreConfig) (result, error) {
+	dir, err := os.MkdirTemp("", "graymatter-quality-*")
+	if err != nil {
+		return result{}, err
+	}
+	defer os.RemoveAll(dir)
+
+	cfg.DataDir = dir
+	cfg.Embedder = embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
+	if cfg.DecayHalfLife == 0 {
+		cfg.DecayHalfLife = 720 * time.Hour
+	}
+
+	store, err := memory.Open(cfg)
+	if err != nil {
+		return result{}, err
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	textToID, err := seed(ctx, store, corpus)
+	if err != nil {
+		return result{}, err
+	}
+	if err := applySupersede(store, corpus, textToID); err != nil {
+		return result{}, err
+	}
+
+	return measure(name, mode, queries, func(q query) ([]string, time.Duration) {
+		start := time.Now()
+		got, rerr := store.Recall(ctx, agentID, q.Text, budget)
+		elapsed := time.Since(start)
+		if rerr != nil {
+			fail("recall %q: %v", q.ID, rerr)
+		}
+		ids := make([]string, 0, len(got))
+		for _, text := range got {
+			if id, ok := textToID[text]; ok {
+				ids = append(ids, id)
+			}
+		}
+		return ids, elapsed
+	}, corpus), nil
+}
+
+// seed writes the corpus and backdates each fact to its session on the
+// timeline. Timestamps go through the public API — Put, then List and
+// UpdateFact — so this benchmark needs no access to store internals and makes
+// no change to the engine.
+func seed(ctx context.Context, store *memory.Store, corpus []fact) (map[string]string, error) {
+	ordered := make([]fact, len(corpus))
+	copy(ordered, corpus)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Session < ordered[j].Session })
+
+	latest := ordered[len(ordered)-1].Session
+	now := time.Now().UTC()
+
+	for _, f := range ordered {
+		if err := store.Put(ctx, agentID, f.Text); err != nil {
+			return nil, fmt.Errorf("put %s: %w", f.ID, err)
+		}
+	}
+
+	stored, err := store.List(agentID)
+	if err != nil {
+		return nil, err
+	}
+	byText := make(map[string]memory.Fact, len(stored))
+	for _, sf := range stored {
+		byText[sf.Text] = sf
+	}
+
+	textToID := make(map[string]string, len(corpus))
+	for _, f := range ordered {
+		sf, ok := byText[f.Text]
+		if !ok {
+			return nil, fmt.Errorf("fact %s did not survive the write", f.ID)
+		}
+		// Session N sits (latest-N) spans before the query time.
+		at := now.Add(-time.Duration(latest-f.Session) * sessionSpan)
+		sf.CreatedAt = at
+		sf.AccessedAt = at
+		if err := store.UpdateFact(agentID, sf); err != nil {
+			return nil, fmt.Errorf("backdate %s: %w", f.ID, err)
+		}
+		textToID[f.Text] = f.ID
+	}
+	return textToID, nil
+}
+
+// applySupersede tombstones every kind=stale fact, pointing at the
+// kind=replacement fact, exactly as memory_reflect does.
+func applySupersede(store *memory.Store, corpus []fact, textToID map[string]string) error {
+	var replacementText string
+	for _, f := range corpus {
+		if f.Kind == "replacement" {
+			replacementText = f.Text
+		}
+	}
+	stored, err := store.List(agentID)
+	if err != nil {
+		return err
+	}
+	byText := make(map[string]memory.Fact, len(stored))
+	for _, sf := range stored {
+		byText[sf.Text] = sf
+	}
+	replacementID := ""
+	if replacementText != "" {
+		if sf, ok := byText[replacementText]; ok {
+			replacementID = sf.ID
+		}
+	}
+
+	for _, f := range corpus {
+		if f.Kind != "stale" {
+			continue
+		}
+		sf, ok := byText[f.Text]
+		if !ok {
+			return fmt.Errorf("stale fact %s not found in store", f.ID)
+		}
+		sf.SupersededBy = replacementID
+		if sf.SupersededBy == "" {
+			sf.SupersededBy = memory.SupersededByAgent
+		}
+		sf.Weight = 0
+		if err := store.UpdateFact(agentID, sf); err != nil {
+			return fmt.Errorf("supersede %s: %w", f.ID, err)
+		}
+	}
+	return nil
+}
+
+// ---- measurement -----------------------------------------------------------
+
+func measure(name, mode string, queries []query, run func(query) ([]string, time.Duration), corpus []fact) result {
+	byID := make(map[string]fact, len(corpus))
+	for _, f := range corpus {
+		byID[f.ID] = f
+	}
+
+	var hits, dead, totalTokens, totalReturned int
+	latencies := make([]time.Duration, 0, len(queries))
+	outcomes := make([]queryOutcome, 0, len(queries))
+	returned := make(map[string][]string, len(queries))
+
+	for _, q := range queries {
+		ids, elapsed := run(q)
+		latencies = append(latencies, elapsed)
+
+		texts := make([]string, 0, len(ids))
+		for _, id := range ids {
+			texts = append(texts, byID[id].Text)
+		}
+		totalTokens += tokens.ApproxAll(texts)
+		totalReturned += len(ids)
+
+		got := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			got[id] = true
+		}
+		outcome := queryOutcome{QueryID: q.ID}
+		for _, g := range q.Gold {
+			if got[g] {
+				hits++
+				outcome.Hit = true
+				break
+			}
+		}
+		for _, bad := range q.Forbidden {
+			if got[bad] {
+				dead++
+				outcome.Dead = true
+				break
+			}
+		}
+		outcomes = append(outcomes, outcome)
+		returned[q.ID] = ids
+	}
+
+	n := float64(len(queries))
+	p50, p95 := percentiles(latencies)
+	return result{
+		System:      name,
+		Mode:        mode,
+		HitRate:     float64(hits) / n * 100,
+		DeadRate:    float64(dead) / n * 100,
+		AvgTokens:   float64(totalTokens) / n,
+		AvgReturned: float64(totalReturned) / n,
+		P50:         p50,
+		P95:         p95,
+		PerQuery:    outcomes,
+		Returned:    returned,
+	}
+}
+
+func percentiles(d []time.Duration) (p50, p95 time.Duration) {
+	if len(d) == 0 {
+		return 0, 0
+	}
+	s := make([]time.Duration, len(d))
+	copy(s, d)
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	return s[len(s)*50/100], s[min(len(s)*95/100, len(s)-1)]
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// ---- reporting -------------------------------------------------------------
+
+func report(corpus []fact, queries []query, fixedK []result, adaptive result) {
+	var gold, stale int
+	for _, f := range corpus {
+		switch f.Kind {
+		case "gold":
+			gold++
+		case "stale":
+			stale++
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("GrayMatter Retrieval Quality Benchmark")
+	fmt.Println()
+	fmt.Printf("Corpus:   %d facts, %d planted early as gold, %d superseded\n", len(corpus), gold, stale)
+	fmt.Printf("Queries:  %d across %d domains, all asked at the newest session\n", len(queries), countDomains(queries))
+	fmt.Printf("Budget:   %d facts (GrayMatter TopK and sliding-window size)\n", budget)
+	fmt.Printf("Embedder: keyword (no LLM, no network, no API key)\n")
+	fmt.Println()
+
+	fmt.Println("── fixed-K protocol: equal budget, apples to apples ──")
+	fmt.Println()
+	header()
+	for _, r := range fixedK {
+		row(r)
+	}
+	fmt.Println()
+
+	fmt.Println("── adaptive protocol: reported separately, never compared above ──")
+	fmt.Println()
+	fmt.Printf("MinRelevance=%.2f returns a variable number of facts, so comparing it\n", adaptiveMinRelevance)
+	fmt.Println("against a fixed-K baseline would measure the budget, not the ranking.")
+	fmt.Println()
+	header()
+	row(adaptive)
+	fmt.Println()
+
+	perQuery(fixedK, queries)
+	ablationCheck(fixedK)
+
+	fmt.Println("Tokens are words × 1.33, the same approximation ./benchmarks/token_count uses.")
+	fmt.Println("HitRate: queries where a planted gold fact was returned.")
+	fmt.Println("Dead:    queries that returned a fact the store knows is superseded.")
+	fmt.Println()
+}
+
+func header() {
+	fmt.Printf("%-26s  %-9s  %8s  %6s  %9s  %8s  %9s  %9s\n",
+		"System", "Mode", "HitRate", "Dead", "Tokens/q", "Facts/q", "p50", "p95")
+	fmt.Println(strings.Repeat("─", 104))
+}
+
+func row(r result) {
+	fmt.Printf("%-26s  %-9s  %7.0f%%  %5.0f%%  %9.0f  %8.1f  %9s  %9s\n",
+		r.System, r.Mode, r.HitRate, r.DeadRate, r.AvgTokens, r.AvgReturned,
+		r.P50.Round(time.Microsecond), r.P95.Round(time.Microsecond))
+}
+
+func countDomains(queries []query) int {
+	seen := map[string]bool{}
+	for _, q := range queries {
+		seen[q.Domain] = true
+	}
+	return len(seen)
+}
+
+// ---- fixtures --------------------------------------------------------------
+
+func loadCorpus(path string) ([]fact, error) {
+	var out []fact
+	err := eachJSONLine(path, func(line []byte) error {
+		var f fact
+		if err := json.Unmarshal(line, &f); err != nil {
+			return err
+		}
+		out = append(out, f)
+		return nil
+	})
+	return out, err
+}
+
+func loadQueries(path string) ([]query, error) {
+	var out []query
+	err := eachJSONLine(path, func(line []byte) error {
+		var q query
+		if err := json.Unmarshal(line, &q); err != nil {
+			return err
+		}
+		out = append(out, q)
+		return nil
+	})
+	return out, err
+}
+
+func eachJSONLine(path string, fn func([]byte) error) error {
+	fh, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	sc := bufio.NewScanner(fh)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if err := fn([]byte(line)); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+	return sc.Err()
+}
+
+// validateFixtures refuses to run against a corpus that cannot answer its own
+// questions. Silently measuring a HitRate of zero because a gold ID was
+// renamed would look like a finding rather than a broken fixture.
+func validateFixtures(corpus []fact, queries []query) error {
+	ids := make(map[string]bool, len(corpus))
+	texts := make(map[string]bool, len(corpus))
+	for _, f := range corpus {
+		if ids[f.ID] {
+			return fmt.Errorf("duplicate fact id %s", f.ID)
+		}
+		if texts[f.Text] {
+			return fmt.Errorf("duplicate fact text for %s; ids are recovered by text", f.ID)
+		}
+		ids[f.ID] = true
+		texts[f.Text] = true
+	}
+	if len(queries) < 5 {
+		return fmt.Errorf("need at least 5 queries, have %d", len(queries))
+	}
+	if d := countDomains(queries); d < 3 {
+		return fmt.Errorf("need queries from at least 3 domains, have %d", d)
+	}
+	for _, q := range queries {
+		if len(q.Gold) == 0 {
+			return fmt.Errorf("query %s has no gold facts", q.ID)
+		}
+		for _, g := range q.Gold {
+			if !ids[g] {
+				return fmt.Errorf("query %s references unknown gold fact %s", q.ID, g)
+			}
+		}
+		for _, b := range q.Forbidden {
+			if !ids[b] {
+				return fmt.Errorf("query %s references unknown forbidden fact %s", q.ID, b)
+			}
+		}
+	}
+	return nil
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+// perQuery prints the hit/miss grid. An aggregate HitRate says something
+// missed; this says which, which is the part that directs engineering.
+func perQuery(results []result, queries []query) {
+	fmt.Println("── per query (· hit, x miss, D returned a superseded fact) ──")
+	fmt.Println()
+	fmt.Printf("%-26s", "System")
+	for _, q := range queries {
+		fmt.Printf("  %-4s", q.ID)
+	}
+	fmt.Println()
+	fmt.Println(strings.Repeat("─", 26+6*len(queries)))
+	for _, r := range results {
+		fmt.Printf("%-26s", r.System)
+		for _, o := range r.PerQuery {
+			mark := "x"
+			if o.Hit {
+				mark = "·"
+			}
+			if o.Dead {
+				mark += "D"
+			}
+			fmt.Printf("  %-4s", mark)
+		}
+		fmt.Println()
+	}
+	fmt.Println()
+	for _, q := range queries {
+		fmt.Printf("  %-4s [%s] %q\n", q.ID, q.Domain, q.Text)
+	}
+	fmt.Println()
+}
+
+// ablationCheck tests ADR-006 empirically. The ADR claims a sliding window is
+// the special case of this ranking with all weight on recency. window-8 is
+// implemented independently, so if the claim holds the two must return the
+// same facts for every query — and if they diverge, the ADR is wrong and says
+// so here rather than in prose nobody re-checks.
+func ablationCheck(results []result) {
+	var window, ablation *result
+	for i := range results {
+		switch results[i].System {
+		case "window-8":
+			window = &results[i]
+		case "graymatter-recency-only":
+			ablation = &results[i]
+		}
+	}
+	if window == nil || ablation == nil {
+		return
+	}
+
+	fmt.Println("── ADR-006 check: is a sliding window the recency-only special case? ──")
+	fmt.Println()
+	agree := true
+	for qid, wids := range window.Returned {
+		aids, ok := ablation.Returned[qid]
+		if !ok || !sameSet(wids, aids) {
+			agree = false
+			fmt.Printf("  %s: window and recency-only ablation returned different facts\n", qid)
+		}
+	}
+	if agree {
+		fmt.Println("  CONFIRMED: for every query, SignalWeights{0,0,1} returns exactly the")
+		fmt.Println("  facts an independently implemented sliding window returns.")
+	} else {
+		fmt.Println("  NOT CONFIRMED. ADR-006 overstates the equivalence and needs correcting.")
+	}
+	fmt.Println()
+}
+
+func sameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[string]int, len(a))
+	for _, x := range a {
+		m[x]++
+	}
+	for _, x := range b {
+		m[x]--
+		if m[x] < 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/benchmarks/retrieval_quality/main_test.go
+++ b/benchmarks/retrieval_quality/main_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A benchmark whose own arithmetic is untested is a number generator. These
+// tests cover the parts that decide what gets published: that the shipped
+// fixtures are internally consistent, that a broken fixture fails loudly
+// instead of quietly scoring zero, and that the metrics count what they say.
+
+const fixtureDir = "../fixtures"
+
+// TestShippedFixturesAreValid is the guard that matters most. If a gold fact
+// ID were renamed, every HitRate would drop to zero and look like a finding
+// about retrieval rather than a typo in a JSON file.
+func TestShippedFixturesAreValid(t *testing.T) {
+	corpus, err := loadCorpus(filepath.Join(fixtureDir, "corpus-v1.jsonl"))
+	if err != nil {
+		t.Fatalf("load corpus: %v", err)
+	}
+	queries, err := loadQueries(filepath.Join(fixtureDir, "queries-v1.jsonl"))
+	if err != nil {
+		t.Fatalf("load queries: %v", err)
+	}
+	if err := validateFixtures(corpus, queries); err != nil {
+		t.Fatalf("shipped fixtures are inconsistent: %v", err)
+	}
+
+	// The protocol in RESULTS.md rests on these properties; assert them here
+	// so a corpus edit cannot silently invalidate the published method.
+	var gold, stale, replacement int
+	newest := 0
+	for _, f := range corpus {
+		switch f.Kind {
+		case "gold":
+			gold++
+		case "stale":
+			stale++
+		case "replacement":
+			replacement++
+		}
+		if f.Session > newest {
+			newest = f.Session
+		}
+	}
+	if gold < 3 {
+		t.Errorf("need at least 3 planted gold facts, have %d", gold)
+	}
+	if stale == 0 || replacement == 0 {
+		t.Errorf("the contradiction pair is missing: stale=%d replacement=%d", stale, replacement)
+	}
+
+	// Gold facts must be planted early and asked about late, or the benchmark
+	// is not measuring what it claims to measure.
+	for _, f := range corpus {
+		if f.Kind != "gold" {
+			continue
+		}
+		if f.Session > 10 {
+			t.Errorf("gold fact %s is at session %d; it must be planted early to be "+
+				"out of reach of a sliding window", f.ID, f.Session)
+		}
+	}
+	for _, q := range queries {
+		if q.AskedAt < newest-10 {
+			t.Errorf("query %s is asked at session %d but the corpus runs to %d; "+
+				"queries must be late for the window comparison to mean anything",
+				q.ID, q.AskedAt, newest)
+		}
+	}
+}
+
+// TestValidateFixtures_RejectsBrokenFixtures is the regression test for the
+// validator itself.
+func TestValidateFixtures_RejectsBrokenFixtures(t *testing.T) {
+	base := []fact{
+		{ID: "f1", Session: 1, Domain: "a", Kind: "gold", Text: "alpha"},
+		{ID: "f2", Session: 2, Domain: "b", Kind: "filler", Text: "beta"},
+		{ID: "f3", Session: 3, Domain: "c", Kind: "filler", Text: "gamma"},
+	}
+	okQueries := []query{
+		{ID: "q1", Domain: "a", Text: "x", Gold: []string{"f1"}},
+		{ID: "q2", Domain: "b", Text: "x", Gold: []string{"f2"}},
+		{ID: "q3", Domain: "c", Text: "x", Gold: []string{"f3"}},
+		{ID: "q4", Domain: "a", Text: "x", Gold: []string{"f1"}},
+		{ID: "q5", Domain: "b", Text: "x", Gold: []string{"f2"}},
+	}
+	if err := validateFixtures(base, okQueries); err != nil {
+		t.Fatalf("valid fixtures rejected: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		corpus  []fact
+		queries []query
+	}{
+		{
+			name:    "unknown gold id",
+			corpus:  base,
+			queries: append(clone(okQueries[:4]), query{ID: "q5", Domain: "b", Text: "x", Gold: []string{"f99"}}),
+		},
+		{
+			name:    "unknown forbidden id",
+			corpus:  base,
+			queries: append(clone(okQueries[:4]), query{ID: "q5", Domain: "b", Text: "x", Gold: []string{"f2"}, Forbidden: []string{"f99"}}),
+		},
+		{
+			name:    "query with no gold",
+			corpus:  base,
+			queries: append(clone(okQueries[:4]), query{ID: "q5", Domain: "b", Text: "x"}),
+		},
+		{
+			name:    "too few queries",
+			corpus:  base,
+			queries: okQueries[:4],
+		},
+		{
+			name:    "too few domains",
+			corpus:  base,
+			queries: []query{{ID: "q1", Domain: "a", Text: "x", Gold: []string{"f1"}}, {ID: "q2", Domain: "a", Text: "x", Gold: []string{"f1"}}, {ID: "q3", Domain: "a", Text: "x", Gold: []string{"f1"}}, {ID: "q4", Domain: "a", Text: "x", Gold: []string{"f1"}}, {ID: "q5", Domain: "b", Text: "x", Gold: []string{"f1"}}},
+		},
+		{
+			name:    "duplicate fact id",
+			corpus:  append(clone3(base), fact{ID: "f1", Session: 4, Domain: "a", Text: "delta"}),
+			queries: okQueries,
+		},
+		{
+			name: "duplicate fact text",
+			// Fact IDs are recovered from returned text, so two facts sharing
+			// text would make the mapping ambiguous and the metrics wrong.
+			corpus:  append(clone3(base), fact{ID: "f4", Session: 4, Domain: "a", Text: "alpha"}),
+			queries: okQueries,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateFixtures(tc.corpus, tc.queries); err == nil {
+				t.Error("broken fixture accepted; a benchmark run against it would publish nonsense")
+			}
+		})
+	}
+}
+
+// TestMeasure_CountsWhatItClaims pins the metric arithmetic against a system
+// whose answers are fixed by hand.
+func TestMeasure_CountsWhatItClaims(t *testing.T) {
+	corpus := []fact{
+		{ID: "f1", Text: "one two three"},   // 3 words -> 3*1.33 = 3 tokens
+		{ID: "f2", Text: "four five"},       // 2 words
+		{ID: "f3", Text: "six"},             // 1 word
+		{ID: "dead", Text: "stale content"}, // 2 words
+	}
+	queries := []query{
+		{ID: "hit", Gold: []string{"f1"}},
+		{ID: "miss", Gold: []string{"f2"}},
+		{ID: "deadly", Gold: []string{"f3"}, Forbidden: []string{"dead"}},
+	}
+	answers := map[string][]string{
+		"hit":    {"f1"},         // hit, no dead
+		"miss":   {"f3"},         // miss, no dead
+		"deadly": {"f3", "dead"}, // hit AND dead
+	}
+
+	got := measure("stub", "fixed-K", queries, func(q query) ([]string, time.Duration) {
+		return answers[q.ID], time.Millisecond
+	}, corpus)
+
+	if got.HitRate < 66.6 || got.HitRate > 66.7 {
+		t.Errorf("HitRate = %.2f, want 2 of 3 (66.67)", got.HitRate)
+	}
+	if got.DeadRate < 33.3 || got.DeadRate > 33.4 {
+		t.Errorf("DeadRate = %.2f, want 1 of 3 (33.33)", got.DeadRate)
+	}
+	if got.AvgReturned != (1+1+2)/3.0 {
+		t.Errorf("AvgReturned = %.2f, want 1.33", got.AvgReturned)
+	}
+	if len(got.PerQuery) != 3 {
+		t.Fatalf("per-query outcomes = %d, want 3", len(got.PerQuery))
+	}
+	if !got.PerQuery[0].Hit || got.PerQuery[1].Hit || !got.PerQuery[2].Hit {
+		t.Errorf("per-query hits wrong: %+v", got.PerQuery)
+	}
+	if got.PerQuery[0].Dead || got.PerQuery[1].Dead || !got.PerQuery[2].Dead {
+		t.Errorf("per-query dead flags wrong: %+v", got.PerQuery)
+	}
+}
+
+// TestSameSet backs the ADR-006 equivalence check. If this were wrong, the
+// benchmark could report the ADR confirmed when it is not.
+func TestSameSet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"identical", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"reordered", []string{"a", "b"}, []string{"b", "a"}, true},
+		{"different length", []string{"a"}, []string{"a", "b"}, false},
+		{"different members", []string{"a", "b"}, []string{"a", "c"}, false},
+		{"duplicates matter", []string{"a", "a"}, []string{"a", "b"}, false},
+		{"both empty", nil, nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameSet(tc.a, tc.b); got != tc.want {
+				t.Errorf("sameSet(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func clone(qs []query) []query {
+	out := make([]query, len(qs))
+	copy(out, qs)
+	return out
+}
+
+func clone3(fs []fact) []fact {
+	out := make([]fact, len(fs))
+	copy(out, fs)
+	return out
+}

--- a/benchmarks/retrieval_quality/main_test.go
+++ b/benchmarks/retrieval_quality/main_test.go
@@ -225,13 +225,13 @@ func clone3(fs []fact) []fact {
 	return out
 }
 
-// TestReadmeQualityTableMatchesMeasurement gates the numbers README.md
-// publishes from this benchmark.
+// TestReadmeQualityTableMatchesMeasurement gates every number README.md
+// publishes from this benchmark, including the adaptive column.
 //
-// The previous round of work removed a five-fold-wrong token table from
+// An earlier round removed a five-fold-wrong token table from
 // docs/benchmarks.md that had survived several releases because nothing
-// compared it against a run. Publishing a quality table in README.md without
-// gating it would recreate exactly that, one release later.
+// compared it against a run. Publishing a quality table without gating it
+// would recreate that.
 func TestReadmeQualityTableMatchesMeasurement(t *testing.T) {
 	raw, err := os.ReadFile("../../README.md")
 	if err != nil {
@@ -239,17 +239,21 @@ func TestReadmeQualityTableMatchesMeasurement(t *testing.T) {
 	}
 	readme := string(raw)
 
-	suite, err := runAll(fixtureDir)
+	measured, err := runAll(fixtureDir)
 	if err != nil {
 		t.Fatalf("runAll: %v", err)
 	}
-	window, ok := suite.byName("window-8")
+	window, ok := measured.byName("window-8")
 	if !ok {
 		t.Fatal("window-8 missing from the measured suite")
 	}
-	gm, ok := suite.byName("graymatter-fixed-k")
+	gm, ok := measured.byName("graymatter-fixed-k")
 	if !ok {
 		t.Fatal("graymatter-fixed-k missing from the measured suite")
+	}
+	adaptive, ok := measured.byName("graymatter-adaptive")
+	if !ok {
+		t.Fatal("graymatter-adaptive missing from the measured suite")
 	}
 
 	// Each published row, as it appears in README.md, against the measurement.
@@ -259,18 +263,23 @@ func TestReadmeQualityTableMatchesMeasurement(t *testing.T) {
 	}{
 		{
 			label: "HitRate on the planted old fact",
-			row: fmt.Sprintf("| Finds a fact planted 96 sessions ago | %.0f%% | %.0f%% |",
-				window.HitRate, gm.HitRate),
+			row: fmt.Sprintf("| Finds a fact planted 96 sessions ago | %.0f%% | %.0f%% | %.0f%% |",
+				window.HitRate, gm.HitRate, adaptive.HitRate),
 		},
 		{
 			label: "dead-fact rate",
-			row: fmt.Sprintf("| Returns a fact known to be superseded | %.0f%% | %.0f%% |",
-				window.DeadRate, gm.DeadRate),
+			row: fmt.Sprintf("| Returns a fact known to be superseded | %.0f%% | %.0f%% | %.0f%% |",
+				window.DeadRate, gm.DeadRate, adaptive.DeadRate),
 		},
 		{
 			label: "tokens per query",
-			row: fmt.Sprintf("| Tokens per query | %.0f | %.0f |",
-				window.AvgTokens, gm.AvgTokens),
+			row: fmt.Sprintf("| Tokens per query | %.0f | %.0f | %.0f |",
+				window.AvgTokens, gm.AvgTokens, adaptive.AvgTokens),
+		},
+		{
+			label: "facts per query",
+			row: fmt.Sprintf("| Facts per query | %.0f | %.0f | %.0f |",
+				window.AvgReturned, gm.AvgReturned, adaptive.AvgReturned),
 		},
 	} {
 		if !strings.Contains(readme, tc.row) {
@@ -281,13 +290,24 @@ func TestReadmeQualityTableMatchesMeasurement(t *testing.T) {
 		}
 	}
 
-	// The README states GrayMatter costs more per query than a window. That is
-	// a claim about the direction of the result, so it gets checked too: if it
-	// ever reverses, the sentence has to change with it.
+	// The prose around the table states two directional relationships. Both are
+	// checked, so a reversal fails here instead of leaving a stale sentence
+	// standing next to a correct table.
 	if gm.AvgTokens <= window.AvgTokens {
-		t.Errorf("README.md says GrayMatter costs more per query than a window, but "+
-			"the benchmark now measures GrayMatter at %.0f and the window at %.0f. "+
-			"The claim has reversed and the README must be rewritten.",
+		t.Errorf("README.md states GrayMatter costs more per query than a window at "+
+			"equal fact count, but the measurement is GrayMatter %.0f, window %.0f. "+
+			"The relationship reversed; update the sentence.",
 			gm.AvgTokens, window.AvgTokens)
+	}
+	if adaptive.AvgTokens >= window.AvgTokens {
+		t.Errorf("README.md states MinRelevance drops below the window on tokens, but "+
+			"the measurement is adaptive %.0f, window %.0f. "+
+			"The relationship reversed; update the sentence.",
+			adaptive.AvgTokens, window.AvgTokens)
+	}
+	if adaptive.HitRate != gm.HitRate {
+		t.Errorf("README.md states MinRelevance keeps the same recall, but the "+
+			"measurement is adaptive %.0f%% against fixed-K %.0f%%. "+
+			"Update the sentence.", adaptive.HitRate, gm.HitRate)
 	}
 }

--- a/benchmarks/retrieval_quality/main_test.go
+++ b/benchmarks/retrieval_quality/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -220,4 +223,71 @@ func clone3(fs []fact) []fact {
 	out := make([]fact, len(fs))
 	copy(out, fs)
 	return out
+}
+
+// TestReadmeQualityTableMatchesMeasurement gates the numbers README.md
+// publishes from this benchmark.
+//
+// The previous round of work removed a five-fold-wrong token table from
+// docs/benchmarks.md that had survived several releases because nothing
+// compared it against a run. Publishing a quality table in README.md without
+// gating it would recreate exactly that, one release later.
+func TestReadmeQualityTableMatchesMeasurement(t *testing.T) {
+	raw, err := os.ReadFile("../../README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(raw)
+
+	suite, err := runAll(fixtureDir)
+	if err != nil {
+		t.Fatalf("runAll: %v", err)
+	}
+	window, ok := suite.byName("window-8")
+	if !ok {
+		t.Fatal("window-8 missing from the measured suite")
+	}
+	gm, ok := suite.byName("graymatter-fixed-k")
+	if !ok {
+		t.Fatal("graymatter-fixed-k missing from the measured suite")
+	}
+
+	// Each published row, as it appears in README.md, against the measurement.
+	for _, tc := range []struct {
+		label string
+		row   string
+	}{
+		{
+			label: "HitRate on the planted old fact",
+			row: fmt.Sprintf("| Finds a fact planted 96 sessions ago | %.0f%% | %.0f%% |",
+				window.HitRate, gm.HitRate),
+		},
+		{
+			label: "dead-fact rate",
+			row: fmt.Sprintf("| Returns a fact known to be superseded | %.0f%% | %.0f%% |",
+				window.DeadRate, gm.DeadRate),
+		},
+		{
+			label: "tokens per query",
+			row: fmt.Sprintf("| Tokens per query | %.0f | %.0f |",
+				window.AvgTokens, gm.AvgTokens),
+		},
+	} {
+		if !strings.Contains(readme, tc.row) {
+			t.Errorf("README.md does not carry the measured %s.\n"+
+				"  expected row: %s\n"+
+				"Update the table in README.md from `go run ./benchmarks/retrieval_quality`.",
+				tc.label, tc.row)
+		}
+	}
+
+	// The README states GrayMatter costs more per query than a window. That is
+	// a claim about the direction of the result, so it gets checked too: if it
+	// ever reverses, the sentence has to change with it.
+	if gm.AvgTokens <= window.AvgTokens {
+		t.Errorf("README.md says GrayMatter costs more per query than a window, but "+
+			"the benchmark now measures GrayMatter at %.0f and the window at %.0f. "+
+			"The claim has reversed and the README must be rewritten.",
+			gm.AvgTokens, window.AvgTokens)
+	}
 }

--- a/benchmarks/token_count/main.go
+++ b/benchmarks/token_count/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/angelnicolasc/graymatter/benchmarks/internal/tokens"
 	"github.com/angelnicolasc/graymatter/pkg/embedding"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
@@ -131,12 +132,12 @@ var corpus = [100]string{
 // ── Token approximation ───────────────────────────────────────────────────────
 
 // approxTokens estimates GPT-4-class token count for text.
-// Each word contributes ~1.33 tokens on average (accounts for subword splits,
-// punctuation tokens, and whitespace). Matches tiktoken empirically within ±10%
-// for English business prose.
+//
+// The approximation lives in benchmarks/internal/tokens so that this benchmark
+// and benchmarks/retrieval_quality cannot drift into meaning different things
+// by the word "tokens" — docs/benchmarks.md publishes figures from both.
 func approxTokens(text string) int {
-	words := strings.Fields(text)
-	return int(float64(len(words)) * 1.33)
+	return tokens.Approx(text)
 }
 
 // ── Benchmark ─────────────────────────────────────────────────────────────────
@@ -165,73 +166,92 @@ type result struct {
 // in sessionCounts. It is separated from main so the reproducibility test can
 // call it and compare the published tables against freshly measured numbers.
 func runBenchmark() ([]result, error) {
+	// Shuffle insertion order so keyword ranking is not biased by the order
+	// the corpus happens to be written in. Fixed seed: the shuffle is part of
+	// the fixture, not a source of variation.
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec
+	perm := rng.Perm(len(corpus))
+
+	results := make([]result, 0, len(sessionCounts))
+	for _, target := range sessionCounts {
+		r, err := measureAt(target, perm)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+// measureAt builds a fresh store holding exactly `target` observations and
+// takes one measurement from it.
+//
+// Each row gets its own store on purpose. Reusing one store across rows made
+// the benchmark non-reproducible: Recall updates AccessCount and AccessedAt
+// from detached goroutines, so the writebacks from one row were still in
+// flight while the next row was inserting and backdating, and a late writeback
+// restores the whole Fact as it looked when it was read. Measured rate was
+// about one differing run in twenty-five — often enough to publish a number
+// nobody else can reproduce, rare enough that nobody notices why.
+//
+// Recall itself is deterministic: 300 calls against a fixed store return the
+// same result every time. The variance was entirely in how the store was
+// built, which is why the fix belongs here and not in the engine.
+func measureAt(target int, perm []int) (result, error) {
 	dataDir, err := os.MkdirTemp("", "graymatter-bench-*")
 	if err != nil {
-		return nil, fmt.Errorf("mktemp: %w", err)
+		return result{}, fmt.Errorf("mktemp: %w", err)
 	}
 	defer os.RemoveAll(dataDir)
 
-	// Open store with keyword-only embedder — zero LLM calls, deterministic.
 	emb := embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
 	store, err := memory.Open(memory.StoreConfig{
 		DataDir:  dataDir,
 		Embedder: emb,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("open store: %w", err)
+		return result{}, fmt.Errorf("open store: %w", err)
 	}
 	defer store.Close()
 
-	// Shuffle insertion order so keyword ranking isn't biased by recency.
-	rng := rand.New(rand.NewSource(42)) //nolint:gosec
-	perm := rng.Perm(len(corpus))
-
 	ctx := context.Background()
-
-	results := make([]result, 0, len(sessionCounts))
-	inserted := 0
-
-	for _, target := range sessionCounts {
-		// Insert observations up to the target session count.
-		for inserted < target && inserted < len(corpus) {
-			if err := store.Put(ctx, agentID, corpus[perm[inserted]]); err != nil {
-				return nil, fmt.Errorf("put: %w", err)
-			}
-			inserted++
+	for i := 0; i < target && i < len(corpus); i++ {
+		if err := store.Put(ctx, agentID, corpus[perm[i]]); err != nil {
+			return result{}, fmt.Errorf("put: %w", err)
 		}
-
-		// Full injection: ALL stored observations concatenated.
-		allFacts, err := store.List(agentID)
-		if err != nil {
-			return nil, fmt.Errorf("list: %w", err)
-		}
-		var fullTexts []string
-		for _, f := range allFacts {
-			fullTexts = append(fullTexts, f.Text)
-		}
-		fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
-
-		// GrayMatter: recall only top-K most relevant observations.
-		recalled, err := store.Recall(ctx, agentID, query, topK)
-		if err != nil {
-			return nil, fmt.Errorf("recall: %w", err)
-		}
-		recallTokens := approxTokens(strings.Join(recalled, "\n"))
-
-		reduction := 0.0
-		if fullTokens > 0 {
-			reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
-		}
-
-		results = append(results, result{
-			Sessions:     target,
-			FullTokens:   fullTokens,
-			RecallTokens: recallTokens,
-			Reduction:    reduction,
-		})
+	}
+	if err := spreadOverSessions(store); err != nil {
+		return result{}, err
 	}
 
-	return results, nil
+	// Full injection: ALL stored observations concatenated.
+	allFacts, err := store.List(agentID)
+	if err != nil {
+		return result{}, fmt.Errorf("list: %w", err)
+	}
+	fullTexts := make([]string, 0, len(allFacts))
+	for _, f := range allFacts {
+		fullTexts = append(fullTexts, f.Text)
+	}
+	fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
+
+	// GrayMatter: recall only the top-K most relevant observations.
+	recalled, err := store.Recall(ctx, agentID, query, topK)
+	if err != nil {
+		return result{}, fmt.Errorf("recall: %w", err)
+	}
+	recallTokens := approxTokens(strings.Join(recalled, "\n"))
+
+	reduction := 0.0
+	if fullTokens > 0 {
+		reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
+	}
+	return result{
+		Sessions:     target,
+		FullTokens:   fullTokens,
+		RecallTokens: recallTokens,
+		Reduction:    reduction,
+	}, nil
 }
 
 func main() {
@@ -264,4 +284,40 @@ func main() {
 	fmt.Println("Approximation: words × 1.33 ≈ GPT-4 tokens (±10% for English prose).")
 	fmt.Println("With vector embeddings (Ollama / OpenAI / Anthropic) recall precision")
 	fmt.Println("improves further, maintaining similar or better token reduction ratios.")
+}
+
+// spreadOverSessions backdates the stored facts so that session N sits N days
+// before session inserted, one observation per simulated day.
+//
+// Without this the benchmark writes every fact inside the same few
+// milliseconds, and the clock is not that precise: in a 30-fact run, 8 facts
+// routinely share a CreatedAt. Facts with an identical timestamp have an
+// identical recency score, and recall.go turns scores into ranks with
+// sort.Slice, which is not stable — so tied facts receive arbitrary ranks,
+// those ranks feed the fused score, and the final ordering varies between
+// runs. Measured rate on this corpus was roughly one differing run in
+// twenty-five, which is exactly often enough to publish a number nobody can
+// reproduce and rare enough that nobody notices why.
+//
+// One fact per day also matches what the benchmark says it models: a session
+// is a day of agent work, not a microsecond of one.
+//
+// This is a fix to the benchmark, not to the engine. The underlying tie-break
+// in recall.go is still unspecified for facts written in the same instant.
+func spreadOverSessions(store *memory.Store) error {
+	facts, err := store.List(agentID)
+	if err != nil {
+		return fmt.Errorf("list for backdating: %w", err)
+	}
+	now := time.Now().UTC()
+	for i := range facts {
+		// facts is newest-first; index 0 is the most recent session.
+		at := now.Add(-time.Duration(i) * 24 * time.Hour)
+		facts[i].CreatedAt = at
+		facts[i].AccessedAt = at
+		if err := store.UpdateFact(agentID, facts[i]); err != nil {
+			return fmt.Errorf("backdate: %w", err)
+		}
+	}
+	return nil
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -43,18 +43,20 @@ is nothing to cut and the number is 0%. The curve is the result, not the
 
 Stated plainly, because the omissions are larger than the result:
 
-- **Relevance.** The benchmark never checks whether the 8 recalled
+- **Relevance.** This benchmark never checks whether the 8 recalled
   observations are the *right* 8. A system that returned 8 facts at random
-  would score an identical 90% reduction here. Retrieval quality is not
-  measured anywhere in this repository yet.
+  would score an identical 90% reduction here. That is measured separately now
+  — see [retrieval quality](../benchmarks/RESULTS.md).
 - **A realistic baseline.** Full-history injection is the weakest possible
-  comparison. Production systems truncate. A sliding window keeping the last 8
-  observations would cost roughly 8 × ~70 ≈ 560 tokens in steady state —
-  statistically indistinguishable from GrayMatter's ~550–670. **Against a
-  sliding window, GrayMatter does not win on tokens**, and the honest
-  differentiator has to be what a window cannot do: recall a fact from session
-  3 at session 90, and stop returning a fact that has been superseded.
-- **Multiple queries or domains.** One fixed query, one domain.
+  comparison. Production systems truncate. **Against a sliding window,
+  GrayMatter does not win on tokens** — measured, not estimated: at an equal
+  budget of 8 facts it costs *more*, because it returns the facts that answer
+  the query and those are the longer ones. The differentiator is what a window
+  cannot do at any price: recall a fact planted 96 sessions ago, and refuse to
+  return a fact that has been superseded. Both are measured in
+  [RESULTS.md](../benchmarks/RESULTS.md).
+- **Multiple queries or domains.** One fixed query, one domain. The quality
+  benchmark uses six queries across three.
 - **Vector embeddings.** Keyword-only, so the numbers are reproducible without
   an API key. Vector recall changes precision; it is not measured here.
 - **Consolidation.** Runs with consolidation untriggered.
@@ -62,6 +64,20 @@ Stated plainly, because the omissions are larger than the result:
 Earlier revisions of this page published a token table nothing produced, and a
 relevance score no code computed. Both are gone. The tests named at the top
 exist so that neither can come back quietly.
+
+## The other benchmark
+
+Token count is half the question. [`benchmarks/RESULTS.md`](../benchmarks/RESULTS.md)
+holds the other half: whether the facts that come back are the right ones,
+measured against a real sliding window rather than against full-history
+injection, with the predictions committed before the run.
+
+```bash
+go run ./benchmarks/retrieval_quality
+```
+
+One of its three pre-registered predictions failed, and it is written up there
+in full.
 
 ## Reproducing
 

--- a/docs/decisions/004-local-first-single-node.md
+++ b/docs/decisions/004-local-first-single-node.md
@@ -51,9 +51,9 @@ This record is why that sentence is a design constraint rather than modesty.
   another store, never at writing to a shared one.
 - No backup, replication, or point-in-time recovery. The store is a file on
   one disk. `graymatter export` is the recovery story, and it is manual.
-- Anyone evaluating this against Mem0 or Zep on tenancy features is comparing
-  it against something it does not attempt to be. That is a positioning cost,
-  paid deliberately.
+- Tenancy features are out of scope by construction, so a feature-by-feature
+  comparison against a multi-tenant service compares against something this
+  project does not attempt to be.
 - The whole surface stays auditable by one person in an afternoon, which is
   the property the project is actually trading for.
 

--- a/docs/decisions/006-configurable-signal-weights.md
+++ b/docs/decisions/006-configurable-signal-weights.md
@@ -12,10 +12,11 @@ ranking.
 That blocked a claim worth being able to make honestly.
 
 The natural comparison for this kind of system is a **sliding window**: keep
-the last K observations, drop the rest. It is what production systems actually
-do, it costs nothing to implement, and it is the baseline a sceptical reader
-has in mind. The appealing framing is that a sliding window is a *special case*
-of this ranking — the one where all the weight sits on recency.
+the last K observations, drop the rest. It is what production systems do, it
+costs nothing to implement, and it is therefore the reference point any
+retrieval claim has to be measured against. The framing worth testing is that a
+sliding window is a *special case* of this ranking — the one where all the
+weight sits on recency.
 
 With hardcoded weights that framing was false. Not an overstatement: false.
 There was no configuration of GrayMatter that ranked by recency alone, so the
@@ -71,8 +72,8 @@ when it is turned up to 1.0 alone.
 ## Consequences
 
 - A window baseline can be measured without writing one. Any comparison
-  against truncation reconfigures the same code path, so there is no second
-  implementation whose fairness a reader has to take on trust.
+  against truncation reconfigures the same code path, so its fairness is a
+  property of the configuration rather than of a second implementation.
 - Weights are a supported surface now, so a bad combination is a supported way
   to get bad results. `{0, 0, 0}` scores everything zero and returns an
   arbitrary K. Nothing validates this, and nothing should — a caller asking
@@ -98,11 +99,11 @@ rather than implied.
 
 ## Alternatives rejected
 
-- **Keep them hardcoded and make the claim anyway.** Marketing. The exact
-  failure this release exists to remove.
-- **Keep them hardcoded and write a separate window baseline.** Honest and
-  worse: two retrieval paths to keep in step, and a reader still has to trust
-  that the baseline was implemented fairly.
+- **Keep them hardcoded and make the claim anyway.** The claim would describe
+  a configuration that cannot be reached, so it would be untestable.
+- **Keep them hardcoded and write a separate window baseline.** Correct but
+  costlier: two retrieval paths to keep in step, and the baseline's fairness
+  becomes a property of a second implementation rather than of configuration.
 - **A plain struct instead of a pointer.** Ambiguous zero value; see above.
 - **Expose k too.** A knob that cannot change a single-signal ordering.
 - **Presets (`ModeRecent`, `ModeRelevant`) instead of numbers.** Friendlier,

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -113,8 +113,9 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 	// a supersede tombstone (ADR-007) — must stay collectable by pruning
 	// instead of being resurrected by its own recent access time.
 	var decayErrs []error
+	nowT := s.now()
 	for i := range facts {
-		hours := time.Since(facts[i].AccessedAt).Hours()
+		hours := nowT.Sub(facts[i].AccessedAt).Hours()
 		facts[i].Weight = math.Min(facts[i].Weight, math.Exp(-lambda*hours))
 		if err := s.UpdateFact(agentID, facts[i]); err != nil {
 			decayErrs = append(decayErrs, fmt.Errorf("decay fact %s: %w", facts[i].ID, err))

--- a/pkg/memory/fact.go
+++ b/pkg/memory/fact.go
@@ -51,8 +51,11 @@ const SupersededByAgent = "agent"
 func (f Fact) IsSuperseded() bool { return f.SupersededBy != "" }
 
 // newFact creates a Fact with a new ULID and weight=1.0.
-func newFact(agentID, text string, embedding []float32) Fact {
-	now := time.Now().UTC()
+//
+// The timestamp is passed in rather than read here so the caller's clock is
+// the only clock: Store.Put supplies s.now(), which tests can freeze.
+func newFact(agentID, text string, embedding []float32, at time.Time) Fact {
+	now := at.UTC()
 	return Fact{
 		ID:          ulid.Make().String(),
 		AgentID:     agentID,

--- a/pkg/memory/fuzz_test.go
+++ b/pkg/memory/fuzz_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 // FuzzTokenize ensures tokenize never panics on arbitrary Unicode input.
@@ -47,7 +48,7 @@ func FuzzTokenize(f *testing.F) {
 // Run the fuzzer: go test -fuzz=FuzzUnmarshalFact ./pkg/memory/
 func FuzzUnmarshalFact(f *testing.F) {
 	// Seed corpus: valid JSON, truncated JSON, empty, binary garbage.
-	validFact, _ := json.Marshal(newFact("agent", "some text", nil))
+	validFact, _ := json.Marshal(newFact("agent", "some text", nil, time.Now()))
 	seeds := [][]byte{
 		validFact,
 		[]byte(`{}`),

--- a/pkg/memory/golden_test.go
+++ b/pkg/memory/golden_test.go
@@ -1,0 +1,484 @@
+package memory
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+)
+
+// The anti-regression gate.
+//
+// v0.10.0 added two ranking knobs — SignalWeights and MinRelevance — whose
+// defaults are supposed to reproduce v0.9.0 exactly. Unit tests assert that
+// property one behaviour at a time, which catches a knob that is wired wrong
+// but not a change in the ranking underneath them: a different RRF constant, a
+// changed decay floor, a reordered tie-break would all leave those tests green
+// while silently changing what every agent reads.
+//
+// This test freezes the observable output of the engine byte for byte against
+// a committed fixture, with every knob at its zero value.
+//
+// Regenerate deliberately, never reflexively:
+//
+//	go test ./pkg/memory/ -run TestGolden -update
+//
+// A golden diff is the test doing its job. The question to answer before
+// updating is always "did the recorded behaviour change on purpose?"
+//
+// # What each phase is for
+//
+// Every phase exists because mutation testing showed the previous version of
+// this fixture missing a class of change. That record is kept here, because
+// what a golden test cannot catch is the only interesting thing about it.
+//
+//	Phase A — ranking.    Records the fused RRF scores, not just the resulting
+//	                      order. An order-only fixture passed with the default
+//	                      recency weight moved 0.5 -> 0.6 and with the RRF
+//	                      constant k moved 60 -> 50: both change every score,
+//	                      neither reordered the head of this corpus.
+//	Phase B — lifecycle.  One realistic recall, a long idle gap, then
+//	                      Consolidate, sized so facts straddle the 0.01 prune
+//	                      floor. An earlier version recalled everything at full
+//	                      depth, which reset every AccessedAt and left nothing
+//	                      near the floor — the prune threshold could then be
+//	                      moved from 0.01 to 0.7 unnoticed.
+//	Phase C — fallbacks.  Consolidate with a zero half-life, the only way to
+//	                      reach the 720h default inside consolidate.go.
+//	Phase D — tombstones. A superseded fact and two consecutive Consolidate
+//	                      passes. Reaches the supersede filter in Recall and
+//	                      the min() guard in the decay step, neither of which
+//	                      any other phase can touch.
+
+var updateGolden = flag.Bool("update", false, "rewrite the golden fixtures in testdata/golden")
+
+const (
+	goldenDir    = "testdata/golden"
+	goldenAgent  = "golden-agent"
+	goldenTopK   = 5
+	goldenHalfLi = 720 * time.Hour
+
+	// goldenIdleGap is how long the store sits untouched before consolidating.
+	// Chosen so the corpus straddles the prune floor: facts touched by the
+	// preceding recall survive, the oldest untouched ones do not.
+	goldenIdleGap = 180 * 24 * time.Hour
+
+	// The two corpus entries Phase D uses. Named so a corpus edit that removes
+	// them fails loudly instead of quietly skipping the phase.
+	goldenVictimText      = "release tags are signed with the team gpg key before publishing"
+	goldenReplacementText = "the deployment freeze window runs from december 20th to january 2nd"
+)
+
+// goldenQueries spans the corpus's topics so the fixture exercises rankings
+// where different signals dominate, rather than one query whose answer is
+// obvious.
+var goldenQueries = []string{
+	"deployment pipeline release",
+	"office facilities and food",
+	"oncall rotation and incident handling",
+	"gpg",         // matches exactly one fact
+	"nonexistent", // matches none: pure recency ordering
+}
+
+// goldenEpoch is the fixed instant the scripted clock counts from. Any date
+// works; it is pinned so the fixture never depends on when it was generated.
+var goldenEpoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// corpusEntry is one line of testdata/golden/corpus.jsonl. OffsetHours places
+// the fact on the timeline relative to goldenEpoch, so the corpus carries its
+// own timestamps and the fixture does not depend on insertion timing.
+type corpusEntry struct {
+	OffsetHours int    `json:"offset_hours"`
+	Text        string `json:"text"`
+}
+
+// scriptedClock reports goldenEpoch plus a caller-driven offset. It is a
+// scripted clock rather than a frozen one on purpose.
+//
+// A constant clock gives every fact the same CreatedAt. That makes all recency
+// scores equal, and recall.go ranks them with sort.Slice, which is not stable
+// — so the tie order among identically-aged facts is unspecified and may vary
+// between runs or Go versions. A frozen clock would therefore pin the wrong
+// thing: a degenerate ranking regime that never occurs in practice, and it
+// would be flaky while doing it.
+type scriptedClock struct{ offset time.Duration }
+
+func (c *scriptedClock) now() time.Time      { return goldenEpoch.Add(c.offset) }
+func (c *scriptedClock) set(d time.Duration) { c.offset = d }
+
+func TestGolden_EngineAtDefaults(t *testing.T) {
+	compareGolden(t, "engine.golden", buildGoldenFixture(t, true))
+}
+
+// TestGolden_IsStableAcrossRuns proves the fixture is reproducible rather than
+// merely recorded. A golden that drifts between runs is worse than no golden:
+// it trains people to regenerate it without reading the diff.
+func TestGolden_IsStableAcrossRuns(t *testing.T) {
+	first := buildGoldenFixture(t, false)
+	for i := 2; i <= 5; i++ {
+		if got := buildGoldenFixture(t, false); got != first {
+			t.Fatalf("run %d differs from run 1; the fixture is not reproducible.\n%s",
+				i, firstDiff(first, got))
+		}
+	}
+}
+
+func buildGoldenFixture(t *testing.T, withHeader bool) string {
+	t.Helper()
+	corpus := loadGoldenCorpus(t)
+	ctx := context.Background()
+
+	var b strings.Builder
+	if withHeader {
+		b.WriteString("# GrayMatter engine golden fixture\n")
+		b.WriteString("#\n")
+		b.WriteString("# Regenerate: go test ./pkg/memory/ -run TestGolden -update\n")
+		b.WriteString("# A diff here means the default-configuration output of the engine\n")
+		b.WriteString("# changed. That is either a bug or a decision; it is never noise.\n")
+		b.WriteString("#\n")
+		fmt.Fprintf(&b, "# epoch:     %s\n", goldenEpoch.Format(time.RFC3339))
+		fmt.Fprintf(&b, "# half-life: %s\n", goldenHalfLi)
+		b.WriteString("# knobs:     SignalWeights=nil (defaults), MinRelevance=0\n")
+		b.WriteString("#\n")
+		b.WriteString("# Fact IDs are ULIDs seeded from the real clock and random entropy, so\n")
+		b.WriteString("# they cannot be pinned. Facts appear by List position or by text;\n")
+		b.WriteString("# every other value is the stored one, verbatim and unrounded.\n")
+		b.WriteString("\n")
+	}
+
+	b.WriteString(goldenPhaseA(t, ctx, corpus))
+	b.WriteString(goldenPhaseB(t, ctx, corpus))
+	b.WriteString(goldenPhaseC(t, ctx, corpus))
+	b.WriteString(goldenPhaseD(t, ctx, corpus))
+	return b.String()
+}
+
+// goldenPhaseA records the fused score of every candidate for every query,
+// which is what makes the gate sensitive to the ranking knobs themselves.
+func goldenPhaseA(t *testing.T, ctx context.Context, corpus []corpusEntry) string {
+	t.Helper()
+	s, clock := openGoldenStore(t)
+	defer s.Close()
+	seedGoldenCorpus(t, s, clock, corpus)
+
+	byID := factsByID(t, s)
+	var b strings.Builder
+	b.WriteString("== PHASE A: fused ranking (all candidates, scores verbatim) ==\n\n")
+	for _, q := range goldenQueries {
+		var ranked []scored
+		s.debugRanking = func(_ string, r []scored) { ranked = r }
+		got, err := s.Recall(ctx, goldenAgent, q, goldenTopK)
+		if err != nil {
+			t.Fatalf("Recall(%q): %v", q, err)
+		}
+		s.wg.Wait()
+		s.debugRanking = nil
+
+		fmt.Fprintf(&b, "-- query %q\n", q)
+		for i, sc := range ranked {
+			fmt.Fprintf(&b, "  rank=%02d score=%.17g  %s\n", i+1, sc.score, byID[sc.id])
+		}
+		fmt.Fprintf(&b, "  returned at topK=%d: %d\n", goldenTopK, len(got))
+		for i, text := range got {
+			fmt.Fprintf(&b, "    %02d %s\n", i+1, text)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// goldenPhaseB is the realistic lifecycle: one recall, a long idle gap, then
+// Consolidate with facts straddling the prune floor.
+func goldenPhaseB(t *testing.T, ctx context.Context, corpus []corpusEntry) string {
+	t.Helper()
+	s, clock := openGoldenStore(t)
+	defer s.Close()
+	seedGoldenCorpus(t, s, clock, corpus)
+
+	if _, err := s.Recall(ctx, goldenAgent, goldenQueries[0], goldenTopK); err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	s.wg.Wait()
+
+	var b strings.Builder
+	b.WriteString("== PHASE B: store state after one recall ==\n")
+	b.WriteString(snapshotStore(t, s))
+
+	clock.set(clock.offset + goldenIdleGap)
+	if err := s.Consolidate(ctx, goldenAgent, goldenConsolidateCfg{halfLife: goldenHalfLi}); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	s.wg.Wait()
+
+	fmt.Fprintf(&b, "\n== PHASE B: after %s idle, then consolidate ==\n", goldenIdleGap)
+	b.WriteString(snapshotStore(t, s))
+	return b.String()
+}
+
+// goldenPhaseC reaches the 720h fallback inside consolidate.go, which is only
+// used when the config reports a zero half-life.
+func goldenPhaseC(t *testing.T, ctx context.Context, corpus []corpusEntry) string {
+	t.Helper()
+	s, clock := openGoldenStore(t)
+	defer s.Close()
+	seedGoldenCorpus(t, s, clock, corpus)
+	clock.set(clock.offset + goldenIdleGap)
+
+	if err := s.Consolidate(ctx, goldenAgent, goldenConsolidateCfg{halfLife: 0}); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	s.wg.Wait()
+
+	var b strings.Builder
+	b.WriteString("\n== PHASE C: consolidate with half-life 0 (uses the 720h fallback) ==\n")
+	b.WriteString(snapshotStore(t, s))
+	return b.String()
+}
+
+// goldenPhaseD covers the two paths no other phase reaches: the supersede
+// filter in Recall, and the min() guard in the decay step, which only differs
+// from plain assignment once a fact has been decayed or had its weight zeroed.
+func goldenPhaseD(t *testing.T, ctx context.Context, corpus []corpusEntry) string {
+	t.Helper()
+	s, clock := openGoldenStore(t)
+	defer s.Close()
+	seedGoldenCorpus(t, s, clock, corpus)
+
+	facts, err := s.List(goldenAgent)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var victim, replacement *Fact
+	for i := range facts {
+		switch facts[i].Text {
+		case goldenVictimText:
+			victim = &facts[i]
+		case goldenReplacementText:
+			replacement = &facts[i]
+		}
+	}
+	if victim == nil || replacement == nil {
+		t.Fatalf("golden corpus no longer contains the facts phase D supersedes:\n  victim=%q\n  replacement=%q",
+			goldenVictimText, goldenReplacementText)
+	}
+
+	// Retire it the way memory_reflect does: tombstone pointing at the
+	// replacement, weight zeroed so ordinary pruning collects it.
+	victim.SupersededBy = replacement.ID
+	victim.Weight = 0
+	if err := s.UpdateFact(goldenAgent, *victim); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	got, err := s.Recall(ctx, goldenAgent, goldenQueries[0], goldenTopK)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	s.wg.Wait()
+
+	var b strings.Builder
+	b.WriteString("\n== PHASE D: recall with one fact tombstoned ==\n")
+	for i, text := range got {
+		fmt.Fprintf(&b, "  %02d %s\n", i+1, text)
+	}
+
+	// Consolidate twice at the same instant. Decay is defined to be
+	// idempotent, so the second pass must change nothing; without the min()
+	// guard the tombstoned fact's zeroed weight is also handed back.
+	clock.set(clock.offset + goldenIdleGap)
+	for pass := 1; pass <= 2; pass++ {
+		if err := s.Consolidate(ctx, goldenAgent, goldenConsolidateCfg{halfLife: goldenHalfLi}); err != nil {
+			t.Fatalf("Consolidate pass %d: %v", pass, err)
+		}
+		s.wg.Wait()
+		fmt.Fprintf(&b, "\n== PHASE D: after consolidate pass %d ==\n", pass)
+		b.WriteString(snapshotStore(t, s))
+	}
+	return b.String()
+}
+
+// openGoldenStore opens a store with every knob at its zero value. That is the
+// whole point: this fixture records what a caller who configures nothing gets.
+func openGoldenStore(t *testing.T) (*Store, *scriptedClock) {
+	t.Helper()
+	s, err := Open(StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: goldenHalfLi,
+		// SignalWeights: nil
+		// MinRelevance:  0
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	clock := &scriptedClock{}
+	s.now = clock.now
+	return s, clock
+}
+
+// seedGoldenCorpus writes the corpus on its own timeline, so each fact has a
+// distinct age, then advances the clock a week past the last write.
+func seedGoldenCorpus(t *testing.T, s *Store, clock *scriptedClock, corpus []corpusEntry) {
+	t.Helper()
+	ctx := context.Background()
+	for _, e := range corpus {
+		clock.set(time.Duration(e.OffsetHours) * time.Hour)
+		if err := s.Put(ctx, goldenAgent, e.Text); err != nil {
+			t.Fatalf("Put %q: %v", e.Text, err)
+		}
+	}
+	clock.set(time.Duration(corpus[len(corpus)-1].OffsetHours)*time.Hour + 168*time.Hour)
+}
+
+func factsByID(t *testing.T, s *Store) map[string]string {
+	t.Helper()
+	facts, err := s.List(goldenAgent)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	m := make(map[string]string, len(facts))
+	for _, f := range facts {
+		m[f.ID] = f.Text
+	}
+	return m
+}
+
+// snapshotStore renders every stored field a caller can observe. Fact IDs are
+// omitted because ULIDs are not reproducible; every other field is the stored
+// value at full precision.
+func snapshotStore(t *testing.T, s *Store) string {
+	t.Helper()
+	facts, err := s.List(goldenAgent)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(facts) == 0 {
+		return "  (store empty)\n"
+	}
+	var b strings.Builder
+	for i, f := range facts {
+		superseded := "-"
+		if f.IsSuperseded() {
+			superseded = "yes"
+		}
+		fmt.Fprintf(&b, "[%02d] created=%s accessed=%s count=%d weight=%.17g superseded=%s embedding=%d\n",
+			i,
+			f.CreatedAt.UTC().Format(time.RFC3339Nano),
+			f.AccessedAt.UTC().Format(time.RFC3339Nano),
+			f.AccessCount,
+			f.Weight,
+			superseded,
+			len(f.Embedding),
+		)
+		fmt.Fprintf(&b, "     text=%s\n", f.Text)
+	}
+	return b.String()
+}
+
+func loadGoldenCorpus(t *testing.T) []corpusEntry {
+	t.Helper()
+	fh, err := os.Open(filepath.Join(goldenDir, "corpus.jsonl"))
+	if err != nil {
+		t.Fatalf("open golden corpus: %v", err)
+	}
+	defer fh.Close()
+
+	var out []corpusEntry
+	sc := bufio.NewScanner(fh)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		var e corpusEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("corpus line %q: %v", line, err)
+		}
+		out = append(out, e)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("read golden corpus: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("golden corpus is empty")
+	}
+	// Written oldest first; the timeline must be monotonic or the fixture's
+	// meaning depends on file order rather than on the declared offsets.
+	if !sort.SliceIsSorted(out, func(i, j int) bool {
+		return out[i].OffsetHours < out[j].OffsetHours
+	}) {
+		t.Fatal("golden corpus offsets are not strictly increasing")
+	}
+	return out
+}
+
+func compareGolden(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join(goldenDir, name)
+
+	if *updateGolden {
+		if err := os.WriteFile(path, []byte(got), 0o600); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("golden fixture rewritten: %s", path)
+		return
+	}
+
+	wantBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v\nGenerate it with: go test ./pkg/memory/ -run TestGolden -update", path, err)
+	}
+	// Normalise line endings: the repo checks out CRLF on Windows, and the
+	// fixture's content is what is under test, not its line terminators.
+	want := strings.ReplaceAll(string(wantBytes), "\r\n", "\n")
+	got = strings.ReplaceAll(got, "\r\n", "\n")
+
+	if got == want {
+		return
+	}
+	t.Errorf("default-configuration engine output changed.\n\n%s\n\n"+
+		"If this change is intended, regenerate the fixture in the same commit so a\n"+
+		"reviewer sees the behavioural diff:\n"+
+		"    go test ./pkg/memory/ -run TestGolden -update",
+		firstDiff(want, got))
+}
+
+// firstDiff reports the first differing line, because a full dump of two
+// multi-hundred-line fixtures is unreadable in CI output.
+func firstDiff(want, got string) string {
+	wl := strings.Split(want, "\n")
+	gl := strings.Split(got, "\n")
+	for i := 0; i < len(wl) || i < len(gl); i++ {
+		var w, g string
+		if i < len(wl) {
+			w = wl[i]
+		}
+		if i < len(gl) {
+			g = gl[i]
+		}
+		if w != g {
+			return fmt.Sprintf("first difference at line %d:\n  want | %s\n  got  | %s\n(%d golden lines, %d produced)",
+				i+1, w, g, len(wl), len(gl))
+		}
+	}
+	return "files differ only in trailing content"
+}
+
+// goldenConsolidateCfg drives Consolidate deterministically: decay and prune,
+// no LLM, so the fixture needs no network and no key.
+type goldenConsolidateCfg struct{ halfLife time.Duration }
+
+func (goldenConsolidateCfg) GetAnthropicAPIKey() string        { return "" }
+func (goldenConsolidateCfg) GetConsolidateLLM() string         { return "" }
+func (goldenConsolidateCfg) GetConsolidateModel() string       { return "" }
+func (goldenConsolidateCfg) GetConsolidateThreshold() int      { return 100 }
+func (c goldenConsolidateCfg) GetDecayHalfLife() time.Duration { return c.halfLife }

--- a/pkg/memory/golden_test.go
+++ b/pkg/memory/golden_test.go
@@ -150,8 +150,11 @@ func buildGoldenFixture(t *testing.T, withHeader bool) string {
 		b.WriteString("# knobs:     SignalWeights=nil (defaults), MinRelevance=0\n")
 		b.WriteString("#\n")
 		b.WriteString("# Fact IDs are ULIDs seeded from the real clock and random entropy, so\n")
-		b.WriteString("# they cannot be pinned. Facts appear by List position or by text;\n")
-		b.WriteString("# every other value is the stored one, verbatim and unrounded.\n")
+		b.WriteString("# they cannot be pinned. Facts appear by List position or by text.\n")
+		b.WriteString("#\n")
+		b.WriteString("# RRF scores are exact. Weights carry 12 significant digits: math.Exp\n")
+		b.WriteString("# differs by one ulp between arm64 and amd64, which is 1e-16 relative,\n")
+		b.WriteString("# while the smallest change this gate must catch is 1e-1.\n")
 		b.WriteString("\n")
 	}
 
@@ -353,8 +356,29 @@ func factsByID(t *testing.T, s *Store) map[string]string {
 }
 
 // snapshotStore renders every stored field a caller can observe. Fact IDs are
-// omitted because ULIDs are not reproducible; every other field is the stored
-// value at full precision.
+// omitted because ULIDs are not reproducible.
+//
+// Weight is printed at 12 significant digits rather than the full 17, and the
+// reason is architectural rather than cosmetic. Decay calls math.Exp, whose
+// last bit differs between arm64 and amd64. CI caught it:
+//
+//	amd64  weight=0.011571074627238781
+//	arm64  weight=0.011571074627238779
+//
+// a 1-ulp gap, 1.5e-16 relative. Once the clock is controlled that is the only
+// residual variation left, and it is a property of the platform's libm rather
+// than of this code — pinning it would make the fixture assert which CPU ran
+// it.
+//
+// 12 digits is a bound with room on both sides, not a shrug at precision. The
+// noise it absorbs is 1e-16. The smallest change this gate has to catch is the
+// decay half-life moving from 720h to 700h, which shifts weights by 1.2e-1.
+// Four orders of margin above the noise, ten below the signal.
+//
+// Everything else stays exact. The fused RRF scores in Phase A keep full
+// precision: they are sums of w/(k+rank), pure IEEE-754 division of constants
+// by integers, correctly rounded and therefore identical on every
+// architecture.
 func snapshotStore(t *testing.T, s *Store) string {
 	t.Helper()
 	facts, err := s.List(goldenAgent)
@@ -370,7 +394,7 @@ func snapshotStore(t *testing.T, s *Store) string {
 		if f.IsSuperseded() {
 			superseded = "yes"
 		}
-		fmt.Fprintf(&b, "[%02d] created=%s accessed=%s count=%d weight=%.17g superseded=%s embedding=%d\n",
+		fmt.Fprintf(&b, "[%02d] created=%s accessed=%s count=%d weight=%.12g superseded=%s embedding=%d\n",
 			i,
 			f.CreatedAt.UTC().Format(time.RFC3339Nano),
 			f.AccessedAt.UTC().Format(time.RFC3339Nano),

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -80,8 +80,9 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	}
 	lambda := math.Log(2) / halfLife.Hours()
 	recencyScores := make(map[string]float64, len(facts))
+	nowT := s.now()
 	for _, f := range facts {
-		ageDays := time.Since(f.CreatedAt).Hours()
+		ageDays := nowT.Sub(f.CreatedAt).Hours()
 		recencyScores[f.ID] = math.Exp(-lambda * ageDays)
 	}
 	type recEntry struct {
@@ -171,7 +172,7 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 		seen[f.Text] = true
 		// Update access metadata (best-effort, non-blocking).
 		f.AccessCount++
-		f.AccessedAt = time.Now().UTC()
+		f.AccessedAt = nowT.UTC()
 		s.wg.Add(1)
 		go func(fact Fact) {
 			defer s.wg.Done()

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -111,10 +111,6 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 		d := DefaultSignalWeights()
 		w = &d
 	}
-	type scored struct {
-		id    string
-		score float64
-	}
 	candidates := make(map[string]float64, len(facts))
 	for _, f := range facts {
 		rrf := 0.0
@@ -135,6 +131,20 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 		allScored = append(allScored, scored{id, sc})
 	}
 	sort.Slice(allScored, func(i, j int) bool { return allScored[i].score > allScored[j].score })
+
+	// Test-only seam. Nil in production; the golden fixture sets it to freeze
+	// the fused scores themselves rather than only their argmax.
+	//
+	// Recording just the returned order proved far too weak: mutation testing
+	// showed a golden built on order alone passing with the default recency
+	// weight changed from 0.5 to 0.6, and with the RRF constant k changed from
+	// 60 to 50. Both alter every score; neither reordered the head of this
+	// corpus. A gate on ranking knobs has to observe the ranking arithmetic.
+	if s.debugRanking != nil {
+		snapshot := make([]scored, len(allScored))
+		copy(snapshot, allScored)
+		s.debugRanking(query, snapshot)
+	}
 
 	// Optional relevance floor, relative to the best score in this result set.
 	// At the default of 0 every score clears the bar and the slice is
@@ -280,6 +290,13 @@ func tokenize(text string) []string {
 		}
 	}
 	return result
+}
+
+// scored is one fact's fused RRF score. Package-level so the debugRanking
+// seam can hand it to a test without exporting anything.
+type scored struct {
+	id    string
+	score float64
 }
 
 // SignalWeights sets the relative contribution of each retrieval signal to the

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -162,6 +162,12 @@ type Store struct {
 	// clock would report every operation as taking zero.
 	now func() time.Time
 
+	// debugRanking, if non-nil, receives the fused ranking from Recall before
+	// topK truncation. Test-only seam; production never sets it, and nothing
+	// reads it outside pkg/memory. See the call site in recall.go for why the
+	// golden fixture needs the scores and not just the resulting order.
+	debugRanking func(query string, ranked []scored)
+
 	// graph and extractor are set via SetKG after Open().
 	// They are optional; Consolidate and Recall work without them.
 	graph     GraphAccessor

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -142,6 +142,26 @@ type Store struct {
 
 	mu sync.RWMutex
 
+	// now reads the wall clock. It exists so tests can freeze time.
+	//
+	// Three things the store computes are functions of "what time is it":
+	// a new fact's CreatedAt/AccessedAt, the recency signal in Recall, and
+	// the decay exponent in Consolidate. On the real clock all three drift
+	// between runs, which makes byte-for-byte comparison of store output
+	// impossible — and the drift is not float noise: decay is 2^(-dt/30d),
+	// so a second of separation between writing a corpus and consolidating
+	// it moves every weight by ~2.7e-7 relative. That is hundreds of times
+	// larger than any plausible rounding tolerance, so a golden test would
+	// flake rather than hold.
+	//
+	// Set to time.Now by Open() and never nil. Assign before any concurrent
+	// use; it is not guarded, because production never writes it.
+	//
+	// Deliberately NOT used for the elapsed-time measurements that feed
+	// OnRecall and OnPut. Those are stopwatches, not clock reads — a frozen
+	// clock would report every operation as taking zero.
+	now func() time.Time
+
 	// graph and extractor are set via SetKG after Open().
 	// They are optional; Consolidate and Recall work without them.
 	graph     GraphAccessor
@@ -201,6 +221,7 @@ func Open(cfg StoreConfig) (*Store, error) {
 		embedder:       cfg.Embedder,
 		cfg:            cfg,
 		readOnly:       readOnly,
+		now:            time.Now,
 		shutdownCtx:    ctx,
 		shutdownCancel: cancel,
 		sema:           make(chan struct{}, cfg.MaxAsyncConsolidations),
@@ -298,7 +319,7 @@ func (s *Store) Put(ctx context.Context, agentID, text string) error {
 		}
 	}
 
-	f := newFact(agentID, text, emb)
+	f := newFact(agentID, text, emb, s.now())
 	hasEmbedding := len(emb) > 0
 
 	if err := s.db.Update(func(tx *bolt.Tx) error {

--- a/pkg/memory/store_test.go
+++ b/pkg/memory/store_test.go
@@ -100,7 +100,7 @@ func TestUpdateFact_NonExistentBucket(t *testing.T) {
 	s, cleanup := openTestStore(t)
 	defer cleanup()
 
-	f := newFact("ghost-agent", "orphan fact", nil)
+	f := newFact("ghost-agent", "orphan fact", nil, time.Now())
 	if err := s.UpdateFact("ghost-agent", f); err != nil {
 		t.Errorf("UpdateFact on missing bucket should not error: %v", err)
 	}
@@ -448,7 +448,7 @@ func TestReadOnlyStore_MutationsReturnErr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("write open: %v", err)
 	}
-	f := newFact("mut-agent", "original text", nil)
+	f := newFact("mut-agent", "original text", nil, time.Now())
 	_ = rw.Put(context.Background(), "mut-agent", "original text")
 	_ = rw.Close()
 

--- a/pkg/memory/testdata/golden/corpus.jsonl
+++ b/pkg/memory/testdata/golden/corpus.jsonl
@@ -1,0 +1,10 @@
+{"offset_hours":0,"text":"the deployment pipeline runs on kubernetes with argo rollouts"}
+{"offset_hours":72,"text":"database migrations are applied by atlas during deployment"}
+{"offset_hours":144,"text":"the staging deployment cluster is shared between all teams"}
+{"offset_hours":216,"text":"incident retrospectives happen every thursday afternoon"}
+{"offset_hours":288,"text":"the oncall rotation is two weeks per engineer"}
+{"offset_hours":360,"text":"lunch is catered on fridays in the office kitchen"}
+{"offset_hours":432,"text":"parking permits are renewed through the facilities portal"}
+{"offset_hours":504,"text":"the coffee machine on floor two takes whole beans only"}
+{"offset_hours":576,"text":"release tags are signed with the team gpg key before publishing"}
+{"offset_hours":648,"text":"the deployment freeze window runs from december 20th to january 2nd"}

--- a/pkg/memory/testdata/golden/engine.golden
+++ b/pkg/memory/testdata/golden/engine.golden
@@ -1,0 +1,196 @@
+# GrayMatter engine golden fixture
+#
+# Regenerate: go test ./pkg/memory/ -run TestGolden -update
+# A diff here means the default-configuration output of the engine
+# changed. That is either a bug or a decision; it is never noise.
+#
+# epoch:     2026-01-01T00:00:00Z
+# half-life: 720h0m0s
+# knobs:     SignalWeights=nil (defaults), MinRelevance=0
+#
+# Fact IDs are ULIDs seeded from the real clock and random entropy, so
+# they cannot be pinned. Facts appear by List position or by text;
+# every other value is the stored one, verbatim and unrounded.
+
+== PHASE A: fused ranking (all candidates, scores verbatim) ==
+
+-- query "deployment pipeline release"
+  rank=01 score=0.024193548387096774  release tags are signed with the team gpg key before publishing
+  rank=02 score=0.023581336696090797  the deployment freeze window runs from december 20th to january 2nd
+  rank=03 score=0.023536299765807962  the deployment pipeline runs on kubernetes with argo rollouts
+  rank=04 score=0.023119392684610076  database migrations are applied by atlas during deployment
+  rank=05 score=0.02297794117647059  the staging deployment cluster is shared between all teams
+  rank=06 score=0.0079365079365079361  the coffee machine on floor two takes whole beans only
+  rank=07 score=0.0078125  parking permits are renewed through the facilities portal
+  rank=08 score=0.0076923076923076927  lunch is catered on fridays in the office kitchen
+  rank=09 score=0.007575757575757576  the oncall rotation is two weeks per engineer
+  rank=10 score=0.007462686567164179  incident retrospectives happen every thursday afternoon
+  returned at topK=5: 5
+    01 release tags are signed with the team gpg key before publishing
+    02 the deployment freeze window runs from december 20th to january 2nd
+    03 the deployment pipeline runs on kubernetes with argo rollouts
+    04 database migrations are applied by atlas during deployment
+    05 the staging deployment cluster is shared between all teams
+
+-- query "office facilities and food"
+  rank=01 score=0.024085750315258513  lunch is catered on fridays in the office kitchen
+  rank=02 score=0.023941532258064516  parking permits are renewed through the facilities portal
+  rank=03 score=0.0081967213114754103  the deployment freeze window runs from december 20th to january 2nd
+  rank=04 score=0.0080645161290322578  release tags are signed with the team gpg key before publishing
+  rank=05 score=0.0079365079365079361  the coffee machine on floor two takes whole beans only
+  rank=06 score=0.007575757575757576  the oncall rotation is two weeks per engineer
+  rank=07 score=0.007462686567164179  incident retrospectives happen every thursday afternoon
+  rank=08 score=0.0073529411764705881  the staging deployment cluster is shared between all teams
+  rank=09 score=0.007246376811594203  database migrations are applied by atlas during deployment
+  rank=10 score=0.0071428571428571426  the deployment pipeline runs on kubernetes with argo rollouts
+  returned at topK=5: 5
+    01 lunch is catered on fridays in the office kitchen
+    02 parking permits are renewed through the facilities portal
+    03 the deployment freeze window runs from december 20th to january 2nd
+    04 release tags are signed with the team gpg key before publishing
+    05 the coffee machine on floor two takes whole beans only
+
+-- query "oncall rotation and incident handling"
+  rank=01 score=0.023969200198708396  the oncall rotation is two weeks per engineer
+  rank=02 score=0.023591718825228696  incident retrospectives happen every thursday afternoon
+  rank=03 score=0.0081967213114754103  the deployment freeze window runs from december 20th to january 2nd
+  rank=04 score=0.0080645161290322578  release tags are signed with the team gpg key before publishing
+  rank=05 score=0.0079365079365079361  the coffee machine on floor two takes whole beans only
+  rank=06 score=0.0078125  parking permits are renewed through the facilities portal
+  rank=07 score=0.0076923076923076927  lunch is catered on fridays in the office kitchen
+  rank=08 score=0.0073529411764705881  the staging deployment cluster is shared between all teams
+  rank=09 score=0.007246376811594203  database migrations are applied by atlas during deployment
+  rank=10 score=0.0071428571428571426  the deployment pipeline runs on kubernetes with argo rollouts
+  returned at topK=5: 5
+    01 the oncall rotation is two weeks per engineer
+    02 incident retrospectives happen every thursday afternoon
+    03 the deployment freeze window runs from december 20th to january 2nd
+    04 release tags are signed with the team gpg key before publishing
+    05 the coffee machine on floor two takes whole beans only
+
+-- query "gpg"
+  rank=01 score=0.024457958751983078  release tags are signed with the team gpg key before publishing
+  rank=02 score=0.0081967213114754103  the deployment freeze window runs from december 20th to january 2nd
+  rank=03 score=0.0079365079365079361  the coffee machine on floor two takes whole beans only
+  rank=04 score=0.0078125  parking permits are renewed through the facilities portal
+  rank=05 score=0.0076923076923076927  lunch is catered on fridays in the office kitchen
+  rank=06 score=0.007575757575757576  the oncall rotation is two weeks per engineer
+  rank=07 score=0.007462686567164179  incident retrospectives happen every thursday afternoon
+  rank=08 score=0.0073529411764705881  the staging deployment cluster is shared between all teams
+  rank=09 score=0.007246376811594203  database migrations are applied by atlas during deployment
+  rank=10 score=0.0071428571428571426  the deployment pipeline runs on kubernetes with argo rollouts
+  returned at topK=5: 5
+    01 release tags are signed with the team gpg key before publishing
+    02 the deployment freeze window runs from december 20th to january 2nd
+    03 the coffee machine on floor two takes whole beans only
+    04 parking permits are renewed through the facilities portal
+    05 lunch is catered on fridays in the office kitchen
+
+-- query "nonexistent"
+  rank=01 score=0.0081967213114754103  the deployment freeze window runs from december 20th to january 2nd
+  rank=02 score=0.0080645161290322578  release tags are signed with the team gpg key before publishing
+  rank=03 score=0.0079365079365079361  the coffee machine on floor two takes whole beans only
+  rank=04 score=0.0078125  parking permits are renewed through the facilities portal
+  rank=05 score=0.0076923076923076927  lunch is catered on fridays in the office kitchen
+  rank=06 score=0.007575757575757576  the oncall rotation is two weeks per engineer
+  rank=07 score=0.007462686567164179  incident retrospectives happen every thursday afternoon
+  rank=08 score=0.0073529411764705881  the staging deployment cluster is shared between all teams
+  rank=09 score=0.007246376811594203  database migrations are applied by atlas during deployment
+  rank=10 score=0.0071428571428571426  the deployment pipeline runs on kubernetes with argo rollouts
+  returned at topK=5: 5
+    01 the deployment freeze window runs from december 20th to january 2nd
+    02 release tags are signed with the team gpg key before publishing
+    03 the coffee machine on floor two takes whole beans only
+    04 parking permits are renewed through the facilities portal
+    05 lunch is catered on fridays in the office kitchen
+
+== PHASE B: store state after one recall ==
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=1 superseded=- embedding=0
+     text=the deployment freeze window runs from december 20th to january 2nd
+[01] created=2026-01-25T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=1 superseded=- embedding=0
+     text=release tags are signed with the team gpg key before publishing
+[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=1 superseded=- embedding=0
+     text=the coffee machine on floor two takes whole beans only
+[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=1 superseded=- embedding=0
+     text=parking permits are renewed through the facilities portal
+[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=1 superseded=- embedding=0
+     text=lunch is catered on fridays in the office kitchen
+[05] created=2026-01-13T00:00:00Z accessed=2026-01-13T00:00:00Z count=0 weight=1 superseded=- embedding=0
+     text=the oncall rotation is two weeks per engineer
+[06] created=2026-01-10T00:00:00Z accessed=2026-01-10T00:00:00Z count=0 weight=1 superseded=- embedding=0
+     text=incident retrospectives happen every thursday afternoon
+[07] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=1 superseded=- embedding=0
+     text=the staging deployment cluster is shared between all teams
+[08] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=1 superseded=- embedding=0
+     text=database migrations are applied by atlas during deployment
+[09] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=1 superseded=- embedding=0
+     text=the deployment pipeline runs on kubernetes with argo rollouts
+
+== PHASE B: after 4320h0m0s idle, then consolidate ==
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the deployment freeze window runs from december 20th to january 2nd
+[01] created=2026-01-25T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=release tags are signed with the team gpg key before publishing
+[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=0.011571074627238781 superseded=- embedding=0
+     text=the coffee machine on floor two takes whole beans only
+[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+     text=parking permits are renewed through the facilities portal
+[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+     text=lunch is catered on fridays in the office kitchen
+[05] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the staging deployment cluster is shared between all teams
+[06] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=database migrations are applied by atlas during deployment
+[07] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the deployment pipeline runs on kubernetes with argo rollouts
+
+== PHASE C: consolidate with half-life 0 (uses the 720h fallback) ==
+[00] created=2026-01-28T00:00:00Z accessed=2026-01-28T00:00:00Z count=0 weight=0.013291674389857117 superseded=- embedding=0
+     text=the deployment freeze window runs from december 20th to january 2nd
+[01] created=2026-01-25T00:00:00Z accessed=2026-01-25T00:00:00Z count=0 weight=0.012401570718501556 superseded=- embedding=0
+     text=release tags are signed with the team gpg key before publishing
+[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=0.011571074627238781 superseded=- embedding=0
+     text=the coffee machine on floor two takes whole beans only
+[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+     text=parking permits are renewed through the facilities portal
+[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+     text=lunch is catered on fridays in the office kitchen
+
+== PHASE D: recall with one fact tombstoned ==
+  01 the deployment freeze window runs from december 20th to january 2nd
+  02 the deployment pipeline runs on kubernetes with argo rollouts
+  03 database migrations are applied by atlas during deployment
+  04 the staging deployment cluster is shared between all teams
+  05 the coffee machine on floor two takes whole beans only
+
+== PHASE D: after consolidate pass 1 ==
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the deployment freeze window runs from december 20th to january 2nd
+[01] created=2026-01-22T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the coffee machine on floor two takes whole beans only
+[02] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+     text=parking permits are renewed through the facilities portal
+[03] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+     text=lunch is catered on fridays in the office kitchen
+[04] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the staging deployment cluster is shared between all teams
+[05] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=database migrations are applied by atlas during deployment
+[06] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the deployment pipeline runs on kubernetes with argo rollouts
+
+== PHASE D: after consolidate pass 2 ==
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the deployment freeze window runs from december 20th to january 2nd
+[01] created=2026-01-22T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the coffee machine on floor two takes whole beans only
+[02] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+     text=parking permits are renewed through the facilities portal
+[03] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+     text=lunch is catered on fridays in the office kitchen
+[04] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the staging deployment cluster is shared between all teams
+[05] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=database migrations are applied by atlas during deployment
+[06] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+     text=the deployment pipeline runs on kubernetes with argo rollouts

--- a/pkg/memory/testdata/golden/engine.golden
+++ b/pkg/memory/testdata/golden/engine.golden
@@ -9,8 +9,11 @@
 # knobs:     SignalWeights=nil (defaults), MinRelevance=0
 #
 # Fact IDs are ULIDs seeded from the real clock and random entropy, so
-# they cannot be pinned. Facts appear by List position or by text;
-# every other value is the stored one, verbatim and unrounded.
+# they cannot be pinned. Facts appear by List position or by text.
+#
+# RRF scores are exact. Weights carry 12 significant digits: math.Exp
+# differs by one ulp between arm64 and amd64, which is 1e-16 relative,
+# while the smallest change this gate must catch is 1e-1.
 
 == PHASE A: fused ranking (all candidates, scores verbatim) ==
 
@@ -127,33 +130,33 @@
      text=the deployment pipeline runs on kubernetes with argo rollouts
 
 == PHASE B: after 4320h0m0s idle, then consolidate ==
-[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the deployment freeze window runs from december 20th to january 2nd
-[01] created=2026-01-25T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[01] created=2026-01-25T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=release tags are signed with the team gpg key before publishing
-[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=0.011571074627238781 superseded=- embedding=0
+[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=0.0115710746272 superseded=- embedding=0
      text=the coffee machine on floor two takes whole beans only
-[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.0107961943747 superseded=- embedding=0
      text=parking permits are renewed through the facilities portal
-[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.0100732055347 superseded=- embedding=0
      text=lunch is catered on fridays in the office kitchen
-[05] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[05] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the staging deployment cluster is shared between all teams
-[06] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[06] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=database migrations are applied by atlas during deployment
-[07] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[07] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the deployment pipeline runs on kubernetes with argo rollouts
 
 == PHASE C: consolidate with half-life 0 (uses the 720h fallback) ==
-[00] created=2026-01-28T00:00:00Z accessed=2026-01-28T00:00:00Z count=0 weight=0.013291674389857117 superseded=- embedding=0
+[00] created=2026-01-28T00:00:00Z accessed=2026-01-28T00:00:00Z count=0 weight=0.0132916743899 superseded=- embedding=0
      text=the deployment freeze window runs from december 20th to january 2nd
-[01] created=2026-01-25T00:00:00Z accessed=2026-01-25T00:00:00Z count=0 weight=0.012401570718501556 superseded=- embedding=0
+[01] created=2026-01-25T00:00:00Z accessed=2026-01-25T00:00:00Z count=0 weight=0.0124015707185 superseded=- embedding=0
      text=release tags are signed with the team gpg key before publishing
-[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=0.011571074627238781 superseded=- embedding=0
+[02] created=2026-01-22T00:00:00Z accessed=2026-01-22T00:00:00Z count=0 weight=0.0115710746272 superseded=- embedding=0
      text=the coffee machine on floor two takes whole beans only
-[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+[03] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.0107961943747 superseded=- embedding=0
      text=parking permits are renewed through the facilities portal
-[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+[04] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.0100732055347 superseded=- embedding=0
      text=lunch is catered on fridays in the office kitchen
 
 == PHASE D: recall with one fact tombstoned ==
@@ -164,33 +167,33 @@
   05 the coffee machine on floor two takes whole beans only
 
 == PHASE D: after consolidate pass 1 ==
-[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the deployment freeze window runs from december 20th to january 2nd
-[01] created=2026-01-22T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[01] created=2026-01-22T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the coffee machine on floor two takes whole beans only
-[02] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+[02] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.0107961943747 superseded=- embedding=0
      text=parking permits are renewed through the facilities portal
-[03] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+[03] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.0100732055347 superseded=- embedding=0
      text=lunch is catered on fridays in the office kitchen
-[04] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[04] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the staging deployment cluster is shared between all teams
-[05] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[05] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=database migrations are applied by atlas during deployment
-[06] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[06] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the deployment pipeline runs on kubernetes with argo rollouts
 
 == PHASE D: after consolidate pass 2 ==
-[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[00] created=2026-01-28T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the deployment freeze window runs from december 20th to january 2nd
-[01] created=2026-01-22T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[01] created=2026-01-22T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the coffee machine on floor two takes whole beans only
-[02] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.010796194374748247 superseded=- embedding=0
+[02] created=2026-01-19T00:00:00Z accessed=2026-01-19T00:00:00Z count=0 weight=0.0107961943747 superseded=- embedding=0
      text=parking permits are renewed through the facilities portal
-[03] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.010073205534684219 superseded=- embedding=0
+[03] created=2026-01-16T00:00:00Z accessed=2026-01-16T00:00:00Z count=0 weight=0.0100732055347 superseded=- embedding=0
      text=lunch is catered on fridays in the office kitchen
-[04] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[04] created=2026-01-07T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the staging deployment cluster is shared between all teams
-[05] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[05] created=2026-01-04T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=database migrations are applied by atlas during deployment
-[06] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625000000000007 superseded=- embedding=0
+[06] created=2026-01-01T00:00:00Z accessed=2026-02-04T00:00:00Z count=1 weight=0.015625 superseded=- embedding=0
      text=the deployment pipeline runs on kubernetes with argo rollouts


### PR DESCRIPTION
A byte-exact anti-regression gate for the default engine output, and a
retrieval-quality benchmark measured against a real sliding window.

At an equal budget of 8 facts:

| | full-history | window-8 | GrayMatter | GrayMatter + `MinRelevance` |
|---|---|---|---|---|
| Finds a fact planted 96 sessions ago | 100% | 0% | **83%** | **83%** |
| Returns a superseded fact | 17% | 0% | **0%** | **0%** |
| Tokens per query | 1141 | 95 | 114 | **64** |
| Facts per query | 78 | 8 | 8 | 4 |

Method, per-query breakdown and the scoring of all three pre-registered
predictions: [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).

## The gate

Byte-for-byte against a committed fixture, no tolerances on anything the code
controls. That required the clock first: decay is `2^(-dt/30d)`, so a second of
wall-clock separation between writing a corpus and consolidating it moves every
weight by `2.7e-7` relative, above any rounding tolerance small enough to catch
a real change. `Store` gets an unexported `now func() time.Time` — a pure
refactor, four lines of test changed, all arity, no assertion touched.

The fixture was mutation-tested, and the first two versions were insufficient:

| Mutation | v1 (order only) | v2 (+full depth) | final |
|---|---|---|---|
| default recency weight 0.5 → 0.6 | escaped | escaped | **caught** |
| RRF constant k 60 → 50 | escaped | escaped | **caught** |
| default keyword weight 1.0 → 1.1 | caught | caught | **caught** |
| prune floor 0.01 → 0.7 | caught | escaped | **caught** |
| decay fallback 720h → 700h | escaped | escaped | **caught** |
| access counter increment | caught | caught | **caught** |
| drop the `min()` decay guard | escaped | escaped | **caught** |
| disable the supersede filter | escaped | escaped | **caught** |
| `MinRelevance > 0` → `>= 0` | escaped | escaped | escaped — equivalent mutant |

v1 recorded only the top-5 order, which does not constrain the ranking that
produced it; hence an unexported `debugRanking` seam and a fixture storing every
candidate's fused score. v2 recalled at full depth, which reset every
`AccessedAt` and left nothing near the prune floor; hence the four phases. The
last row escapes correctly — with `MinRelevance = 0` the floor is `0 × maxScore`
and no RRF score is negative, so the branch cuts nothing either way.

The clock is scripted rather than frozen: a constant clock gives every fact the
same `CreatedAt`, all recency scores tie, and `sort.Slice` is not stable. Fact
IDs stay out of the fixture, since ULIDs draw on the real clock and entropy no
seam controls.

## The benchmark

Predictions were committed before the benchmark existed;
`git log --follow benchmarks/RESULTS.md` shows the ordering, and the
predictions commit contains no measured values.

- **P1** predicted tokens within ±15% of a window; measured 114 against 95,
  +20%, outside the band. At equal fact count the relevance-selected facts are
  longer than the newest ones, so cost tracks fact length rather than count.
- **P2** predicted window ≈0% and GrayMatter >70%; measured 0% and 83%. The
  stated candidate cause for a low result — recency dominating the fusion at
  its default 0.5 — is not supported: recency-only scores 0%, the default 83%.
  The single miss is q2, where the query contains "roll back" and the fact
  contains "Rollbacks"; the keyword scorer applies no stemming.
- **P3** predicted zero superseded facts; measured 0%, against 17% for
  full-history.

ADR-006 states a sliding window is the special case of this ranking with all
weight on recency. `window-8` is implemented independently, and for every query
`SignalWeights{0,0,1}` returned exactly the same facts. The check runs on every
invocation.

## Three defects found and fixed

1. **`token_count` was not reproducible** — about one run in twenty-five
   differed. `Recall` is not the source (300 calls on a fixed store are
   identical); rows shared a store, and async `AccessedAt` writebacks from one
   row landed while the next was being built. Each row now gets its own store:
   30 consecutive runs identical, published figures unchanged.
2. **The benchmark tests were never running in CI.** CI enumerates test
   packages explicitly and `./benchmarks/...` was in none of them. Now wired,
   verified by editing a README row and confirming the failure.
3. **A cross-architecture float difference**, caught by the CI matrix. macOS
   runners are arm64 and `math.Exp` differs by 1 ulp from amd64 (1.5e-16
   relative). Weights are bounded to 12 significant digits: noise absorbed
   1e-16, smallest catchable change 1e-1. Full mutation battery re-run at the
   reduced precision, all eight still caught. RRF scores keep full precision,
   being exact rational arithmetic.

## Compatibility

No public API change. `now` and `debugRanking` are unexported, nil-safe, and
never set in production.

## Verification

- Both modules green, `-count=1`; `go vet` clean; 3 platforms × 2 Go versions
- Golden gate: 8 of 8 non-equivalent mutations caught
- `token_count` 30/30 identical runs; `retrieval_quality` identical locally and
  in CI
- Every published number gated, each gate verified to fail on drift
- Zero broken relative links

## Follow-ups, not in this PR

1. **The engine tie-break.** `Recall` sorts tied signal scores with
   `sort.Slice`, which is unstable, so facts written in the same instant rank
   nondeterministically. Needs its own change and golden regeneration.
2. **PR-B depends on this PR.** Its acceptance criterion — recall HitRate not
   inferior to the uncurated baseline — cannot be evaluated without this
   benchmark.
