### PR TITLE
fix(memory): order equal-scoring facts deterministically in Recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Recall breaks score ties deterministically (oldest first); previously
+  arbitrary.** The three signal rankings were sorted by score alone, and
+  `sort.Slice` is not stable, so facts that scored equally received arbitrary
+  ranks — and those ranks are what the RRF fusion reads. Six facts written in
+  the same instant produced all six rotations of the result, both across
+  repeated calls on one store and across freshly built stores. The order is now
+  total: descending fused score, then `CreatedAt` ascending, then fact ID.
+  Scores are unchanged; only the resolution of ties. The contract is recorded
+  in [docs/api-stability.md](docs/api-stability.md).
+
+---
+
 ## [0.10.0] - 2026-08-23
 
 A release about claims. Every number this project published, and every

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -43,7 +43,7 @@ Starting with **v0.1.0**, GrayMatter follows a best-effort compatibility policy 
 | `(*Store).ListAgents() ([]string, error)` | |
 | `(*Store).Stats(agentID string) (MemoryStats, error)` | |
 | `(*Store).UpdateFact(agentID string, f Fact) error` | |
-| `(*Store).Recall(ctx, agentID, query string, topK int) ([]string, error)` | |
+| `(*Store).Recall(ctx, agentID, query string, topK int) ([]string, error)` | Result ordering is deterministic — see below |
 | `(*Store).RecallShared(ctx, query string, topK int) ([]string, error)` | |
 | `(*Store).RecallAll(ctx, agentID, query string, topK int) ([]string, error)` | |
 | `(*Store).PutShared(ctx, text string) error` | |
@@ -64,6 +64,26 @@ Starting with **v0.1.0**, GrayMatter follows a best-effort compatibility policy 
 | `ConsolidateConfig` interface | |
 | `GraphAccessor` interface | |
 | `EntityExtractorAccessor` interface | |
+
+### Recall result ordering
+
+**Recall result ordering is deterministic: descending fused score, oldest
+first, then ID.**
+
+The same query against the same store returns the same facts in the same order,
+on every call, on every platform. Facts that score equally are ordered by
+`CreatedAt` ascending, and facts created in the same instant by fact ID
+ascending, which makes the order total.
+
+This is a guarantee callers may rely on. It applies to `Recall`, `RecallShared`
+and `RecallAll`, and to every configuration of `SignalWeights` and
+`MinRelevance`.
+
+Before v0.10.1 the ordering of equal-scoring facts was unspecified in practice:
+the three signal rankings were sorted with a comparator that read only the
+score, and `sort.Slice` is not stable, so tied facts received arbitrary ranks
+which the fusion then read. Nothing about the scores has changed — only the
+resolution of ties.
 
 ### Additions in v0.10.0
 

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -50,6 +50,37 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 		return nil, nil
 	}
 
+	factByID := make(map[string]*Fact, len(facts))
+	for i := range facts {
+		factByID[facts[i].ID] = &facts[i]
+	}
+
+	// rankBefore is the total order every ranking below uses: score
+	// descending, then oldest first, then fact ID.
+	//
+	// Each of the three signal rankings turns scores into ranks, and those
+	// ranks are what the RRF fusion actually reads. Sorting them with a
+	// comparator that only looks at the score leaves the order of equal
+	// scores unspecified — sort.Slice is not stable — so tied facts received
+	// arbitrary ranks, arbitrary ranks produced different fused scores, and
+	// the same query against the same store returned different facts from one
+	// call to the next. With six facts written in the same instant, all six
+	// rotations of the result were observable.
+	//
+	// CreatedAt comes before ID because it is meaningful: when two facts score
+	// the same, the older one has been in the store longer and is the more
+	// established of the two. ID is the final fallback, so the order is total
+	// even for facts created in the same instant.
+	rankBefore := func(aID string, aScore float64, bID string, bScore float64) bool {
+		if aScore != bScore {
+			return aScore > bScore
+		}
+		if fa, fb := factByID[aID], factByID[bID]; fa != nil && fb != nil && !fa.CreatedAt.Equal(fb.CreatedAt) {
+			return fa.CreatedAt.Before(fb.CreatedAt)
+		}
+		return aID < bID
+	}
+
 	// --- Signal 1: vector similarity ---
 	vectorRank := make(map[string]int, topK*2) // factID → rank (1-based)
 	vecResults, _ := s.vectorSearch(ctx, agentID, query, topK*2)
@@ -67,7 +98,9 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	for id, sc := range kwScores {
 		kwSorted = append(kwSorted, kwEntry{id, sc})
 	}
-	sort.Slice(kwSorted, func(i, j int) bool { return kwSorted[i].score > kwSorted[j].score })
+	sort.Slice(kwSorted, func(i, j int) bool {
+		return rankBefore(kwSorted[i].id, kwSorted[i].score, kwSorted[j].id, kwSorted[j].score)
+	})
 	kwRank := make(map[string]int, len(kwSorted))
 	for i, e := range kwSorted {
 		kwRank[e.id] = i + 1
@@ -93,7 +126,9 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	for id, sc := range recencyScores {
 		recSorted = append(recSorted, recEntry{id, sc})
 	}
-	sort.Slice(recSorted, func(i, j int) bool { return recSorted[i].score > recSorted[j].score })
+	sort.Slice(recSorted, func(i, j int) bool {
+		return rankBefore(recSorted[i].id, recSorted[i].score, recSorted[j].id, recSorted[j].score)
+	})
 	recRank := make(map[string]int, len(recSorted))
 	for i, e := range recSorted {
 		recRank[e.id] = i + 1
@@ -130,7 +165,9 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	for id, sc := range candidates {
 		allScored = append(allScored, scored{id, sc})
 	}
-	sort.Slice(allScored, func(i, j int) bool { return allScored[i].score > allScored[j].score })
+	sort.Slice(allScored, func(i, j int) bool {
+		return rankBefore(allScored[i].id, allScored[i].score, allScored[j].id, allScored[j].score)
+	})
 
 	// Test-only seam. Nil in production; the golden fixture sets it to freeze
 	// the fused scores themselves rather than only their argmax.
@@ -159,12 +196,6 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 			}
 		}
 		allScored = allScored[:cut]
-	}
-
-	// Build fact lookup.
-	factByID := make(map[string]*Fact, len(facts))
-	for i := range facts {
-		factByID[facts[i].ID] = &facts[i]
 	}
 
 	// Collect top-k, updating access metadata along the way.

--- a/pkg/memory/tiebreak_test.go
+++ b/pkg/memory/tiebreak_test.go
@@ -1,0 +1,265 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+)
+
+// Recall ranks by fused RRF score, and equal scores used to leave the order
+// unspecified: sort.Slice is not stable, and each of the three signal
+// rankings turns scores into ranks that the fusion then reads. Six facts
+// written in the same instant produced all six rotations of the result, both
+// across repeated calls on one store and across freshly built stores.
+//
+// The order is now total: score descending, then oldest first, then fact ID.
+
+// tiebreakTexts are written in this order and are constructed so every signal
+// ties. They share every scoreable term with the query, so keyword scores are
+// equal; the clock is frozen, so recency scores are equal; the keyword
+// embedder stores no vectors, so there is no vector signal. Only the
+// tie-break can order them.
+var tiebreakTexts = []string{
+	"alpha deployment pipeline note",
+	"bravo deployment pipeline note",
+	"charlie deployment pipeline note",
+	"delta deployment pipeline note",
+	"echo deployment pipeline note",
+	"foxtrot deployment pipeline note",
+}
+
+const tiebreakQuery = "deployment pipeline"
+
+// tiebreakFrozen is the instant every fact in these tests is created at.
+var tiebreakFrozen = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+// newTiebreakStore builds a store whose clock never advances, so every fact
+// shares a CreatedAt and every recency score is identical.
+func newTiebreakStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	s, err := Open(StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.now = func() time.Time { return tiebreakFrozen }
+
+	ctx := context.Background()
+	for _, text := range tiebreakTexts {
+		if err := s.Put(ctx, "tiebreak", text); err != nil {
+			t.Fatalf("Put %q: %v", text, err)
+		}
+	}
+	return s, func() { _ = s.Close() }
+}
+
+// label strips the shared suffix so failures read as "alpha bravo charlie"
+// rather than as six near-identical sentences.
+func label(results []string) string {
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		out = append(out, strings.Fields(r)[0])
+	}
+	return strings.Join(out, " ")
+}
+
+// TestRecall_TieBreakIsDeterministicAcrossCalls covers repeated calls against
+// one store.
+func TestRecall_TieBreakIsDeterministicAcrossCalls(t *testing.T) {
+	s, cleanup := newTiebreakStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	first, err := s.Recall(ctx, "tiebreak", tiebreakQuery, 4)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	s.wg.Wait()
+
+	for i := 2; i <= 150; i++ {
+		got, err := s.Recall(ctx, "tiebreak", tiebreakQuery, 4)
+		if err != nil {
+			t.Fatalf("Recall call %d: %v", i, err)
+		}
+		s.wg.Wait()
+		if label(got) != label(first) {
+			t.Fatalf("call %d returned a different order than call 1\n  call 1: %s\n  call %d: %s",
+				i, label(first), i, label(got))
+		}
+	}
+}
+
+// TestRecall_TieBreakIsDeterministicAcrossStores covers freshly built stores,
+// where the ULIDs differ between runs. Insertion order has to survive that.
+func TestRecall_TieBreakIsDeterministicAcrossStores(t *testing.T) {
+	var first string
+	for i := 1; i <= 25; i++ {
+		s, cleanup := newTiebreakStore(t)
+		got, err := s.Recall(context.Background(), "tiebreak", tiebreakQuery, 4)
+		if err != nil {
+			t.Fatalf("Recall on store %d: %v", i, err)
+		}
+		s.wg.Wait()
+		cleanup()
+
+		if i == 1 {
+			first = label(got)
+			continue
+		}
+		if label(got) != first {
+			t.Fatalf("store %d returned a different order than store 1\n  store 1: %s\n  store %d: %s",
+				i, first, i, label(got))
+		}
+	}
+}
+
+// TestRecall_TieBreakOrdersOldestFirst pins the order itself, not only its
+// stability. A stable-but-wrong order would pass the two tests above.
+//
+// Every signal ties here, so the tie-break decides alone. CreatedAt is equal
+// by construction, which leaves fact ID, and ULIDs increase monotonically
+// within a process — so ascending ID is insertion order. The oldest fact
+// written comes first.
+func TestRecall_TieBreakOrdersOldestFirst(t *testing.T) {
+	s, cleanup := newTiebreakStore(t)
+	defer cleanup()
+
+	got, err := s.Recall(context.Background(), "tiebreak", tiebreakQuery, len(tiebreakTexts))
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	s.wg.Wait()
+
+	want := "alpha bravo charlie delta echo foxtrot"
+	if label(got) != want {
+		t.Errorf("tied facts are not returned oldest-first\n  got:  %s\n  want: %s", label(got), want)
+	}
+}
+
+// TestRecall_TieBreakPrefersOlderCreatedAt covers the middle term of the
+// order: when scores tie but CreatedAt differs, the older fact ranks first.
+//
+// Reaching that term takes care. Backdating a fact under the default weights
+// does not produce a tie — it lowers the fact's recency score, so it ranks
+// lower on merit rather than on the tie-break. The recency weight is therefore
+// set to zero, which leaves CreatedAt with exactly one route into the result:
+// the tie-break inside the keyword ranking, where these facts tie.
+//
+// The fact written last is backdated to be the oldest, so ID order and
+// CreatedAt order disagree. An implementation that compared IDs alone would
+// return it last instead of first.
+func TestRecall_TieBreakPrefersOlderCreatedAt(t *testing.T) {
+	s, err := Open(StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+		SignalWeights: &SignalWeights{Vector: 0, Keyword: 1, Recency: 0},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+	s.now = func() time.Time { return tiebreakFrozen }
+
+	ctx := context.Background()
+	for _, text := range tiebreakTexts {
+		if err := s.Put(ctx, "tiebreak", text); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	facts, err := s.List("tiebreak")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// With a frozen clock List is reverse insertion order, so index 0 is the
+	// last fact written and therefore the highest ULID.
+	highestID := facts[0]
+	highestID.CreatedAt = tiebreakFrozen.Add(-72 * time.Hour)
+	if err := s.UpdateFact("tiebreak", highestID); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	got, err := s.Recall(ctx, "tiebreak", tiebreakQuery, len(tiebreakTexts))
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	s.wg.Wait()
+
+	want := strings.Fields(highestID.Text)[0]
+	if len(got) == 0 {
+		t.Fatal("Recall returned nothing")
+	}
+	if first := strings.Fields(got[0])[0]; first != want {
+		t.Errorf("the oldest fact should rank first when scores tie, even with the highest ID\n"+
+			"  got first:  %s\n  want first: %s\n  full order: %s", first, want, label(got))
+	}
+}
+
+// TestRecall_TieBreakInKeywordRanking covers the keyword ranking specifically.
+//
+// The corpus above cannot reach it. Every fact there contains both query
+// terms, so df equals the fact count and idf is log((n+1)/(df+1)) = log(1) = 0
+// — every keyword score is zero, no fact is scored at all, and the keyword
+// ranking is empty. A tie-break defect there would be invisible, which is what
+// mutation testing showed: reverting that sort to compare scores alone left
+// every test above passing.
+//
+// Here only half the corpus matches the query, so idf is positive and the
+// matching facts score equally and non-zero. The recency weight is set to zero
+// so the keyword ranking is the only thing ordering them.
+func TestRecall_TieBreakInKeywordRanking(t *testing.T) {
+	matching := []string{
+		"alpha deployment pipeline note",
+		"bravo deployment pipeline note",
+		"charlie deployment pipeline note",
+		"delta deployment pipeline note",
+	}
+	unrelated := []string{
+		"echo kitchen catering roster",
+		"foxtrot kitchen catering roster",
+		"golf kitchen catering roster",
+		"hotel kitchen catering roster",
+	}
+
+	recall := func() []string {
+		s, err := Open(StoreConfig{
+			DataDir:       t.TempDir(),
+			Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+			DecayHalfLife: 720 * time.Hour,
+			SignalWeights: &SignalWeights{Vector: 0, Keyword: 1, Recency: 0},
+		})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		defer s.Close()
+		s.now = func() time.Time { return tiebreakFrozen }
+
+		ctx := context.Background()
+		for _, text := range append(append([]string{}, matching...), unrelated...) {
+			if err := s.Put(ctx, "kwtie", text); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+		}
+		got, err := s.Recall(ctx, "kwtie", tiebreakQuery, len(matching))
+		if err != nil {
+			t.Fatalf("Recall: %v", err)
+		}
+		s.wg.Wait()
+		return got
+	}
+
+	want := "alpha bravo charlie delta"
+	for i := 1; i <= 20; i++ {
+		if got := label(recall()); got != want {
+			t.Fatalf("run %d: facts with equal keyword scores are not ordered oldest-first\n"+
+				"  got:  %s\n  want: %s", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Recall turns each signal's scores into ranks, and the RRF fusion reads those
ranks. All three rankings were sorted by score alone, and `sort.Slice` is not
stable, so equal-scoring facts received arbitrary ranks and the fusion computed
different scores between calls.

Measured on a frozen clock with six facts written in the same instant:

```
same store, 200 calls -> 6 distinct orders
25 fresh stores       -> 6 distinct orders
```

All six rotations of the top-4. The published flake in `token_count` was the
same defect at a lower rate.

## The change

The comparator is a total order — score descending, `CreatedAt` ascending, fact
ID ascending — applied to all three rankings rather than only the fused one.
The keyword and recency rankings are where ties actually occur, and their
arbitrary ranks were what varied the fused scores.

Scores are unchanged; only tie resolution. No signature changes.

## Acceptance

| Criterion | Result |
|---|---|
| Goldens stable without regeneration | `engine.golden` unmodified |
| Both benchmarks identical | `token_count` byte-identical; `retrieval_quality` identical on every measured value |
| Control mutation detected | 5 of 5 |

Mutations, each verified to fail the new tests: inverting the `CreatedAt` term,
inverting the ID term, and reverting each of the three sorts to the old
score-only comparator.

## Two test defects found while building this

Reverting the keyword sort was initially **undetected**. The cause was the
corpus: every fact contained both query terms, so `df` equalled the fact count,
`idf = log((n+1)/(df+1)) = log(1) = 0`, and no fact was keyword-scored at all.
A corpus where only half the facts match gives a positive idf and equal
non-zero scores, which reaches that ranking.

An earlier `CreatedAt` test was also unreachable as written: backdating a fact
under the default weights does not produce a tie, it lowers that fact's recency
score. Setting the recency weight to zero leaves `CreatedAt` exactly one route
into the result — the tie-break inside the keyword ranking.

## Contract

`docs/api-stability.md` now states: *Recall result ordering is deterministic:
descending fused score, oldest first, then ID.* It covers `Recall`,
`RecallShared` and `RecallAll` under every `SignalWeights` and `MinRelevance`
configuration.