### PR TITLE
feat(cli): doctor --audit — free auditor for instruction documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **`graymatter doctor --audit [path]`** — free auditor for instruction
+  documents, no store or adoption required. Reports approx token cost per
+  prompt (tokenizer declared in every output), near-duplicate paragraphs
+  (word-5-shingle Jaccard ≥ 0.8), staleness buckets from git blame
+  (≤30d / 31–90d / >90d / uncommitted), size alerts at declared thresholds,
+  and structural conflicts in managed blocks only: unterminated or duplicate
+  graymatter regions, nesting across kinds, and context-block hashes that no
+  longer verify. Semantic contradiction detection is out of scope by design.
+  Human and JSON output; exit code 1 only on failure-level findings.
 - **`graymatter context-sync` (opt-in)** — projects the highest-weight live
   facts into a managed block inside CLAUDE.md / AGENTS.md under an explicit
   token budget (default 512), regenerated on every run. Safety model:

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ graymatter sessions list                          # list managed agent sessions
 graymatter plugin install manifest.json           # install a plugin (sha256 required, asks first)
 graymatter server                                 # REST API server (127.0.0.1:8080)
 graymatter context-sync                           # project top facts into a managed block in AGENTS.md (opt-in)
+graymatter doctor --audit [path]                  # audit any CLAUDE.md/AGENTS.md: tokens, duplicates, staleness, markers
 ```
 
 Global flags: `--dir` (data dir), `--quiet`, `--json`

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -29,8 +29,9 @@ type checkResult struct {
 }
 
 func doctorCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "doctor",
+	var audit bool
+	cmd := &cobra.Command{
+		Use:   "doctor [path]",
 		Short: "Diagnose the GrayMatter setup in this directory",
 		Long: `Checks every link in the chain that makes agent memory work:
 
@@ -40,8 +41,22 @@ func doctorCmd() *cobra.Command {
   4. MCP server wired into at least one client config
   5. CLAUDE.md / AGENTS.md tell the model to use the memory tools
 
-Exit code is 1 only when a check fails outright; warnings exit 0.`,
+With --audit, skips the setup checks and instead audits the instruction
+documents themselves: approx token cost per prompt (tokenizer declared in
+the output), near-duplicate paragraphs, staleness by git blame, size
+alerts at declared thresholds, and structural conflicts in managed
+blocks. Works on any project — no .graymatter directory required.
+Exit code is 1 only when a finding is a failure; warnings exit 0.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if audit {
+				root := "."
+				if len(args) > 0 {
+					root = args[0]
+				}
+				return runDoctorAudit(cmd, root)
+			}
+
 			checks := []checkResult{
 				checkBinaryOnPath(),
 				checkDataDir(dataDir),
@@ -102,6 +117,8 @@ Exit code is 1 only when a check fails outright; warnings exit 0.`,
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&audit, "audit", false, "audit instruction documents (tokens, duplicates, staleness, markers) instead of setup checks")
+	return cmd
 }
 
 func checkBinaryOnPath() checkResult {

--- a/cmd/graymatter/cmd_doctor_audit.go
+++ b/cmd/graymatter/cmd_doctor_audit.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/docaudit"
+)
+
+// runDoctorAudit is the `doctor --audit [path]` mode: a free auditor for
+// instruction documents that requires no store, no daemon and no adoption.
+// It reads, measures, reports — and writes nothing.
+func runDoctorAudit(cmd *cobra.Command, root string) error {
+	rep, err := docaudit.AuditPath(root, docaudit.Options{Now: time.Now()})
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return err
+		}
+	} else {
+		printAuditReport(cmd, rep)
+	}
+	if rep.FailCount > 0 {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func printAuditReport(cmd *cobra.Command, rep *docaudit.Report) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Auditing instruction documents under %q\n\n", rep.Root)
+	fmt.Fprintf(out, "  Tokenizer: %s\n", rep.Tokenizer)
+	for _, t := range rep.Thresholds {
+		fmt.Fprintf(out, "  Threshold: %s\n", t)
+	}
+	fmt.Fprintln(out)
+
+	if len(rep.Files) == 0 {
+		fmt.Fprintln(out, "  No CLAUDE.md / AGENTS.md found at this location; nothing to audit.")
+		return
+	}
+
+	for _, fr := range rep.Files {
+		fmt.Fprintf(out, "%s — %d lines, ~%d tokens/prompt\n", fr.Path, fr.Lines, fr.Tokens)
+		if len(fr.Blocks) > 0 {
+			var parts []string
+			for _, b := range fr.Blocks {
+				s := fmt.Sprintf("%s L%d–L%d", b.Kind, b.Begin, b.End)
+				if b.Verified != nil {
+					if *b.Verified {
+						s += " (verified)"
+					} else {
+						s += " (HASH MISMATCH)"
+					}
+				}
+				parts = append(parts, s)
+			}
+			fmt.Fprintf(out, "  managed blocks: %s\n", join(parts, "; "))
+		} else {
+			fmt.Fprintln(out, "  managed blocks: none")
+		}
+		if len(fr.Duplicates) > 0 {
+			for _, d := range fr.Duplicates {
+				fmt.Fprintf(out, "  near-duplicate: lines %d ↔ %d (Jaccard %.2f)\n", d.ALine, d.BLine, d.Score)
+			}
+		}
+		if st := fr.Staleness; st != nil {
+			switch st.Available {
+			case true:
+				fmt.Fprintf(out, "  staleness: ≤30d %d · 31–90d %d · >90d %d · uncommitted %d (median %.0f days)\n",
+					st.Recent, st.Aging, st.Stale, st.Uncommitted, st.MedianAgeDays)
+			default:
+				fmt.Fprintf(out, "  staleness: unavailable (%s)\n", st.Reason)
+			}
+		}
+		fmt.Fprintln(out)
+	}
+
+	if len(rep.Findings) == 0 {
+		fmt.Fprintln(out, "No findings.")
+		return
+	}
+	glyph := map[docaudit.Severity]string{docaudit.SevInfo: "·", docaudit.SevWarn: "!", docaudit.SevFail: "✗"}
+	for _, f := range rep.Findings {
+		fmt.Fprintf(out, "  %s %-10s %s\n      %s\n", glyph[f.Severity], f.Check, f.File, f.Detail)
+	}
+	fmt.Fprintf(out, "\n%d warning(s), %d failure(s).\n", rep.WarnCount, rep.FailCount)
+}
+
+func join(parts []string, sep string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += sep
+		}
+		out += p
+	}
+	return out
+}

--- a/cmd/graymatter/internal/contextblock/block_test.go
+++ b/cmd/graymatter/internal/contextblock/block_test.go
@@ -230,8 +230,13 @@ func TestGolden_Body(t *testing.T) {
 	if err != nil {
 		t.Fatalf("golden missing; run with -update to write it: %v", err)
 	}
-	if string(want) != got {
-		t.Fatalf("golden mismatch (-want +got):\n--- want\n+++ got\n%s", unifiedish(string(want), got))
+	// Checkouts with autocrlf hand the golden back as CRLF while RenderBody
+	// always emits LF: the contract is content, not line endings, so the
+	// comparison normalises before byte comparison.
+	got = strings.ReplaceAll(got, "\r\n", "\n")
+	wantStr := strings.ReplaceAll(string(want), "\r\n", "\n")
+	if wantStr != got {
+		t.Fatalf("golden mismatch (-want +got):\n--- want\n+++ got\n%s", unifiedish(wantStr, got))
 	}
 	// The oversized fact must be the one dropped: rank priority, not size.
 	if strings.Contains(got, "filler") {

--- a/cmd/graymatter/internal/docaudit/audit.go
+++ b/cmd/graymatter/internal/docaudit/audit.go
@@ -1,0 +1,469 @@
+// Package docaudit implements the free auditor behind `doctor --audit`: it
+// reads instruction documents (CLAUDE.md / AGENTS.md — any markdown file it is
+// pointed at), requires nothing else from the project, and reports what a
+// prompt pays for the file and where that content has gone wrong.
+//
+// Scope discipline, v1: measurement and explicit-marker conflicts only. No
+// semantic analysis of any kind — the tool never claims two sentences
+// contradict each other, because a public false positive there would cost
+// more than every true positive is worth. What it does check, with thresholds
+// declared in every report so nobody has to trust the number:
+//
+//   - cost: approx tokens per prompt, counted by internal/tokens (whitespace
+//     words × 1.33) — the SAME approximation the benchmarks and the
+//     context-sync budget use, deliberately NOT pkg/memory's tokenize(),
+//     which exists for retrieval scoring and undercounts prompt cost by
+//     43–56% (retrieval scoring and cost estimation are different jobs)
+//   - duplication: near-duplicate paragraphs, word-5-shingle Jaccard >= 0.8
+//   - staleness: git-blame line ages, bucketed 30d / 90d / uncommitted
+//   - size: line-count alerts at declared thresholds
+//   - markers: structural conflicts in managed blocks only — unterminated or
+//     duplicated graymatter regions, nesting across kinds, and context-block
+//     hashes that no longer verify against their recorded value
+package docaudit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/contextblock"
+	"github.com/angelnicolasc/graymatter/internal/tokens"
+)
+
+// Declared thresholds. They ship in every Report so a reader can audit the
+// auditor instead of trusting it.
+const (
+	SizeWarnLines   = 500  // a prompt carrying this many lines deserves a look
+	SizeFailLines   = 1500 // three times that: the file is the product now
+	DupThreshold    = 0.8  // conservative Jaccard bar for near-duplicate text
+	MedianStaleDays = 90   // median line age past this warns
+	ShingleSize     = 5    // words per shingle
+)
+
+type Severity string
+
+const (
+	SevInfo Severity = "info"
+	SevWarn Severity = "warn"
+	SevFail Severity = "fail"
+)
+
+type Finding struct {
+	Check    string   `json:"check"`
+	Severity Severity `json:"severity"`
+	File     string   `json:"file"`
+	Detail   string   `json:"detail"`
+}
+
+type Block struct {
+	Kind     string `json:"kind"` // instructions | context
+	Begin    int    `json:"begin_line"`
+	End      int    `json:"end_line"`
+	Verified *bool  `json:"verified,omitempty"` // context blocks only
+}
+
+type DuplicatePair struct {
+	ALine int     `json:"a_line"`
+	BLine int     `json:"b_line"`
+	Score float64 `json:"jaccard"`
+}
+
+type Staleness struct {
+	Available     bool    `json:"available"`
+	Reason        string  `json:"reason_if_unavailable,omitempty"`
+	Recent        int     `json:"lines_le_30d"`
+	Aging         int     `json:"lines_31_90d"`
+	Stale         int     `json:"lines_gt_90d"`
+	Uncommitted   int     `json:"lines_uncommitted"`
+	MedianAgeDays float64 `json:"median_age_days"`
+}
+
+type FileReport struct {
+	Path       string          `json:"path"`
+	Lines      int             `json:"lines"`
+	Tokens     int             `json:"tokens_approx"`
+	Blocks     []Block         `json:"managed_blocks,omitempty"`
+	Duplicates []DuplicatePair `json:"near_duplicates,omitempty"`
+	Staleness  *Staleness      `json:"staleness,omitempty"`
+}
+
+type Report struct {
+	Root       string       `json:"root"`
+	Tokenizer  string       `json:"tokenizer"`
+	Thresholds []string     `json:"declared_thresholds"`
+	Files      []FileReport `json:"files"`
+	Findings   []Finding    `json:"findings"`
+	FailCount  int          `json:"-"`
+	WarnCount  int          `json:"-"`
+}
+
+// Options carries the injected clock for reproducible runs.
+type Options struct {
+	Now time.Time
+}
+
+// AuditPath audits root: a directory is scanned for CLAUDE.md / AGENTS.md,
+// a file path is audited directly. It never opens a store and never writes;
+// a directory with no .graymatter/ audits exactly the same as one with it.
+func AuditPath(root string, opts Options) (*Report, error) {
+	rep := &Report{
+		Root: root,
+		Tokenizer: fmt.Sprintf(
+			"approx tokens = whitespace words x %.2f (GPT-4-class estimate; shared with benchmarks and context-sync budgets)",
+			tokens.PerWord),
+		Thresholds: []string{
+			fmt.Sprintf("size: warn > %d lines, fail > %d lines", SizeWarnLines, SizeFailLines),
+			fmt.Sprintf("duplication: word-%d-shingle Jaccard >= %.2f between paragraphs", ShingleSize, DupThreshold),
+			fmt.Sprintf("staleness: median line age > %d days warns", MedianStaleDays),
+		},
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	if !info.IsDir() {
+		paths = []string{root}
+	} else {
+		for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+			p := filepath.Join(root, name)
+			if _, err := os.Stat(p); err == nil {
+				paths = append(paths, p)
+			}
+		}
+	}
+
+	for _, p := range paths {
+		fr, finds, err := auditFile(p, opts)
+		if err != nil {
+			return nil, err
+		}
+		rep.Files = append(rep.Files, fr)
+		rep.Findings = append(rep.Findings, finds...)
+	}
+	for _, f := range rep.Findings {
+		switch f.Severity {
+		case SevWarn:
+			rep.WarnCount++
+		case SevFail:
+			rep.FailCount++
+		}
+	}
+	return rep, nil
+}
+
+func auditFile(path string, opts Options) (FileReport, []Finding, error) {
+	rep := FileReport{Path: filepath.ToSlash(path)}
+	var finds []Finding
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return rep, nil, err
+	}
+	content := string(data)
+	lines := splitLines(content)
+	rep.Lines = len(lines)
+	rep.Tokens = tokens.Approx(content)
+
+	// --- managed blocks ---------------------------------------------------
+	blocks, markerFinds := auditMarkers(path, content)
+	rep.Blocks = blocks
+	finds = append(finds, markerFinds...)
+
+	// --- duplication ------------------------------------------------------
+	pairs := findDuplicates(lines)
+	rep.Duplicates = pairs
+	for _, d := range pairs {
+		finds = append(finds, Finding{Check: "duplicates", Severity: SevWarn, File: path,
+			Detail: fmt.Sprintf("near-duplicate paragraphs at lines %d and %d (Jaccard %.2f)", d.ALine, d.BLine, d.Score)})
+	}
+
+	// --- size -------------------------------------------------------------
+	switch {
+	case rep.Lines > SizeFailLines:
+		finds = append(finds, Finding{Check: "size", Severity: SevFail, File: path,
+			Detail: fmt.Sprintf("%d lines exceeds the %d-line failure threshold", rep.Lines, SizeFailLines)})
+	case rep.Lines > SizeWarnLines:
+		finds = append(finds, Finding{Check: "size", Severity: SevWarn, File: path,
+			Detail: fmt.Sprintf("%d lines exceeds the %d-line warning threshold", rep.Lines, SizeWarnLines)})
+	}
+
+	// --- staleness --------------------------------------------------------
+	st := stalenessReport(path, lines, opts)
+	rep.Staleness = st
+	if st.Available && st.MedianAgeDays > MedianStaleDays {
+		finds = append(finds, Finding{Check: "staleness", Severity: SevWarn, File: path,
+			Detail: fmt.Sprintf("median line age %.0f days exceeds %d days (%.0f%% of lines older than %dd)",
+				st.MedianAgeDays, MedianStaleDays, pct(st.Stale+st.Aging, rep.Lines), 30)})
+	}
+	return rep, finds, nil
+}
+
+// --- markers -----------------------------------------------------------------
+
+type markerSpan struct {
+	kind  string
+	start int // byte offset
+	end   int // byte offset, exclusive, past the end marker
+}
+
+// auditMarkers inventories every managed region, flags structural conflicts,
+// and verifies context-block hashes. Only explicit-marker conflicts are in
+// scope; semantic contradiction checking is out of scope by design.
+func auditMarkers(path, content string) ([]Block, []Finding) {
+	var blocks []Block
+	var finds []Finding
+
+	kinds := []struct {
+		name   string
+		begin  string
+		end    string
+		verify bool
+	}{
+		{"instructions", "<!-- graymatter:instructions:begin", "<!-- graymatter:instructions:end -->", false},
+		{"context", contextblock.BeginMarker, contextblock.EndMarker, true},
+	}
+
+	type rawSpan struct {
+		kind  string
+		begin int // byte offset just past the begin marker
+		end   int // byte offset of end-marker start
+	}
+	var all []rawSpan
+
+	for _, k := range kinds {
+		spans, orphans, unterminated := scanPairs(content, k.begin, k.end)
+		if orphans > 0 {
+			finds = append(finds, Finding{Check: "markers", Severity: SevFail, File: path,
+				Detail: fmt.Sprintf("%d orphaned %q begin marker(s) without an end marker", orphans, k.name)})
+		}
+		if unterminated {
+			finds = append(finds, Finding{Check: "markers", Severity: SevFail, File: path,
+				Detail: fmt.Sprintf("an unterminated %q block runs to end of file", k.name)})
+		}
+		if len(spans) > 1 {
+			finds = append(finds, Finding{Check: "markers", Severity: SevWarn, File: path,
+				Detail: fmt.Sprintf("%d duplicate %q managed blocks; tools will rewrite the first and leave the rest stale", len(spans), k.name)})
+		}
+		for i, s := range spans {
+			b := Block{Kind: k.name, Begin: byteToLine(content, s[0]), End: byteToLine(content, s[1])}
+			if k.verify {
+				v := verifyContextBlock(content[s[0]:s[1]])
+				b.Verified = &v
+				if !v {
+					finds = append(finds, Finding{Check: "markers", Severity: SevWarn, File: path,
+						Detail: fmt.Sprintf("context block #%d was edited by hand since its last sync (hash mismatch)", i+1)})
+				}
+			}
+			blocks = append(blocks, b)
+			all = append(all, rawSpan{kind: k.name, begin: s[0], end: s[1]})
+		}
+	}
+
+	// Nesting across kinds: one managed region inside another means two tools
+	// believe they own overlapping bytes and will fight on rewrite.
+	sort.Slice(all, func(i, j int) bool { return all[i].begin < all[j].begin })
+	for i := 1; i < len(all); i++ {
+		if all[i].begin < all[i-1].end {
+			finds = append(finds, Finding{Check: "markers", Severity: SevFail, File: path,
+				Detail: fmt.Sprintf("nested managed blocks: %q region sits inside a %q region",
+					all[i].kind, all[i-1].kind)})
+		}
+	}
+	return blocks, finds
+}
+
+// scanPairs pairs begin/end markers non-greedily and reports how many begins
+// were orphaned plus whether any begin ran to EOF without an end.
+func scanPairs(content, beginMarker, endMarker string) (spans [][2]int, orphans int, unterminated bool) {
+	for off := 0; off < len(content); {
+		rel := strings.Index(content[off:], beginMarker)
+		if rel < 0 {
+			break
+		}
+		beginStart := off + rel
+		after := beginStart + len(beginMarker)
+
+		endRel := strings.Index(content[after:], endMarker)
+		if endRel < 0 {
+			unterminated = true
+			break
+		}
+		endStart := after + endRel
+		endEnd := endStart + len(endMarker)
+
+		if nextRel := strings.Index(content[after:], beginMarker); nextRel >= 0 && after+nextRel < endStart {
+			orphans++
+			off = after
+			continue
+		}
+		spans = append(spans, [2]int{beginStart, endEnd})
+		off = endEnd
+	}
+	return spans, orphans, unterminated
+}
+
+// verifyContextBlock re-checks the recorded SHA-256 of a context block body
+// using the same parser context-sync wrote it with.
+func verifyContextBlock(inner string) bool {
+	_, _, verified, found := contextblock.Parse(contextblock.BeginMarker + inner)
+	if !found {
+		return false
+	}
+	return verified
+}
+
+func byteToLine(content string, off int) int {
+	return 1 + strings.Count(content[:off], "\n")
+}
+
+// --- duplication ---------------------------------------------------------------
+
+type paragraph struct {
+	startLine int
+	shingles  map[string]struct{}
+}
+
+// findDuplicates splits the document into blank-line-separated paragraphs and
+// reports every pair whose word-shingle Jaccard similarity reaches the
+// threshold. Paragraphs too short to produce a single shingle do not
+// participate at all: repeated one-liners (headings, bullet labels, fence
+// markers) are normal in instruction files, and flagging them would spend the
+// tool's credibility on noise.
+func findDuplicates(lines []string) []DuplicatePair {
+	paras := buildParagraphs(lines)
+	var out []DuplicatePair
+	for i := 0; i < len(paras); i++ {
+		for j := i + 1; j < len(paras); j++ {
+			score := jaccard(paras[i], paras[j])
+			if score >= DupThreshold {
+				out = append(out, DuplicatePair{ALine: paras[i].startLine, BLine: paras[j].startLine, Score: score})
+			}
+		}
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a].ALine < out[b].ALine })
+	return out
+}
+
+func buildParagraphs(lines []string) []paragraph {
+	var paras []paragraph
+	var cur []string
+	start := 0
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		p := makeParagraph(start, cur)
+		if p != nil {
+			paras = append(paras, *p)
+		}
+		cur = nil
+	}
+	for idx, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			flush()
+			continue
+		}
+		if len(cur) == 0 {
+			start = idx + 1
+		}
+		cur = append(cur, ln)
+	}
+	flush()
+	return paras
+}
+
+func makeParagraph(startLine int, lines []string) *paragraph {
+	text := normalizeWords(strings.Join(lines, " "))
+	words := strings.Fields(text)
+	if len(words) < ShingleSize {
+		return nil // too short to shingle: excluded, never flagged
+	}
+	p := &paragraph{startLine: startLine}
+	p.shingles = make(map[string]struct{}, len(words))
+	for i := 0; i+ShingleSize <= len(words); i++ {
+		p.shingles[strings.Join(words[i:i+ShingleSize], " ")] = struct{}{}
+	}
+	return p
+}
+
+func jaccard(a, b paragraph) float64 {
+	inter := 0
+	for s := range a.shingles {
+		if _, ok := b.shingles[s]; ok {
+			inter++
+		}
+	}
+	union := len(a.shingles) + len(b.shingles) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// normalizeWords lowercases and strips punctuation so "Deploy." matches
+// "deploy".
+func normalizeWords(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			return unicode.ToLower(r)
+		default:
+			return ' '
+		}
+	}, s)
+}
+
+// --- staleness ---------------------------------------------------------------
+
+func stalenessReport(path string, lines []string, opts Options) *Staleness {
+	st := &Staleness{}
+	dates, reason, err := blameDates(path)
+	if err != nil {
+		st.Reason = reason
+		return st
+	}
+
+	var ages []float64
+	for _, t := range dates {
+		if t.IsZero() {
+			st.Uncommitted++
+			continue
+		}
+		ageDays := opts.Now.Sub(t).Hours() / 24
+		ages = append(ages, ageDays)
+		switch {
+		case ageDays <= 30:
+			st.Recent++
+		case ageDays <= 90:
+			st.Aging++
+		default:
+			st.Stale++
+		}
+	}
+	st.Available = true
+	if len(ages) > 0 {
+		sort.Float64s(ages)
+		st.MedianAgeDays = ages[len(ages)/2]
+	}
+	return st
+}
+
+func pct(part, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(part) / float64(total) * 100
+}
+
+func splitLines(content string) []string {
+	s := strings.ReplaceAll(content, "\r\n", "\n")
+	return strings.Split(s, "\n")
+}

--- a/cmd/graymatter/internal/docaudit/audit_test.go
+++ b/cmd/graymatter/internal/docaudit/audit_test.go
@@ -1,0 +1,417 @@
+package docaudit
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/contextblock"
+)
+
+var auditOpts = Options{Now: time.Now()}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func severities(rep *Report) map[string][]Severity {
+	m := map[string][]Severity{}
+	for _, f := range rep.Findings {
+		m[f.Check] = append(m[f.Check], f.Severity)
+	}
+	return m
+}
+
+const cleanBody = `# Project guide
+
+Use table-driven tests for anything with more than two cases.
+Deployments go through the staging pipeline before production.
+The latency budget for the search path is 300 milliseconds.
+
+## Conventions
+
+Commits follow the conventional-commit format with package scopes.
+Reviews require one approval from an owner of the touched module.
+Feature flags are removed within two weeks of full rollout.
+`
+
+func TestAudit_CleanDocumentHasNoFindings(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Guide\n\n"+cleanBody)
+	rep, err := AuditPath(dir, auditOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range rep.Findings {
+		if f.Severity == SevWarn || f.Severity == SevFail {
+			t.Errorf("clean document produced %s finding: %+v", f.Severity, f)
+		}
+	}
+}
+
+func TestAudit_PlantedDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	dup := strings.Repeat("The migration tool replays journal entries in strict chronological order every night.\n\n", 2)
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Ops\n\n"+dup+"\nUnrelated closing paragraph with entirely different vocabulary about testing.\n")
+	rep, err := AuditPath(dir, auditOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(severities(rep)["duplicates"]) != 1 {
+		t.Fatalf("planted duplicate not detected: %+v", rep.Findings)
+	}
+}
+
+func TestAudit_SizeThresholds(t *testing.T) {
+	dir := t.TempDir()
+
+	warnDoc := "# Big\n" + strings.Repeat("Line with some ordinary words to fill space.\n", 600)
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), warnDoc)
+	rep, _ := AuditPath(dir, auditOpts)
+	found := false
+	for _, f := range rep.Findings {
+		if f.Check == "size" && f.Severity == SevWarn {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("600-line document did not produce a size warning")
+	}
+
+	failDoc := "# Bigger\n" + strings.Repeat("Line with some ordinary words to fill space.\n", 1600)
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), failDoc)
+	rep, _ = AuditPath(dir, auditOpts)
+	found = false
+	for _, f := range rep.Findings {
+		if f.Check == "size" && f.Severity == SevFail {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("1600-line document did not produce a size failure")
+	}
+}
+
+func TestAudit_MarkerDefects(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name       string
+		content    string
+		wantSev    Severity
+		wantDetail string
+	}{
+		{
+			name: "orphan begin marker",
+			content: "text\n" +
+				"<!-- graymatter:instructions:begin — managed -->\nuser bytes that were never inside a block\n" +
+				"<!-- graymatter:instructions:begin — managed by init; edits inside this block are overwritten -->\npaired\n<!-- graymatter:instructions:end -->\n",
+			wantSev:    SevFail,
+			wantDetail: "orphaned",
+		},
+		{
+			name: "duplicate instructions blocks",
+			content: "first\n" +
+				"<!-- graymatter:instructions:begin — managed by init; edits inside this block are overwritten -->\nbody\n<!-- graymatter:instructions:end -->\n" +
+				"middle\n" +
+				"<!-- graymatter:instructions:begin — managed by init; edits inside this block are overwritten -->\nbody again\n<!-- graymatter:instructions:end -->\n",
+			wantSev:    SevWarn,
+			wantDetail: "duplicate",
+		},
+		{
+			name: "nested managed regions",
+			content: "<!-- graymatter:instructions:begin — managed by init; edits inside this block are overwritten -->\n" +
+				contextblock.BeginMarker + "\ninner\n" + contextblock.EndMarker + "\n" +
+				"<!-- graymatter:instructions:end -->\n",
+			wantSev:    SevFail,
+			wantDetail: "nested",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeFile(t, filepath.Join(dir, "AGENTS.md"), tc.content)
+			rep, err := AuditPath(dir, auditOpts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			hit := false
+			for _, f := range rep.Findings {
+				if f.Check == "markers" && f.Severity == tc.wantSev && strings.Contains(f.Detail, tc.wantDetail) {
+					hit = true
+				}
+			}
+			if !hit {
+				t.Fatalf("expected a %s markers finding mentioning %q, got %+v", tc.wantSev, tc.wantDetail, rep.Findings)
+			}
+			os.Remove(filepath.Join(dir, "AGENTS.md"))
+		})
+	}
+}
+
+func TestAudit_ContextHashMismatch(t *testing.T) {
+	dir := t.TempDir()
+	body := contextblock.RenderBody(nil)
+	body = strings.Replace(body, contextblockHeading(), "## Memory context (GrayMatter) TAMPERED", 1)
+	block := contextblock.RenderBlock(body, contextblock.SyncMeta{
+		SHA256:   contextblock.HashBody(contextblock.RenderBody(nil)),
+		Facts:    0,
+		SyncedAt: time.Now().UTC(),
+	})
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), block)
+	rep, err := AuditPath(dir, auditOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := false
+	for _, f := range rep.Findings {
+		if f.Check == "markers" && f.Severity == SevWarn && strings.Contains(f.Detail, "hash mismatch") {
+			hit = true
+		}
+	}
+	if !hit {
+		t.Fatalf("tampered context block not flagged: %+v", rep.Findings)
+	}
+}
+
+func contextblockHeading() string { return "## Memory context (GrayMatter)" }
+
+// --- staleness with real git --------------------------------------------------
+
+// gitInitRepo creates a repository and returns a helper committing files with
+// controlled author dates, so staleness buckets are testable without sleeps.
+func gitInitRepo(t *testing.T) (dir string, commit func(name, content, date string)) {
+	t.Helper()
+	dir = t.TempDir()
+	run := func(args ...string) string {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+	run("init", "-q")
+	run("config", "user.email", "audit@test")
+	run("config", "user.name", "auditor")
+
+	commit = func(name, content, date string) {
+		writeFile(t, filepath.Join(dir, name), content)
+		args := []string{"add", name}
+		run(args...)
+		env := os.Environ()
+		if date != "" {
+			env = append(env,
+				"GIT_AUTHOR_DATE="+date,
+				"GIT_COMMITTER_DATE="+date,
+			)
+		}
+		cmd := exec.Command("git", "-c", "user.email=audit@test", "-c", "user.name=auditor", "commit", "-q", "-m", "add "+name)
+		cmd.Dir = dir
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("commit: %v\n%s", err, out)
+		}
+	}
+	return dir, commit
+}
+
+func TestAudit_StalenessBucketsWithRealGit(t *testing.T) {
+	dir, commit := gitInitRepo(t)
+
+	old := "# Stale guide\n\n" + strings.Repeat("Ancient paragraph line written long ago for blame purposes.\n", 12)
+	commit("AGENTS.md", old, "2020-01-15T00:00:00Z")
+
+	// Uncommitted additions land in their own bucket.
+	f, _ := os.OpenFile(filepath.Join(dir, "AGENTS.md"), os.O_APPEND|os.O_WRONLY, 0o644)
+	f.WriteString("\nBrand new uncommitted line appended today.\n")
+	f.Close()
+
+	rep, err := AuditPath(dir, auditOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := rep.Files[0].Staleness
+	if st == nil || !st.Available {
+		t.Fatalf("staleness unavailable: %+v", st)
+	}
+	if st.Stale == 0 {
+		t.Errorf("2020 lines did not land in the >90d bucket: %+v", st)
+	}
+	if st.Uncommitted == 0 {
+		t.Errorf("uncommitted lines not counted: %+v", st)
+	}
+	if st.MedianAgeDays < MedianStaleDays {
+		t.Errorf("median age %.0f below threshold while most lines are from 2020", st.MedianAgeDays)
+	}
+	warns := 0
+	for _, f := range rep.Findings {
+		if f.Check == "staleness" {
+			warns++
+		}
+	}
+	if warns != 1 {
+		t.Errorf("expected exactly one staleness warning, got %d", warns)
+	}
+}
+
+// --- precision harness: the n=20 sample ---------------------------------------
+
+// TestPrecisionHarness_TwentyDocuments is the automated half of the
+// acceptance criterion "estimated false-positive rate over a manual sample of
+// twenty cases before any public use": ten clean documents must produce zero
+// warn/fail findings, ten documents with one planted defect each must trigger
+// at least the planted check. It prints the confusion counts.
+func TestPrecisionHarness_TwentyDocuments(t *testing.T) {
+	dir, commit := gitInitRepo(t)
+	opts := auditOpts
+
+	type specimen struct {
+		file     string
+		content  string
+		date     string // empty → committed now; "UNTRACKED" → never committed
+		defect   string // "" for clean specimens
+		expected string // check name expected to fire on defective ones
+	}
+	var specs []specimen
+
+	// --- ten clean documents -------------------------------------------------
+	for i := 0; i < 10; i++ {
+		body := fmt.Sprintf("# Service %d runbook\n\n"+
+			"Rotate credentials every ninety days using the vault pipeline.\n"+
+			"Alert thresholds page the on-call engineer at severity one.\n"+
+			"Dashboards live under the observability tab of team %d.\n"+
+			"Runbooks are reviewed quarterly by the platform guild %d.\n\n"+
+			"## Escalation %d\n\n"+
+			"Page secondary first when primary does not ack within five minutes.\n"+
+			"Post incident reviews are due within three business days of resolution.\n",
+			i, i, i, i)
+		switch i {
+		case 3:
+			body += "\n" + validInstructionsBlock() + "\n"
+		case 6:
+			sel, _ := contextblock.Select(nil, 512)
+			body += "\n" + contextblock.RenderBlock(contextblock.RenderBody(sel), contextblock.SyncMeta{
+				SHA256:   contextblock.HashBody(contextblock.RenderBody(sel)),
+				SyncedAt: time.Now().UTC(),
+			}) + "\n"
+		case 9:
+			body += "\nThis tenth file stays untracked to exercise that path.\n"
+		}
+		sp := specimen{file: fmt.Sprintf("doc-%02d.md", i), content: body}
+		if i == 9 {
+			sp.date = "UNTRACKED"
+		} else {
+			sp.date = time.Now().UTC().Format(time.RFC3339)
+		}
+		specs = append(specs, sp)
+	}
+
+	// --- ten documents with one planted defect each --------------------------
+	long := "# Long\n" + strings.Repeat("Filler sentence with several ordinary words repeated.\n", 600)
+	tooLong := "# Longer\n" + strings.Repeat("Filler sentence with several ordinary words repeated.\n", 1600)
+
+	specs = append(specs,
+		specimen{file: "def-00-duplicate.md", content: "# Dup\n\n" + strings.Repeat("The importer validates checksum rows before writing any batch to disk.\n\n", 2) + "Trailing unique paragraph about unrelated backup retention windows.\n", defect: "duplicates", expected: "duplicates"},
+		specimen{file: "def-01-size-warn.md", content: long, defect: "size-warn", expected: "size"},
+		specimen{file: "def-02-size-fail.md", content: tooLong, defect: "size-fail", expected: "size"},
+		specimen{file: "def-03-orphan.md", content: "text\n" + "<!-- graymatter:context:begin — managed by `graymatter context-sync`; edits inside this block are overwritten -->\nno end anywhere\n", defect: "orphan", expected: "markers"},
+		specimen{file: "def-04-dup-blocks.md", content: "a\n" + validInstructionsBlock() + "\nb\n" + validInstructionsBlock() + "\n", defect: "duplicate-blocks", expected: "markers"},
+		specimen{file: "def-05-hash.md", content: tamperedContextBlock(), defect: "hash-mismatch", expected: "markers"},
+		specimen{file: "def-06-nested.md", content: validInstructionsBlockBeginOnly() + contextblock.BeginMarker + "\nx\n" + contextblock.EndMarker + "\n" + "<!-- graymatter:instructions:end -->\n", defect: "nested", expected: "markers"},
+		specimen{file: "def-07-stale.md", content: "# Old policy\n\n" + strings.Repeat("Superseded operational guidance retained far past its useful service life.\n", 8), date: "2019-06-01T00:00:00Z", defect: "stale", expected: "staleness"},
+		specimen{file: "def-08-unterminated.md", content: validInstructionsBlock() + "\ntext after\n" + "<!-- graymatter:instructions:begin -- dangling\n", defect: "unterminated", expected: "markers"},
+		specimen{file: "def-09-short-repeats-only.md", content: "# Heading\n\n- alpha\n- beta\n\nTotally distinct body copy so only short lines repeat here.\n", defect: "none-short-lines", expected: ""},
+	)
+
+	// Materialise + commit.
+	for i, sp := range specs {
+		p := filepath.Join(dir, sp.file)
+		writeFile(t, p, sp.content)
+		switch sp.date {
+		case "":
+			commit(sp.file, sp.content, "")
+		case "UNTRACKED":
+			// left out of git on purpose
+		default:
+			commit(sp.file, sp.content, sp.date)
+		}
+		_ = i
+	}
+
+	// Run once per specimen against its own directory? No — one repo, but
+	// AuditPath takes a FILE path directly, which is what we use here.
+	truePositives, falsePositives, trueNegatives := 0, 0, 0
+	for _, sp := range specs {
+		rep, err := AuditPath(filepath.Join(dir, sp.file), opts)
+		if err != nil {
+			t.Fatalf("%s: %v", sp.file, err)
+		}
+		var hits []Finding
+		for _, f := range rep.Findings {
+			if f.Severity == SevWarn || f.Severity == SevFail {
+				hits = append(hits, f)
+			}
+		}
+		if sp.defect == "" || sp.defect == "none-short-lines" {
+			if len(hits) > 0 {
+				falsePositives++
+				t.Errorf("FP on clean %s: %+v", sp.file, hits)
+			} else {
+				trueNegatives++
+			}
+			continue
+		}
+		ok := false
+		for _, h := range hits {
+			if h.Check == sp.expected {
+				ok = true
+			}
+		}
+		if ok {
+			truePositives++
+		} else {
+			t.Errorf("missed defect %q (%s): got %+v", sp.defect, sp.file, rep.Findings)
+		}
+	}
+
+	t.Logf("harness over %d documents: planted defects caught %d/9; negative controls silent %d/11; false positives=%d",
+		len(specs), truePositives, trueNegatives, falsePositives)
+	if falsePositives != 0 {
+		t.Errorf("false positives on clean documents = %d, want 0", falsePositives)
+	}
+	if truePositives != 9 {
+		t.Errorf("detected defects = %d, want 9", truePositives)
+	}
+	if trueNegatives != 11 {
+		t.Errorf("negative controls = %d, want 11 (10 clean + 1 short-line control)", trueNegatives)
+	}
+}
+
+// --- fixtures -----------------------------------------------------------------
+
+func validInstructionsBlock() string {
+	return "<!-- graymatter:instructions:begin — managed by `graymatter init`; edits inside this block are overwritten -->\n" +
+		"Use memory_search before answering; store durable facts after the task.\n" +
+		"<!-- graymatter:instructions:end -->\n"
+}
+
+func validInstructionsBlockBeginOnly() string {
+	return strings.SplitN(validInstructionsBlock(), "\n", 2)[0] + "\n"
+}
+
+func tamperedContextBlock() string {
+	good := contextblock.RenderBody(nil)
+	tampered := strings.Replace(good, "## Memory context (GrayMatter)", "## Memory context (GrayMatter) edited by hand", 1)
+	return contextblock.RenderBlock(tampered, contextblock.SyncMeta{
+		SHA256:   contextblock.HashBody(good),
+		SyncedAt: time.Now().UTC(),
+	})
+}

--- a/cmd/graymatter/internal/docaudit/blame.go
+++ b/cmd/graymatter/internal/docaudit/blame.go
@@ -1,0 +1,94 @@
+package docaudit
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// blameDates returns one commit timestamp per line of path. A zero timestamp
+// marks a line with no commit yet (uncommitted working-tree content).
+//
+// The second return explains unavailability instead of hiding it: git
+// missing, directory outside a repository, or an untracked file each produce
+// Available=false with a stated reason, which the report prints verbatim.
+// Staleness that cannot be measured honestly is reported as unmeasured.
+func blameDates(path string) (dates []time.Time, reason string, err error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, "git not found on PATH", nil
+	}
+	dir := filepath.Dir(path)
+
+	if out, err := run(dir, "rev-parse", "--is-inside-work-tree"); err != nil || strings.TrimSpace(out) != "true" {
+		return nil, "not a git repository", nil
+	}
+	if out, err := run(dir, "ls-files", "--error-unmatch", filepath.Base(path)); err != nil || !strings.Contains(out, filepath.Base(path)) {
+		return nil, "file is not tracked by git", nil
+	}
+
+	out, err := run(dir, "blame", "--line-porcelain", "--", filepath.Base(path))
+	if err != nil {
+		return nil, "git blame failed", err
+	}
+
+	var (
+		cur     time.Time
+		curZero bool
+		haveCur bool
+	)
+	for _, ln := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(ln, "\t"):
+			// Content line: the pending header belongs to it. Uncommitted
+			// lines carry the all-zero SHA and NO committer-time, so they must
+			// fall back to the zero timestamp here — inheriting the previous
+			// line's commit would misfile brand-new text as ancient.
+			switch {
+			case !haveCur:
+			case curZero:
+				dates = append(dates, time.Time{})
+			default:
+				dates = append(dates, cur)
+			}
+			cur, curZero, haveCur = time.Time{}, false, false
+		case isShaHeader(ln):
+			curZero = strings.HasPrefix(ln, "0000000000000000000000000000000000000000")
+			haveCur = true
+		case strings.HasPrefix(ln, "committer-time ") && !curZero:
+			if sec, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(ln, "committer-time ")), 10, 64); err == nil {
+				cur = time.Unix(sec, 0).UTC()
+			}
+		}
+	}
+	return dates, "", nil
+}
+
+func isShaHeader(line string) bool {
+	f := strings.Fields(line)
+	if len(f) < 3 {
+		return false
+	}
+	sha := f[0]
+	if len(sha) != 40 {
+		return false
+	}
+	for _, r := range sha {
+		if !(r >= '0' && r <= '9' || r >= 'a' && r <= 'f') {
+			return false
+		}
+	}
+	for _, num := range f[1:] {
+		if _, err := strconv.Atoi(num); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func run(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.Output()
+	return string(out), err
+}


### PR DESCRIPTION
## What

`graymatter doctor --audit [path]` reads any CLAUDE.md / AGENTS.md — **no store, no daemon, no adoption** — and reports what a prompt pays for the file and where its content has gone wrong. It writes nothing. Works identically on projects with or without a `.graymatter/` directory.

## Checks (thresholds declared inside every report)

| Check | Method | Threshold |
|---|---|---|
| Cost | approx tokens/prompt via `internal/tokens` (whitespace words × 1.33 — the same unit as benchmarks and context-sync budgets; deliberately **not** retrieval `tokenize()`, which undercounts prompt cost 43–56%) | informational; method declared in output |
| Duplication | word-5-shingle Jaccard between paragraphs | ≥ 0.8 → warn |
| Staleness | git-blame line ages, buckets ≤30d / 31–90d / >90d / uncommitted | median > 90d → warn |
| Size | line count | >500 warn, >1500 fail |
| Markers | explicit graymatter markers only: orphaned/unterminated begins, duplicate same-kind blocks, nesting across kinds, context-hash mismatches | corruption → fail |

Semantic contradiction detection is out of scope by design (playbook §7 E1): a public false positive there would cost more than every true positive is worth.

Unmeasurable staleness is reported as unavailable *with its reason* (`git not found`, `not a git repository`, `file is not tracked`) — never silently skipped.

Human and JSON output; exit code 1 only on failure-level findings.

## Tests

- Unit tests per check with planted defects (duplicates, both size thresholds, three marker-corruption classes, context-hash mismatch).
- Staleness buckets verified against a real temp git repository with controlled commit dates plus uncommitted lines.
- **20-document precision harness** (the automated half of the §7 E1 acceptance criterion): ten clean documents — two carrying valid managed blocks, one deliberately untracked — must stay silent; ten documents with one planted defect each must trigger the planted check.
  Current counts: **defects caught 9/9 · negative controls silent 11/11 · false positives 0.**
  The remaining manual half (real-world sample review) stays a precondition before any external use.

## Also

Fixes a portability defect from #32 found by this round's full-suite run: the context-block golden test compared bytes against the golden file verbatim, which breaks on checkouts where `autocrlf` hands the file back as CRLF. The contract is content, not line endings; both sides normalise before comparing.

Full suites green in both modules; `go vet` clean. Dogfooded on this repo's own AGENTS.md/CLAUDE.md during development.