### PR TITLE
fix(memory): verify context-block hashes across CRLF and LF checkouts

### DIFF
--- a/cmd/graymatter/cmd_contextsync_crlf_test.go
+++ b/cmd/graymatter/cmd_contextsync_crlf_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/contextblock"
+)
+
+// TestContextSync_CRLFHostFile pins behaviour on Windows-style host files:
+// a majority-CRLF AGENTS.md must not turn into a perpetual manual-edit
+// warning nor defeat idempotence.
+func TestContextSync_CRLFHostFile(t *testing.T) {
+	s, path := setupSyncStore(t)
+	dir := filepath.Dir(path)
+
+	// Pre-existing CRLF file, like a checkout with autocrlf produces.
+	user := "# Project\r\n\r\nNotes.\r\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := syncContextBlock(s, path, "proj", contextblock.DefaultBudgetTokens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ManualEditDetected {
+		t.Fatalf("first sync on CRLF file flagged manual edit: %+v", res)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "# Project") {
+		t.Fatal("user content lost")
+	}
+	if _, _, verified, found := contextblock.Parse(content); !found || !verified {
+		t.Fatalf("CRLF-written block does not verify (found=%v verified=%v)", found, verified)
+	}
+	_ = context.Background()
+	_ = dir
+}

--- a/cmd/graymatter/internal/contextblock/block.go
+++ b/cmd/graymatter/internal/contextblock/block.go
@@ -220,6 +220,11 @@ func spanScanner(content string) [][2]int {
 // content. found=false means the file carries no context block at all;
 // found=true with an unparsable or missing header still yields the raw body
 // so Verify can report the mismatch instead of silently losing it.
+//
+// The returned body is normalised to LF regardless of the file's dominant
+// line endings. This is what makes hashes portable across platforms: the
+// digest recorded by a Linux sync must still verify inside a checkout that
+// hands the file back as CRLF, so both sides hash the canonical form.
 func Parse(content string) (body string, meta SyncMeta, verified, found bool) {
 	spans := spanScanner(content)
 	if len(spans) == 0 {
@@ -228,7 +233,11 @@ func Parse(content string) (body string, meta SyncMeta, verified, found bool) {
 	// Span ends are exclusive past the END MARKER; the body lives strictly
 	// before that marker, so cut at its start, not its end.
 	inner := content[spans[0][0]+len(BeginMarker) : spans[0][1]-len(EndMarker)]
+	// Canonicalise line endings BEFORE any structural cut: a CRLF host file
+	// must parse identically to an LF one, or hashes stop being portable.
+	inner = strings.ReplaceAll(inner, "\r\n", "\n")
 	inner = strings.TrimPrefix(inner, "\n")
+	inner = strings.TrimPrefix(inner, "\r")
 	// The trailing newline is part of the body and must survive: hashes are
 	// taken over the body exactly as written, and trimming here would fail
 	// verification on an untouched round trip.
@@ -243,6 +252,7 @@ func Parse(content string) (body string, meta SyncMeta, verified, found bool) {
 	} else {
 		body = ""
 	}
+	header = strings.TrimSuffix(header, "\r")
 
 	meta, ok := parseHeader(header)
 	if !ok {

--- a/cmd/graymatter/internal/contextblock/block_test.go
+++ b/cmd/graymatter/internal/contextblock/block_test.go
@@ -147,6 +147,24 @@ func TestParse_DetectsManualEdit(t *testing.T) {
 	}
 }
 
+// TestParse_CRLFBlockVerifies pins cross-platform hash portability: a block
+// written into a CRLF host file must verify against the digest recorded from
+// its LF form, or every Windows checkout would read as "edited by hand".
+func TestParse_CRLFBlockVerifies(t *testing.T) {
+	sel, _ := Select([]memory.Fact{fact("a", 1, 0, "alpha")}, DefaultBudgetTokens)
+	body := RenderBody(sel)
+	block := RenderBlock(body, SyncMeta{SHA256: HashBody(body), Facts: len(sel), SyncedAt: time.Now().UTC()})
+	crlfFile := strings.ReplaceAll(block, "\n", "\r\n")
+
+	gotBody, _, verified, found := Parse(crlfFile)
+	if !found || !verified {
+		t.Fatalf("CRLF block failed verification (found=%v verified=%v)", found, verified)
+	}
+	if gotBody != body {
+		t.Fatalf("normalised body differs:\n got %q\nwant %q", gotBody, body)
+	}
+}
+
 func TestParse_MissingHeaderIsUnverifiedButVisible(t *testing.T) {
 	orphan := BeginMarker + "\n- someone deleted the header\n" + EndMarker + "\n"
 	_, _, verified, found := Parse(orphan)


### PR DESCRIPTION
## Defect

Shipped in #32, caught by this round's own follow-up test before any user report.

On a Windows checkout (`core.autocrlf=true`), the host AGENTS.md is CRLF. `writeContextBlock` adapts the rendered block to CRLF before writing — correct for the file — but the header records the SHA-256 of the **LF** body. The next sync parsed a body full of carriage returns:

- hash never matched → **every run reported "edited by hand" against a file nobody touched**
- idempotence was dead → identical state rewrote the file forever (perpetual churn + fresh `.bak` each run)

## Fix

`contextblock.Parse` canonicalises line endings to LF **before** any structural cut and returns the normalised body; header parsing strips the stray CR that survived at the end of the sync line. Hashes now compare in one canonical form on every platform. The on-disk file keeps its CRLF endings — only verification is normalised.

## Tests

- Package-level: TestParse_CRLFBlockVerifies round-trips an LF-rendered block through a simulated CRLF file.
- Command-level: TestContextSync_CRLFHostFile runs the real pipeline over a majority-CRLF host file — first sync must not flag manual edit, written block must verify.

Both fail on a509b7a and pass here. Full cmd suite green; go vet clean.