### PR TITLE
fix(cli): doctor rejects a positional path when --audit is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **`doctor <path>` without `--audit` is now a loud error** instead of
+  silently auditing the working directory while ignoring the path. A
+  positional path only means something under `--audit`; input that changes
+  nothing and says so to nobody is the failure mode this project fixes
+  everywhere else.
 - **`doctor --audit` no longer reports marker syntax quoted inside fenced
   code blocks.** A document that teaches or documents the managed-block
   syntax inside ``` fences — this repository's own docs do it — produced

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -57,6 +57,14 @@ Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 				return runDoctorAudit(cmd, root)
 			}
 
+			// A positional path only means something under --audit. Taking it
+			// silently and then auditing the working directory anyway is the
+			// exact failure mode this project fixes elsewhere: input that
+			// changes nothing and says so to nobody.
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected argument %q: a path requires --audit", args[0])
+			}
+
 			checks := []checkResult{
 				checkBinaryOnPath(),
 				checkDataDir(dataDir),

--- a/cmd/graymatter/cmd_doctor_test.go
+++ b/cmd/graymatter/cmd_doctor_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -272,5 +273,21 @@ func TestCheckInstructions_StaleBlock(t *testing.T) {
 	}
 	if c := checkInstructions(dir); c.Status != "ok" {
 		t.Errorf("status after re-running init = %s, want ok (%s)", c.Status, c.Detail)
+	}
+}
+
+// TestDoctor_RejectsPathWithoutAudit pins the M-C2 resolution: a positional
+// path only means something under --audit. Taking it silently and auditing
+// the working directory anyway is input that changes nothing and says so to
+// nobody - the failure mode this project fixes everywhere else.
+func TestDoctor_RejectsPathWithoutAudit(t *testing.T) {
+	cmd := doctorCmd()
+	cmd.SilenceUsage = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"some-other-project"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires --audit") {
+		t.Fatalf("expected a requires---audit error, got %v", err)
 	}
 }


### PR DESCRIPTION
Resolves M-C2, the single finding the audit round left to a product decision.

`graymatter doctor some-project` used to run every setup check against the working directory while silently dropping the path — input that changes nothing and says so to nobody. It now returns:

```
Error: unexpected argument "some-project": a path requires --audit
```

Rationale for rejecting over honouring: a positional dir would duplicate the semantics of the existing `--dir` flag, and silent-ignore is the failure mode the last three rounds fixed everywhere else.

Test fails on main, passes here. Full cmd suite green.