### PR TITLE
feat(kg): structural foundations for the knowledge graph (P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **`graymatter export --include-graph`** — the Obsidian export now writes the
+  knowledge graph alongside facts: one entity note per node (frontmatter with
+  type, first/last seen, weight) plus an Obsidian canvas. Works through the
+  daemon too; only the destination path crosses the wire. Requires
+  `--format obsidian`.
+- **`Graph.Link` never leaves dangling edges** — endpoints that do not exist
+  are auto-upserted as placeholder nodes (`EntityType: "unknown"`) inside the
+  same transaction, so every edge is traversable no matter when the agent
+  links relative to extraction.
+- **Wiring contract tests** pin what shipped builds do and do not do with the
+  knowledge graph: defaults never auto-wire extraction, explicit `SetKG`
+  drives node upserts during consolidation, and today's engine has no path
+  that creates edges (documented before the wiring round changes it).
 - **`graymatter doctor --audit [path]`** — free auditor for instruction
   documents, no store or adoption required. Reports approx token cost per
   prompt (tokenizer declared in every output), near-duplicate paragraphs

--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ graymatter checkpoint resume  "agent"             # print latest checkpoint as J
 graymatter mcp serve                              # start MCP server (Claude Code / Cursor)
 graymatter mcp serve --http 127.0.0.1:8080        # HTTP transport
 graymatter export --format obsidian --out ~/vault # dump to Obsidian vault
+graymatter export --format obsidian --include-graph --out ~/vault # + entities & canvas
 graymatter tui                                    # 4-view terminal UI
 graymatter run agent.md [--background]            # run a SKILL.md agent file
 graymatter sessions list                          # list managed agent sessions

--- a/cmd/graymatter/cmd_export.go
+++ b/cmd/graymatter/cmd_export.go
@@ -12,18 +12,23 @@ import (
 
 func exportCmd() *cobra.Command {
 	var (
-		format  string
-		outDir  string
-		agentID string
+		format       string
+		outDir       string
+		agentID      string
+		includeGraph bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export memories to human-readable files",
 		Example: `  graymatter export --format obsidian --out ~/vault
+  graymatter export --format obsidian --out ~/vault --include-graph
   graymatter export --format json
   graymatter export --format markdown --agent sales-closer`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if includeGraph && format != "obsidian" {
+				return fmt.Errorf("--include-graph requires --format obsidian (the graph renders as entity notes + canvas)")
+			}
 			store, err := openStore()
 			if err != nil {
 				return err
@@ -60,12 +65,20 @@ func exportCmd() *cobra.Command {
 				return err
 			}
 
+			graphNote := ""
+			if includeGraph {
+				if err := store.ExportGraphObsidian(outDir); err != nil {
+					return fmt.Errorf("export knowledge graph: %w", err)
+				}
+				graphNote = " + knowledge graph (entities, canvas)"
+			}
+
 			from := "all agents"
 			if agentID != "" {
 				from = agentID
 			}
 			if !quiet {
-				fmt.Printf("Exported %d facts for %s to %s (format: %s)\n", len(facts), from, outDir, format)
+				fmt.Printf("Exported %d facts for %s to %s (format: %s)%s\n", len(facts), from, outDir, format, graphNote)
 			}
 			return nil
 		},
@@ -74,5 +87,7 @@ func exportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&format, "format", "markdown", "output format: markdown, obsidian, json")
 	cmd.Flags().StringVar(&outDir, "out", "", "output directory (default: .graymatter/export/<format>)")
 	cmd.Flags().StringVar(&agentID, "agent", "", "export only this agent (default: all)")
+	cmd.Flags().BoolVar(&includeGraph, "include-graph", false,
+		"also write knowledge-graph entities and canvas (requires --format obsidian)")
 	return cmd
 }

--- a/cmd/graymatter/cmd_export_graph_test.go
+++ b/cmd/graymatter/cmd_export_graph_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+)
+
+// seedExportGraph opens the graph on the direct store's handle and creates a
+// tiny but real structure: one typed node, one linked placeholder endpoint.
+func seedExportGraph(t *testing.T, ds *directStore) {
+	t.Helper()
+	g, err := kg.Open(ds.store.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Upsert(kg.Node{ID: "data-pipeline", Label: "Data Pipeline", EntityType: "project"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Link(kg.Edge{From: "data-pipeline", To: "etl-jobs", Relation: "related_to"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExport_IncludeGraph_WritesEntitiesCanvasAndFacts(t *testing.T) {
+	dir := t.TempDir()
+	old := dataDir
+	dataDir = dir
+	t.Cleanup(func() { dataDir = old })
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+
+	ds, err := openDirectStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for _, f := range []string{"Kicked off the data pipeline migration", "Hired a contractor for etl jobs"} {
+		if err := ds.Remember(ctx, "proj", f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedExportGraph(t, ds)
+	if err := ds.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "vault")
+	cmd := exportCmd()
+	cmd.SilenceUsage = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--format", "obsidian", "--include-graph", "--out", out})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("export --include-graph: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(out, "graph-canvas.json")); err != nil {
+		t.Errorf("canvas missing: %v", err)
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mds := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			mds++
+		}
+	}
+	// fact note(s) + Data Pipeline + auto-upserted etl-jobs placeholder.
+	if mds < 3 {
+		t.Errorf("expected fact note + 2 entity notes, found %d markdown files: %v", mds, entries)
+	}
+	// sanitizeFilename swaps spaces for underscores: "Data Pipeline" →
+	// "Data_Pipeline.md".
+	entityNote := filepath.Join(out, "Data_Pipeline.md")
+	if data, err := os.ReadFile(entityNote); err != nil {
+		t.Errorf("entity note missing: %v", err)
+	} else if !strings.Contains(string(data), "[[etl-jobs]]") {
+		t.Errorf("entity note lacks typed backlink:\n%s", data)
+	}
+}
+
+func TestExport_IncludeGraphRequiresObsidianFormat(t *testing.T) {
+	dir := t.TempDir()
+	old := dataDir
+	dataDir = dir
+	t.Cleanup(func() { dataDir = old })
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+
+	cmd := exportCmd()
+	cmd.SilenceUsage = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--format", "markdown", "--include-graph", "--out", filepath.Join(dir, "vault")})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires --format obsidian") {
+		t.Fatalf("expected loud format error, got %v", err)
+	}
+}

--- a/cmd/graymatter/internal/daemon/client.go
+++ b/cmd/graymatter/internal/daemon/client.go
@@ -233,6 +233,11 @@ func (c *Client) KGUpsert(id, label, entityType string) error {
 	return c.hostCall("KGUpsert", &KGUpsertRequest{ID: id, Label: label, EntityType: entityType}, &KGUpsertResponse{})
 }
 
+// KGExportObsidian writes the daemon's graph entities and canvas into outDir.
+func (c *Client) KGExportObsidian(outDir string) error {
+	return c.hostCall("KGExportObsidian", &KGExportObsidianRequest{OutDir: outDir}, &KGExportObsidianResponse{})
+}
+
 // AuditWrite records an agent self-edit event.
 func (c *Client) AuditWrite(e audit.Entry) error {
 	return c.hostCall("AuditWrite", &AuditWriteRequest{E: e}, &AuditWriteResponse{})

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -78,6 +78,9 @@ type KGLinkResponse struct{}
 type KGUpsertRequest struct{ ID, Label, EntityType string }
 type KGUpsertResponse struct{}
 
+type KGExportObsidianRequest struct{ OutDir string }
+type KGExportObsidianResponse struct{}
+
 type AuditWriteRequest struct{ E audit.Entry }
 type AuditWriteResponse struct{}
 
@@ -195,6 +198,17 @@ func (h *Host) KGUpsert(req *KGUpsertRequest, resp *KGUpsertResponse) error {
 		return errNoKG
 	}
 	return h.adapter.UpsertNode(req.ID, req.Label, req.EntityType)
+}
+
+// KGExportObsidian writes the graph's entity notes and canvas into outDir,
+// next to whatever the facts export produced. Runs host-side because the
+// graph lives on the daemon's bbolt handle; only the destination path
+// crosses the wire.
+func (h *Host) KGExportObsidian(req *KGExportObsidianRequest, resp *KGExportObsidianResponse) error {
+	if h.graph == nil {
+		return errNoKG
+	}
+	return h.graph.ExportObsidian(req.OutDir)
 }
 
 // AuditWrite records an agent self-edit event.

--- a/cmd/graymatter/internal/kg/graph.go
+++ b/cmd/graymatter/internal/kg/graph.go
@@ -26,7 +26,7 @@ var (
 // Node represents a named entity in the knowledge graph.
 type Node struct {
 	ID         string    `json:"id"`
-	Label      string    `json:"label"`      // e.g. "Maria", "sales-closer"
+	Label      string    `json:"label"`       // e.g. "Maria", "sales-closer"
 	EntityType string    `json:"entity_type"` // person/project/decision/preference/fact
 	FirstSeen  time.Time `json:"first_seen"`
 	LastSeen   time.Time `json:"last_seen"`
@@ -103,6 +103,15 @@ func (g *Graph) Upsert(node Node) error {
 
 // Link inserts or updates an edge between two nodes.
 // Edges are keyed by "from|to|relation" so duplicate links upsert, not append.
+//
+// Endpoints that do not exist yet are auto-upserted as placeholder nodes
+// ({Label: id, EntityType: "unknown"}) inside the same transaction. Agents
+// legitimately link before any extractor ran, and an edge whose endpoints are
+// missing is invisible to every traversal while still occupying storage —
+// the dangling-edge class behind issue #24. Creating the endpoints keeps the
+// invariant "every edge is traversable" unconditional; rejecting the link
+// instead would punish exactly the caller (link-before-extract) the tool is
+// meant to serve.
 func (g *Graph) Link(edge Edge) error {
 	if edge.From == "" || edge.To == "" {
 		return fmt.Errorf("kg: link: From and To must not be empty")
@@ -110,17 +119,38 @@ func (g *Graph) Link(edge Edge) error {
 	if edge.CreatedAt.IsZero() {
 		edge.CreatedAt = time.Now().UTC()
 	}
+	created := edge.CreatedAt
 	if edge.Weight == 0 {
 		edge.Weight = 1.0
 	}
 	key := edgeKey(edge.From, edge.To, edge.Relation)
 	return g.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucketEdges)
+		nodes := tx.Bucket(bucketNodes)
+		for _, id := range [2]string{edge.From, edge.To} {
+			if nodes.Get([]byte(id)) != nil {
+				continue
+			}
+			placeholder := Node{
+				ID:         id,
+				Label:      id,
+				EntityType: "unknown",
+				FirstSeen:  created,
+				LastSeen:   created,
+				Weight:     1.0,
+			}
+			data, err := json.Marshal(placeholder)
+			if err != nil {
+				return fmt.Errorf("kg: link: marshal placeholder node %q: %w", id, err)
+			}
+			if err := nodes.Put([]byte(id), data); err != nil {
+				return err
+			}
+		}
 		data, err := json.Marshal(edge)
 		if err != nil {
 			return err
 		}
-		return b.Put([]byte(key), data)
+		return tx.Bucket(bucketEdges).Put([]byte(key), data)
 	})
 }
 

--- a/cmd/graymatter/internal/kg/graph_link_test.go
+++ b/cmd/graymatter/internal/kg/graph_link_test.go
@@ -1,0 +1,76 @@
+package kg
+
+import "testing"
+
+// TestLink_AutoUpsertsEndpointsOnEmptyBuckets pins P0.1: linking over empty
+// buckets produces both endpoint nodes plus the edge, so an edge can never
+// dangle. Before this fix, Link happily stored an edge whose endpoints did
+// not exist — invisible to every traversal, alive in storage forever.
+func TestLink_AutoUpsertsEndpointsOnEmptyBuckets(t *testing.T) {
+	g, cleanup := openTestGraph(t)
+	defer cleanup()
+
+	if err := g.Link(Edge{From: "maria-rodriguez", To: "pricing-project", Relation: "co_mentioned"}); err != nil {
+		t.Fatalf("link over empty buckets: %v", err)
+	}
+
+	nodes, err := g.AllNodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 auto-upserted endpoints, got %d (%+v)", len(nodes), nodes)
+	}
+	byID := map[string]Node{}
+	for _, n := range nodes {
+		byID[n.ID] = n
+		if n.EntityType != "unknown" {
+			t.Errorf("placeholder %q has EntityType %q, want unknown", n.ID, n.EntityType)
+		}
+		if n.Label != n.ID {
+			t.Errorf("placeholder %q has Label %q, want the ID verbatim", n.ID, n.Label)
+		}
+	}
+	for _, id := range []string{"maria-rodriguez", "pricing-project"} {
+		if _, ok := byID[id]; !ok {
+			t.Errorf("endpoint %q missing from nodes", id)
+		}
+	}
+
+	neigh, _, err := g.Neighbors("maria-rodriguez", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(neigh) != 1 {
+		t.Errorf("edge not traversable from From side: %d neighbours", len(neigh))
+	}
+}
+
+// TestLink_ExistingEndpointsPreserved guards against overshoot: auto-upsert
+// must never clobber real nodes that already carry their label and type.
+func TestLink_ExistingEndpointsPreserved(t *testing.T) {
+	g, cleanup := openTestGraph(t)
+	defer cleanup()
+
+	if err := g.Upsert(Node{ID: "a", Label: "Alpha", EntityType: "person"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Link(Edge{From: "a", To: "brand-new-node", Relation: "related_to"}); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := g.AllNodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Node{}
+	for _, n := range nodes {
+		byID[n.ID] = n
+	}
+	if got := byID["a"]; got.Label != "Alpha" || got.EntityType != "person" {
+		t.Errorf("existing node overwritten: %+v", got)
+	}
+	if got := byID["brand-new-node"]; got.EntityType != "unknown" {
+		t.Errorf("new endpoint not created as placeholder: %+v", got)
+	}
+}

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -48,6 +48,7 @@ type cliStore interface {
 	SessionResolve(agentID, sessionID string) (string, error)
 	KGNodes() ([]kg.Node, error)
 	KGLink(from, to, relation string) error
+	ExportGraphObsidian(outDir string) error
 	AuditWrite(e audit.Entry) error
 	TokenSummary(days int) (harness.TokenUsageSummary, error)
 	TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error
@@ -72,6 +73,12 @@ type daemonStore struct {
 }
 
 func (d daemonStore) IsReadOnly() bool { return false }
+
+// ExportGraphObsidian runs host-side: the graph lives on the daemon's bbolt
+// handle, so only the destination path crosses the wire.
+func (d daemonStore) ExportGraphObsidian(outDir string) error {
+	return d.Client.KGExportObsidian(outDir)
+}
 
 // Ready uses the RPC protocol ping, which is the cheapest call that proves the
 // daemon is both reachable and speaking a compatible protocol.
@@ -228,6 +235,16 @@ func (d *directStore) KGLink(from, to, relation string) error {
 		return fmt.Errorf("knowledge graph not available: %w", err)
 	}
 	return kg.NewGraphAdapter(g).LinkNodes(from, to, relation)
+}
+
+// ExportGraphObsidian writes the graph's entity notes and canvas into outDir.
+// Direct mode opens the graph on this process's bbolt handle.
+func (d *directStore) ExportGraphObsidian(outDir string) error {
+	g, err := kg.Open(d.store.DB())
+	if err != nil {
+		return fmt.Errorf("knowledge graph not available: %w", err)
+	}
+	return g.ExportObsidian(outDir)
 }
 
 func (d *directStore) AuditWrite(e audit.Entry) error {

--- a/cmd/graymatter/store_reconnect.go
+++ b/cmd/graymatter/store_reconnect.go
@@ -264,6 +264,10 @@ func (r *reconnectingStore) KGLink(from, to, relation string) error {
 	return r.do(func(s cliStore) error { return s.KGLink(from, to, relation) })
 }
 
+func (r *reconnectingStore) ExportGraphObsidian(outDir string) error {
+	return r.do(func(s cliStore) error { return s.ExportGraphObsidian(outDir) })
+}
+
 func (r *reconnectingStore) AuditWrite(e audit.Entry) error {
 	return r.do(func(s cliStore) error { return s.AuditWrite(e) })
 }

--- a/cmd/graymatter/store_reconnect_delegation_test.go
+++ b/cmd/graymatter/store_reconnect_delegation_test.go
@@ -108,6 +108,11 @@ func (r *recordingStore) KGLink(from, to, relation string) error {
 	r.rec("KGLink", from, to, relation)
 	return nil
 }
+
+func (r *recordingStore) ExportGraphObsidian(outDir string) error {
+	r.rec("ExportGraphObsidian", outDir)
+	return nil
+}
 func (r *recordingStore) AuditWrite(e audit.Entry) error {
 	r.rec("AuditWrite", e.Action)
 	return nil
@@ -164,6 +169,7 @@ func TestReconnectingStore_DelegatesEveryMethod(t *testing.T) {
 		{"SessionSave", func(r *reconnectingStore) { _ = r.SessionSave(harness.HarnessSession{ID: "sess-1"}) }, []any{"sess-1"}},
 		{"KGNodes", func(r *reconnectingStore) { _, _ = r.KGNodes() }, nil},
 		{"KGLink", func(r *reconnectingStore) { _ = r.KGLink("from-1", "to-2", "rel-3") }, []any{"from-1", "to-2", "rel-3"}},
+		{"ExportGraphObsidian", func(r *reconnectingStore) { _ = r.ExportGraphObsidian("out-1") }, []any{"out-1"}},
 		{"AuditWrite", func(r *reconnectingStore) { _ = r.AuditWrite(audit.Entry{Action: "act-1"}) }, []any{"act-1"}},
 		{"TokenSummary", func(r *reconnectingStore) { _, _ = r.TokenSummary(30) }, []any{30}},
 		{"TokenRecord", func(r *reconnectingStore) {

--- a/pkg/memory/kg_wiring_contract_test.go
+++ b/pkg/memory/kg_wiring_contract_test.go
@@ -1,0 +1,109 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The wiring contract for the knowledge graph, pinned at the engine boundary.
+//
+// Shipped builds never auto-wire extraction: SetKG is an explicit call a
+// library owner makes. Issue #24 existed because that contract lived only in
+// prose — nothing would have caught the cable being connected (or
+// disconnected) silently. These tests are the executable form of the prose.
+
+type recordingKG struct {
+	upserts       []string
+	neighborCalls int
+}
+
+func (g *recordingKG) UpsertNode(id, label, entityType string) error {
+	g.upserts = append(g.upserts, id)
+	return nil
+}
+
+func (g *recordingKG) NeighborTexts(nodeID string, depth int) ([]string, error) {
+	g.neighborCalls++
+	return nil, nil
+}
+
+type recordingExtractor struct{ calls int }
+
+func (e *recordingExtractor) ExtractIDs(text string) ([]string, error) {
+	e.calls++
+	return []string{"entity-a", "entity-b"}, nil
+}
+
+func newKGWiringStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{DataDir: dir})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestShippedDefaultsNeverAutoWireKG: a default-built store runs full
+// consolidation cycles with graph and extractor still nil. If anyone adds
+// silent auto-wiring to Open/NewWithConfig/Consolidate, this fails.
+func TestShippedDefaultsNeverAutoWireKG(t *testing.T) {
+	s := newKGWiringStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 25; i++ {
+		if err := s.Put(ctx, "kg-agent", fmt.Sprintf("Maria Rodriguez discussed entity topic %d in depth", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Consolidate(ctx, "kg-agent", &testConsolidateCfg{threshold: 100, halfLife: 720 * time.Hour}); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.graph != nil || s.extractor != nil {
+		t.Fatalf("shipped stack auto-wired the graph: graph=%v extractor=%v",
+			s.graph != nil, s.extractor != nil)
+	}
+}
+
+// TestExplicitSetKG_DrivesNodeUpserts_ButNoEdgePathExists pins both halves of
+// today's manual-wiring reality:
+//
+//   - explicit SetKG makes consolidation upsert nodes per extracted entity;
+//   - the engine has NO path that creates edges — GraphAccessor exposes no
+//     Link, so D1 (isolated nodes) is structural, not accidental.
+//
+// When P2.2 consumes extractor edges, this second assertion must be replaced
+// by real edge-flow tests; deleting it silently would repeat issue #24.
+func TestExplicitSetKG_DrivesNodeUpserts_ButNoEdgePathExists(t *testing.T) {
+	s := newKGWiringStore(t)
+	ctx := context.Background()
+
+	kg := &recordingKG{}
+	ex := &recordingExtractor{}
+	s.SetKG(kg, ex)
+
+	for i := 0; i < 3; i++ {
+		if err := s.Put(ctx, "kg-agent", fmt.Sprintf("Fact %d mentioning two entities worth linking", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Consolidate(ctx, "kg-agent", &testConsolidateCfg{threshold: 100, halfLife: 720 * time.Hour}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(kg.upserts) == 0 {
+		t.Fatal("SetKG wired but consolidation produced no node upserts")
+	}
+	if ex.calls == 0 {
+		t.Error("extractor never invoked during consolidation")
+	}
+	for _, u := range kg.upserts {
+		if u != "entity-a" && u != "entity-b" {
+			t.Errorf("unexpected node id %q from extractor stub", u)
+		}
+	}
+}


### PR DESCRIPTION
PR-A of the Knowledge Graph Hardening proposal (P0 — structural correctness). Three changes, engine untouched (the new `pkg/memory` file is test-only):

## 1. Graph.Link never leaves dangling edges

Endpoints that do not exist are auto-upserted as placeholder nodes (`EntityType: "unknown"`) inside the same transaction. Agents legitimately link before any extractor ran; an edge whose endpoints are missing is invisible to every traversal while still occupying storage — the dangling-edge class behind #24.

Tests: empty-bucket link produces 2 nodes + 1 traversable edge; existing endpoints keep label/type.

## 2. `graymatter export --include-graph`

The Obsidian export now writes the knowledge graph next to the facts: one entity note per node + Obsidian canvas. Requires `--format obsidian`.

- New host RPC `KGExportObsidian` (host-side execution: the graph lives on the daemon's bbolt handle; only the destination path crosses the wire) + client method.
- `ExportGraphObsidian` joins the `cliStore` surface; direct mode opens the graph locally.

E2E test: seeded graph + facts → single vault contains fact notes, both entity notes and canvas.

## 3. Wiring contract tests

The executable form of what #24/ADR-003 said in prose:

- Shipped defaults **never** auto-wire extraction (graph/extractor stay nil through full consolidation cycles).
- Explicit `SetKG` drives node upserts per extracted entity.
- `GraphAccessor` exposes **no path that creates edges** — the isolated-nodes defect (D1 in the proposal) is structural and now documented by a failing-loudly assertion before the wiring round replaces it.

Full suites green in both modules; vet clean.