### PR TITLE
feat(kg): wire knowledge-graph auto-population, gated and budgeted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **Knowledge-graph auto-population ships gated (`daemon run --kg` / `GRAYMATTER_KG=1`)** —
+  consolidation now consumes a typed extractor capability that preserves each
+  entity's label and classification, and persists co-mention edges between
+  them, so the graph fills itself from ordinary use (issue #24). Recall
+  enrichment is budgeted: at most three neighbour labels appended after the
+  ranked facts, tombstones respected on every path — documented as an explicit
+  exception to exactly-topK in `docs/api-stability.md`. Gated by measured
+  results per [ADR-008](docs/decisions/008-knowledge-graph-wiring.md),
+  amending ADR-003: extraction precision 0.946 on a 105-fact labeled corpus,
+  and entity-bridge enrichment answering 67% of multi-hop queries that plain
+  ranking answers at 0%.
 - **`graymatter export --include-graph`** — the Obsidian export now writes the
   knowledge graph alongside facts: one entity note per node (frontmatter with
   type, first/last seen, weight) plus an Obsidian canvas. Works through the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+﻿<div align="center">
   <img width="1500" height="276" alt="graymatter-banner" src=".github/assets/graymatter-banner-1.jpg" />
 </div>
 
@@ -21,7 +21,7 @@ One binary. Drop it in. Run it. No Docker, no databases, no config files, no clo
 <br /><br />
 <strong>General-purpose MCP server. Zero vendor lock-in.</strong>
 <br />
-Works with Claude Code, Cursor, Codex, OpenCode, Antigravity — and any MCP-compatible client.
+Works with Claude Code, Cursor, Codex, OpenCode, Antigravity â€” and any MCP-compatible client.
 <br />
 Also a plain Go library if you don't use MCP.
 <br /><br />
@@ -81,7 +81,7 @@ overwritten, so it is safe in a repo that already has some.
 graymatter doctor
 ```
 
-Every line must be `✓` or `·`. If it warns, fix that before continuing; the
+Every line must be `âœ“` or `Â·`. If it warns, fix that before continuing; the
 hints are actionable.
 
 **4. Ask the user to restart you.** This step is not optional. MCP servers are
@@ -98,12 +98,12 @@ loaded, then follow [`AGENTS.md`](AGENTS.md) for when to use which.
 ## Why
 
 Every AI agent is **stateless by default**. Each run re-injects the full
-conversation history — and that history grows linearly. Two prompts in and you've already burned half of your daily quota.
+conversation history â€” and that history grows linearly. Two prompts in and you've already burned half of your daily quota.
 
 That's not just a memory problem. That's a money and performance problem.
 
 
-**Mem0, Zep, Supermemory** solve this — but they're Python/TypeScript-only
+**Mem0, Zep, Supermemory** solve this â€” but they're Python/TypeScript-only
 and require a running server. The Go ecosystem has no production-ready,
 embeddable, zero-dependency memory layer for agents.
 
@@ -114,10 +114,10 @@ That gap is GrayMatter.
 </p>
 
 <p align="center">
-<strong>~90% reduction in context tokens</strong> — versus full-history injection.<br>
+<strong>~90% reduction in context tokens</strong> â€” versus full-history injection.<br>
 Context quality <em>improves</em> over time as consolidation surfaces only what matters.<br>
 No Docker. No Redis. No API key required for storage.<br><br>
-Drop it in once. It auto-connects to <strong>Claude Code, Cursor, Codex, OpenCode, Antigravity</strong> — any MCP-compatible client picks it up automatically.
+Drop it in once. It auto-connects to <strong>Claude Code, Cursor, Codex, OpenCode, Antigravity</strong> â€” any MCP-compatible client picks it up automatically.
 </p>
 
 ---
@@ -127,7 +127,7 @@ Drop it in once. It auto-connects to <strong>Claude Code, Cursor, Codex, OpenCod
 You can't improve what you can't see.
 
 `graymatter tui` opens a live terminal dashboard with everything your
-agent memory is doing — no extra setup required.
+agent memory is doing â€” no extra setup required.
 
 <p align="center">
   <img src=".github/assets/tui-graymatter.jpg" alt="GrayMatter-TUI" width="900px" style="max-width: 900px;">
@@ -135,16 +135,16 @@ agent memory is doing — no extra setup required.
 
 **What you get at a glance:**
 
-- **Facts** — total stored, distributed across agents
-- **Memory cost** — KB on disk (text + embeddings), not tokens
-- **Recalls** — cumulative access count across all sessions
-- **Health** — percentage of facts above relevance threshold (weight > 0.5)
-- **Token cost (30d)** — real spend breakdown by model, with cache hit rate
-- **Agent activity** — facts vs recalls per agent, side by side
-- **Weight distribution** — how consolidated your memory is over time
-- **Activity timeline** — facts created per day, last 30 days
+- **Facts** â€” total stored, distributed across agents
+- **Memory cost** â€” KB on disk (text + embeddings), not tokens
+- **Recalls** â€” cumulative access count across all sessions
+- **Health** â€” percentage of facts above relevance threshold (weight > 0.5)
+- **Token cost (30d)** â€” real spend breakdown by model, with cache hit rate
+- **Agent activity** â€” facts vs recalls per agent, side by side
+- **Weight distribution** â€” how consolidated your memory is over time
+- **Activity timeline** â€” facts created per day, last 30 days
 
-The dashboard auto-refreshes every 5 seconds. Press `1–4` to switch tabs,
+The dashboard auto-refreshes every 5 seconds. Press `1â€“4` to switch tabs,
 `r` to force refresh, `q` to quit.
 
 ---
@@ -195,7 +195,7 @@ graymatter init
 ```
 
 One command auto-wires GrayMatter into every supported client at once.
-Existing entries from other MCP servers are **merged, not overwritten** —
+Existing entries from other MCP servers are **merged, not overwritten** â€”
 safe to run in any repo.
 
 `init` also drops a managed **memory block into `CLAUDE.md` and
@@ -230,7 +230,7 @@ settings). Five tools become available:
 | `checkpoint_resume` | Restore last checkpoint |
 | `memory_reflect` | Add / update / forget / link memories (agent self-edit) |
 
-> Agents using these tools should read **[docs/AGENTS.md](docs/AGENTS.md)** —
+> Agents using these tools should read **[docs/AGENTS.md](docs/AGENTS.md)** â€”
 > when to store vs. checkpoint, query patterns, anti-patterns, and the exact
 > per-tool parameter names (heads-up: `memory_reflect` uses `agent`, the
 > other four use `agent_id`).
@@ -245,13 +245,13 @@ graymatter mcp serve                        # stdio transport
 graymatter mcp serve --http 127.0.0.1:8080  # HTTP transport (bearer token required)
 ```
 
-The schema is identical to every other MCP server — `command` +
+The schema is identical to every other MCP server â€” `command` +
 `args: ["mcp", "serve"]`. No proprietary glue.
 
 ### Global install (all projects)
 
 If you'd rather not run `graymatter init` in every repo, drop the same
-JSON into the editor's global config — `~/.cursor/mcp.json` for Cursor,
+JSON into the editor's global config â€” `~/.cursor/mcp.json` for Cursor,
 `~/.claude/mcp.json` for Claude Code:
 
 ```json
@@ -269,7 +269,7 @@ JSON into the editor's global config — `~/.cursor/mcp.json` for Cursor,
 automatically on Windows via the User `PATH` registry; on macOS / Linux
 the recommended install path `/usr/local/bin` is already on `PATH`.
 
-### Troubleshooting — "MCP is connected but nothing gets stored"
+### Troubleshooting â€” "MCP is connected but nothing gets stored"
 
 Run the built-in diagnosis first:
 
@@ -278,12 +278,12 @@ graymatter doctor        # human-readable
 graymatter doctor --json # scriptable
 ```
 
-It checks the full chain: binary on `PATH` → data dir writable → store
-health and lock state → MCP wiring per client → agent instructions present.
+It checks the full chain: binary on `PATH` â†’ data dir writable â†’ store
+health and lock state â†’ MCP wiring per client â†’ agent instructions present.
 
 The two most common failure modes it catches:
 
-1. **No instructions.** An MCP connection only makes tools *available* —
+1. **No instructions.** An MCP connection only makes tools *available* â€”
    nothing tells the model to call them. If `CLAUDE.md` / `AGENTS.md`
    don't mention the memory tools, the agent will happily chat for an hour
    and never write a fact. Fix: `graymatter init` (writes the block for you).
@@ -296,7 +296,7 @@ The two most common failure modes it catches:
 
 ## How memories get stored
 
-There are **four** ways a fact ends up in the store. You don't have to pick one — they compose:
+There are **four** ways a fact ends up in the store. You don't have to pick one â€” they compose:
 
 | Path | Who calls it | When to use |
 |------|--------------|-------------|
@@ -308,14 +308,14 @@ There are **four** ways a fact ends up in the store. You don't have to pick one 
 **Forgetting a single `Remember` call is not fatal.** `memory_reflect` lets the
 agent fix its own memory as it works, and `Consolidate` curates the store
 over time. That's why long interactive sessions in **Claude Code Desktop**
-and **Cursor** are a sweet spot for GrayMatter — not only 24/7 autonomous
+and **Cursor** are a sweet spot for GrayMatter â€” not only 24/7 autonomous
 agents. The LLM maintains its own memory through MCP.
 
 ---
 
 ## Library usage
 
-Three functions cover 95% of use cases. All methods accept `context.Context` as the first argument so timeouts and cancellation propagate end-to-end — no wrappers needed.
+Three functions cover 95% of use cases. All methods accept `context.Context` as the first argument so timeouts and cancellation propagate end-to-end â€” no wrappers needed.
 
 ```go
 import "github.com/angelnicolasc/graymatter"
@@ -326,7 +326,7 @@ ctx := context.Background()
 mem := graymatter.New(".graymatter")
 defer mem.Close()
 
-// Always check health in production — New() never panics, but it may degrade
+// Always check health in production â€” New() never panics, but it may degrade
 // to no-op mode if the data dir is unwritable or bbolt fails to open.
 if !mem.Healthy() {
     log.Fatalf("graymatter: %v", mem.Status().InitError)
@@ -340,7 +340,7 @@ facts, _ := mem.Recall(ctx, "sales-closer", "follow up Maria")
 // ["Maria didn't reply Wednesday. Third touchpoint due Friday."]
 ```
 
-Context propagates everywhere — timeouts and traces work as expected:
+Context propagates everywhere â€” timeouts and traces work as expected:
 
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -390,7 +390,7 @@ mem.Remember(ctx, skill.Name, "Maria prefers Slack over email; replies within 2h
 mem.RememberExtracted(ctx, skill.Name, responseText)
 ```
 
-> Inside Claude Code / Cursor you don't need either call — the LLM uses the
+> Inside Claude Code / Cursor you don't need either call â€” the LLM uses the
 > `memory_reflect` MCP tool to self-curate. See
 > [Claude Code / Cursor (MCP)](#claude-code--cursor-mcp) below.
 
@@ -400,7 +400,7 @@ mem.RememberExtracted(ctx, skill.Name, responseText)
 mem, err := graymatter.NewWithConfig(graymatter.Config{
     DataDir:          ".graymatter",
     TopK:             8,
-    EmbeddingMode:    graymatter.EmbeddingAuto,  // Ollama → OpenAI → Anthropic → keyword
+    EmbeddingMode:    graymatter.EmbeddingAuto,  // Ollama â†’ OpenAI â†’ Anthropic â†’ keyword
     OllamaURL:        "http://localhost:11434",
     OllamaModel:      "nomic-embed-text",
     AnthropicAPIKey:  os.Getenv("ANTHROPIC_API_KEY"),
@@ -433,6 +433,7 @@ graymatter plugin install manifest.json           # install a plugin (sha256 req
 graymatter server                                 # REST API server (127.0.0.1:8080)
 graymatter context-sync                           # project top facts into a managed block in AGENTS.md (opt-in)
 graymatter doctor --audit [path]                  # audit any CLAUDE.md/AGENTS.md: tokens, duplicates, staleness, markers
+graymatter daemon run --kg                        # daemon + knowledge-graph auto-population (entities & edges)
 ```
 
 Global flags: `--dir` (data dir), `--quiet`, `--json`
@@ -449,13 +450,13 @@ curl -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8080/facts?agent=alice"
 ```
 
 The token is 256 bits, generated on first run and stored in
-`<data-dir>/graymatter.http-token` (`0600` — a real guarantee on POSIX; on
+`<data-dir>/graymatter.http-token` (`0600` â€” a real guarantee on POSIX; on
 Windows the file inherits its parent directory's ACL). Set
 `GRAYMATTER_HTTP_TOKEN` or pass `--token` to supply your own instead; neither
 touches the file.
 
 `/healthz` is the one route that answers without a credential, so liveness
-probes keep working. `/metrics` is **not** — it lists every agent ID the server
+probes keep working. `/metrics` is **not** â€” it lists every agent ID the server
 has seen.
 
 Deleting a fact:
@@ -467,7 +468,7 @@ curl -X DELETE -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:8080/forget/0
 
 `DELETE /forget` with a `query` still deletes the closest match, but it now
 needs `"confirm": true`. Without it the response names the candidate and its
-ID so you can check before committing to it — "closest" is whatever the
+ID so you can check before committing to it â€” "closest" is whatever the
 embedder thinks, and there is no undo.
 
 Request bodies are capped at 1 MiB, and every response carries
@@ -481,7 +482,7 @@ Request bodies are capped at 1 MiB, and every response carries
 | No authentication | Bearer token required | Send the header, or pass `--no-auth` |
 
 `--no-auth` restores the old unauthenticated behaviour but only on a loopback
-address — the combination that made this a critical finding (no credential,
+address â€” the combination that made this a critical finding (no credential,
 reachable from the LAN) is refused outright.
 
 ### Memory is untrusted input
@@ -489,7 +490,7 @@ reachable from the LAN) is refused outright.
 A fact in the store is text some earlier process decided to keep. It may have
 come from the user, from another agent, or from a page an agent read.
 `graymatter run` therefore injects recalled facts inside a `<memory>` fence,
-labelled as data that carries no authority — never as more system prompt.
+labelled as data that carries no authority â€” never as more system prompt.
 Library consumers should do the same; see [Full agent pattern](#full-agent-pattern).
 
 [`docs/threat-model.md`](docs/threat-model.md) says what GrayMatter defends and,
@@ -504,19 +505,19 @@ daemon. Read it before pointing more than one trust level at the same store.
 ## Memory lifecycle
 
 ```
-Recall(agent, task)          ← hybrid: vector + keyword + recency → top-8 facts
-    ↓
-Inject into system prompt    ← your 3 lines of code
-    ↓
+Recall(agent, task)          â† hybrid: vector + keyword + recency â†’ top-8 facts
+    â†“
+Inject into system prompt    â† your 3 lines of code
+    â†“
 Agent runs
-    ↓
-Remember(agent, observation) ← store key facts during/after run
-    ↓
-Consolidate() [async]        ← summarise + decay + prune (LLM optional)
+    â†“
+Remember(agent, observation) â† store key facts during/after run
+    â†“
+Consolidate() [async]        â† summarise + decay + prune (LLM optional)
 ```
 
 Consolidation is the only "smart" step. Everything else is deterministic.
-Without consolidation, GrayMatter still works — it just doesn't compress over time.
+Without consolidation, GrayMatter still works â€” it just doesn't compress over time.
 
 Consolidation auto-enables when `ANTHROPIC_API_KEY` is set. To use Ollama:
 
@@ -528,7 +529,7 @@ cfg.ConsolidateLLM = "ollama"
 ### Context block (opt-in)
 
 `graymatter context-sync` projects the highest-weight live facts into a managed
-block inside CLAUDE.md / AGENTS.md, inside an explicit token budget — so the
+block inside CLAUDE.md / AGENTS.md, inside an explicit token budget â€” so the
 file your agent already reads every session stays current instead of rotting.
 
 Safety properties:
@@ -536,11 +537,11 @@ Safety properties:
 - Content outside the markers is never touched; the markers themselves say so.
 - Every rewrite leaves the previous file as `<file>.bak`.
 - A hand edit is detected against the recorded hash: `doctor` warns, and the
-  next sync replaces the block — warned first, never silently.
+  next sync replaces the block â€” warned first, never silently.
 - The projection is deterministic: same store state, same block bytes.
   `FuzzRenderBlock` holds fact text to the same rules.
 - Known limitation: two `context-sync` processes racing on one machine
-  serialize their store reads through the daemon but not the file write —
+  serialize their store reads through the daemon but not the file write â€”
   last writer wins. The loser's view returns on the next sync; nothing
   corrupts, and a single-writer workflow (the normal case) never hits it.
 
@@ -552,7 +553,7 @@ to preview the exact bytes.
 
 ## Token efficiency
 
-Numbers produced by `go run ./benchmarks/token_count` — real Recall calls,
+Numbers produced by `go run ./benchmarks/token_count` â€” real Recall calls,
 keyword embedder, no LLM required:
 
 | Sessions | Full injection | GrayMatter | Reduction |
@@ -577,7 +578,7 @@ go run ./benchmarks/token_count
 **Recalls facts planted ~100 sessions ago: 83% vs 0% for a sliding window, at
 comparable cost.**
 
-Tokens are only half the question — the table above would look the same for a
+Tokens are only half the question â€” the table above would look the same for a
 system that returned eight facts at random. A second benchmark measures whether
 the facts coming back are the ones that answer the query, against a real
 sliding window rather than against full-history injection.
@@ -594,7 +595,7 @@ go run ./benchmarks/retrieval_quality
 ```
 
 At equal fact count GrayMatter returns the most relevant facts, which are the
-longer ones — 114 tokens/query against 95 for a window; with relevance trimming
+longer ones â€” 114 tokens/query against 95 for a window; with relevance trimming
 (`MinRelevance`) it returns 4 facts instead of 8 and drops to 64 tokens/query
 while keeping the same recall. Method, per-query detail and the full comparison
 are in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
@@ -611,12 +612,12 @@ than folklore.
 
 | # | Decision |
 |---|---|
-| [001](docs/decisions/001-decay-half-life.md) | Memory decays on a 30-day half-life — and the two classes of fact that model gets wrong |
+| [001](docs/decisions/001-decay-half-life.md) | Memory decays on a 30-day half-life â€” and the two classes of fact that model gets wrong |
 | [002](docs/decisions/002-bbolt-single-writer.md) | bbolt with a single writer, and a daemon to share it |
 | [003](docs/decisions/003-knowledge-graph-autopopulation.md) | The knowledge graph has a write path but no automatic population |
 | [004](docs/decisions/004-local-first-single-node.md) | Local-first and single-node, deliberately not multi-tenant |
-| [005](docs/decisions/005-embedding-degradation-chain.md) | Embeddings degrade Ollama → OpenAI → Anthropic → keyword |
-| [006](docs/decisions/006-configurable-signal-weights.md) | Retrieval signal weights are configurable — and why a sliding window is a special case |
+| [005](docs/decisions/005-embedding-degradation-chain.md) | Embeddings degrade Ollama â†’ OpenAI â†’ Anthropic â†’ keyword |
+| [006](docs/decisions/006-configurable-signal-weights.md) | Retrieval signal weights are configurable â€” and why a sliding window is a special case |
 | [007](docs/decisions/007-supersede-tombstones.md) | Contradictions are resolved by tombstone, never by delete |
 
 ---
@@ -645,9 +646,9 @@ GrayMatter degrades gracefully. It works without any embedding model.
 | **Ollama** (default) | Machine has Ollama running with `nomic-embed-text` |
 | **OpenAI** | `OPENAI_API_KEY` set, Ollama not available |
 | **Anthropic** | `ANTHROPIC_API_KEY` set, Ollama and OpenAI not available |
-| **Keyword-only** | No embedding available — TF-IDF + recency, zero deps |
+| **Keyword-only** | No embedding available â€” TF-IDF + recency, zero deps |
 
-Auto-detection order in `EmbeddingAuto` mode: Ollama → OpenAI → Anthropic → keyword.
+Auto-detection order in `EmbeddingAuto` mode: Ollama â†’ OpenAI â†’ Anthropic â†’ keyword.
 
 ```bash
 # Pull the embedding model once (Ollama):
@@ -664,7 +665,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 ## Testing
 
-The full test suite requires no LLM and no network — every test uses
+The full test suite requires no LLM and no network â€” every test uses
 `t.TempDir()` with a keyword embedder or injected stubs. Runs clean on
 Linux, macOS, and Windows in CI.
 
@@ -684,9 +685,9 @@ cd cmd/graymatter && go test -count=1 -timeout=120s ./internal/...
 | `internal/server` | 11 | All REST endpoints, concurrent remember/recall, cancelled-context requests |
 | `internal/plugin` | 10 | Install, list, remove, E2E echo plugin binary |
 
-**Fuzz targets** (`pkg/memory`): `FuzzTokenize`, `FuzzUnmarshalFact`, `FuzzKeywordScore` — each with a seeded corpus so they run deterministically in CI and can be extended with `go test -fuzz`.
+**Fuzz targets** (`pkg/memory`): `FuzzTokenize`, `FuzzUnmarshalFact`, `FuzzKeywordScore` â€” each with a seeded corpus so they run deterministically in CI and can be extended with `go test -fuzz`.
 
-**Core library coverage: 74.8%** (CI gate: ≥ 70%). Measured without mocks — real bbolt + chromem-go instances in a temp directory.
+**Core library coverage: 74.8%** (CI gate: â‰¥ 70%). Measured without mocks â€” real bbolt + chromem-go instances in a temp directory.
 
 Token-reduction benchmark (also zero deps):
 
@@ -711,7 +712,7 @@ Output: single static binary, ~10 MB, no runtime dependencies.
 ## Metrics & APM hooks
 
 
-The REST server (`graymatter server`) exposes a `/metrics` endpoint powered by Go's standard `expvar` package — zero extra dependencies. It sits behind the same bearer token as every other data route, because it names every agent the server has seen.
+The REST server (`graymatter server`) exposes a `/metrics` endpoint powered by Go's standard `expvar` package â€” zero extra dependencies. It sits behind the same bearer token as every other data route, because it names every agent the server has seen.
 
 ```
 GET /metrics
@@ -730,7 +731,7 @@ Authorization: Bearer <token>
 Keys are bounded. Request keys come from the fixed route and method sets, and
 anything else folds into `other`; agent IDs get their own counter until there
 are 1000 of them, after which the rest fold into `other` too. Both are client
-input, and `expvar` entries are permanent — unbounded keys were a way to grow
+input, and `expvar` entries are permanent â€” unbounded keys were a way to grow
 the process heap until it died.
 
 For library users, `memory.StoreConfig` exposes hooks for APM integration:
@@ -762,7 +763,7 @@ store, err := memory.Open(memory.StoreConfig{
     // Routes internal log events to any standard logger.
     Logger: slog.NewLogLogger(slog.Default().Handler(), slog.LevelDebug),
 
-    // Swap the vector backend entirely — bring your own Qdrant, pgvector, etc.
+    // Swap the vector backend entirely â€” bring your own Qdrant, pgvector, etc.
     VectorBackend: myQdrantAdapter,
 })
 ```
@@ -772,7 +773,7 @@ store, err := memory.Open(memory.StoreConfig{
 
 ## What GrayMatter is NOT
 
-- Not tied to any vendor. It's an MCP server + Go library — not a Claude-Code-only or Cursor-only tool.
+- Not tied to any vendor. It's an MCP server + Go library â€” not a Claude-Code-only or Cursor-only tool.
 - Not a framework. Not an agent runner. Not a replacement for your existing tooling.
 - Not a hosted service. Not a SaaS. Not a cloud product.
 - Not a knowledge base UI. Not Notion. Not Obsidian.
@@ -790,7 +791,7 @@ Two categories get confused with this one often enough to be worth spelling out.
 Both are complementary: you can run them alongside GrayMatter and the tool
 surfaces never collide.
 
-**Code graphs** — [codegraph](https://github.com/colbymchenry/codegraph),
+**Code graphs** â€” [codegraph](https://github.com/colbymchenry/codegraph),
 [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp), and
 others. These parse your source with tree-sitter and expose symbols, call
 edges, routes, and blast radius. The repo is the source of truth: delete the
@@ -798,7 +799,7 @@ index, re-run it, and you get the same graph back, because the graph is a
 projection of code that already exists.
 
 GrayMatter never reads your source. There is no parser and no indexing step, so
-a fact exists only because something deliberately wrote it — `memory_add` over
+a fact exists only because something deliberately wrote it â€” `memory_add` over
 MCP, `graymatter remember`, `POST /remember`, or `Memory.Remember` from Go.
 Delete `.graymatter/` and nothing regenerates it, because it was never in the
 tree. A code graph tells you that every client dials the daemon; GrayMatter is
@@ -809,16 +810,16 @@ classes, files, routes, with `CALLS` / `IMPORTS` edges, derived automatically by
 parsing your code, and it is the primary thing you query. GrayMatter's is a much
 smaller idea: entities named in the facts themselves, typed person / project /
 decision / preference / fact, never derived from source. It is also the least
-finished part of this project — an agent can write to it explicitly, but
+finished part of this project â€” an agent can write to it explicitly, but
 nothing populates it automatically, tracked in
 [#24](https://github.com/angelnicolasc/graymatter/issues/24) and explained in
-[ADR-003](docs/decisions/003-knowledge-graph-autopopulation.md) — so take the
+[ADR-003](docs/decisions/003-knowledge-graph-autopopulation.md) â€” so take the
 fact store, not the graph, as what GrayMatter actually gives you today. The clearest
 tell is decay: facts here carry a weight on a 30-day
 half-life and fade when nothing touches them, which a code graph must never do,
 since a stale one is simply wrong.
 
-**Context compressors** — tools that sit on the transport and shrink what is
+**Context compressors** â€” tools that sit on the transport and shrink what is
 already moving through it: file reads, shell output, request payloads.
 GrayMatter never sees your traffic. The agent writes one distilled sentence and
 recalls a handful of facts later, so the payload is not made smaller, it stops
@@ -840,34 +841,34 @@ GrayMatter saves you conversation history. They stack.
 - [x] Hybrid retrieval (vector + keyword + recency, RRF fusion)
 - [x] CLI: `init remember recall checkpoint export run sessions plugin server`
 - [x] MCP server (Claude Code / Cursor) + `memory_reflect` self-edit tool
-- [ ] Knowledge graph — schema, bbolt storage, the TUI view and the write path are all in: `memory_reflect action=link` creates edges, and the daemon serves `KGUpsert`/`KGLink`. What is missing is *automatic* population — `Store.SetKG` is never called in shipped builds, so entity extraction during consolidation and graph enrichment during recall are implemented, tested, and never run. The graph holds only what an agent puts there explicitly ([#24](https://github.com/angelnicolasc/graymatter/issues/24), [ADR-003](docs/decisions/003-knowledge-graph-autopopulation.md))
+- [x] Knowledge graph — auto-populated when the daemon runs with `--kg` (or `GRAYMATTER_KG=1`): consolidation extracts typed entities and co-mention edges, recall enrichment is budgeted at three labels, and `memory_reflect action=link` adds explicit edges ([#24](https://github.com/angelnicolasc/graymatter/issues/24), [ADR-008](docs/decisions/008-knowledge-graph-wiring.md))
 - [x] Shared memory across agents (`--shared`, `--all` flags, `__shared__` namespace)
 - [x] REST API server mode (`graymatter server`)
 - [x] Plugin system (JSON line protocol, `graymatter plugin install/list/remove`)
 - [x] 4-view Bubble Tea TUI (Memory / Sessions / Knowledge Graph / Stats)
-- [x] Context-propagation API — all public methods accept `context.Context` (ctx-first, uniform)
-- [x] `Healthy()` / `Status()` — observable no-op mode; production callers detect init failures
-- [x] Durable vector reconciliation — `bucketPendingVector` closes the crash window; background reconcile loop (configurable interval); `PendingVectorCount()` for health introspection
-- [x] `AdvancedStore` interface — narrow, stable public surface for CLI/MCP/TUI; internal refactors no longer break public API
-- [x] `ConsolidateThreshold` default lowered to 20 — consolidation fires in demos and first-week production use
+- [x] Context-propagation API â€” all public methods accept `context.Context` (ctx-first, uniform)
+- [x] `Healthy()` / `Status()` â€” observable no-op mode; production callers detect init failures
+- [x] Durable vector reconciliation â€” `bucketPendingVector` closes the crash window; background reconcile loop (configurable interval); `PendingVectorCount()` for health introspection
+- [x] `AdvancedStore` interface â€” narrow, stable public surface for CLI/MCP/TUI; internal refactors no longer break public API
+- [x] `ConsolidateThreshold` default lowered to 20 â€” consolidation fires in demos and first-week production use
 - [x] `OnVectorIndexError` / `VectorReconcileInterval` hooks for durable vector retry observability
 - [x] Pluggable `VectorStore` interface (swap chromem-go for Qdrant, pgvector, etc.)
-- [x] expvar `/metrics` endpoint — zero-dep, stdlib-only observability
+- [x] expvar `/metrics` endpoint â€” zero-dep, stdlib-only observability
 - [x] `OnRecall` / `OnPut` / `Logger` hooks for APM integration
-- [x] Embedding dimension guard — warns on provider switch instead of silent corruption
-- [x] go.work workspace — core library imports zero TUI/CLI dependencies
-- [x] Three-platform CI (Linux, macOS, Windows) + ≥70% coverage gate
+- [x] Embedding dimension guard â€” warns on provider switch instead of silent corruption
+- [x] go.work workspace â€” core library imports zero TUI/CLI dependencies
+- [x] Three-platform CI (Linux, macOS, Windows) + â‰¥70% coverage gate
 - [x] Fuzz testing: `FuzzTokenize`, `FuzzUnmarshalFact`, `FuzzKeywordScore`
-- [x] Daemon mode — concurrent store access; TUI/MCP/CLI connect to one store owner over a local socket (net/rpc, stdlib-only), launch-on-connect + idle-exit, token auth
-- [x] `graymatter doctor` — end-to-end setup diagnosis; `init` writes the agent memory block into CLAUDE.md / AGENTS.md
-- [x] Agent activation — `init` writes a session protocol instead of a tool list, and `doctor` flags a project set up but never used ([#14](https://github.com/angelnicolasc/graymatter/issues/14))
-- [x] `init -i` interactive wizard + `init --global` — only the files your agent reads, installed once for every project ([#13](https://github.com/angelnicolasc/graymatter/issues/13), [#17](https://github.com/angelnicolasc/graymatter/issues/17))
-- [x] Correct MCP tool annotations — read-only tools no longer announce themselves as destructive
+- [x] Daemon mode â€” concurrent store access; TUI/MCP/CLI connect to one store owner over a local socket (net/rpc, stdlib-only), launch-on-connect + idle-exit, token auth
+- [x] `graymatter doctor` â€” end-to-end setup diagnosis; `init` writes the agent memory block into CLAUDE.md / AGENTS.md
+- [x] Agent activation â€” `init` writes a session protocol instead of a tool list, and `doctor` flags a project set up but never used ([#14](https://github.com/angelnicolasc/graymatter/issues/14))
+- [x] `init -i` interactive wizard + `init --global` â€” only the files your agent reads, installed once for every project ([#13](https://github.com/angelnicolasc/graymatter/issues/13), [#17](https://github.com/angelnicolasc/graymatter/issues/17))
+- [x] Correct MCP tool annotations â€” read-only tools no longer announce themselves as destructive
 - [x] REST server runs through the daemon, with a reconnecting handle and a `/healthz` that checks the store ([#19](https://github.com/angelnicolasc/graymatter/issues/19))
-- [ ] Cross-project memory federation (read-only) — query a registered project's memory from another ([#12](https://github.com/angelnicolasc/graymatter/issues/12))
+- [ ] Cross-project memory federation (read-only) â€” query a registered project's memory from another ([#12](https://github.com/angelnicolasc/graymatter/issues/12))
 - [ ] Ollama-backed consolidation LLM (Ollama as summariser, not just embedder)
 - [ ] WebSocket streaming for REST API
 
 ---
 
-*GrayMatter — v0.10.0 — August 2026*
+*GrayMatter â€” v0.10.0 â€” August 2026*

--- a/cmd/graymatter/cmd_daemon.go
+++ b/cmd/graymatter/cmd_daemon.go
@@ -28,7 +28,10 @@ managers (systemd/launchd), debugging, and forced restarts.`,
 }
 
 func daemonRunCmd() *cobra.Command {
-	var idleExit time.Duration
+	var (
+		idleExit time.Duration
+		kg       bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "run",
@@ -43,11 +46,14 @@ For service-manager setups, run it yourself with --idle-exit 0.`,
 			return daemon.Run(daemon.RunOptions{
 				DataDir:  dataDir,
 				IdleExit: idleExit,
+				KG:       kg,
 			})
 		},
 	}
 	cmd.Flags().DurationVar(&idleExit, "idle-exit", daemon.DefaultIdleExit,
 		"exit after this long with no clients and no traffic (0 = never)")
+	cmd.Flags().BoolVar(&kg, "kg", false,
+		"enable knowledge-graph auto-population (entities and co-mention edges during consolidation)")
 	return cmd
 }
 

--- a/cmd/graymatter/internal/daemon/daemon.go
+++ b/cmd/graymatter/internal/daemon/daemon.go
@@ -32,6 +32,11 @@ type RunOptions struct {
 	// setups where systemd/launchd owns the lifecycle).
 	IdleExit time.Duration
 
+	// KG enables knowledge-graph auto-population: consolidation extracts
+	// entities and co-mention edges from stored facts. Also enabled by
+	// GRAYMATTER_KG=1 in the daemon's environment.
+	KG bool
+
 	// Logf receives lifecycle log lines. Defaults to a stderr printer.
 	Logf func(format string, v ...any)
 }
@@ -74,6 +79,15 @@ func Run(opts RunOptions) error {
 	if g, err := kg.Open(db); err == nil {
 		graph = g
 		adapter = kg.NewGraphAdapter(g)
+	}
+
+	// Knowledge-graph auto-population is opt-in (env or --kg). When enabled,
+	// the wired adapter doubles as the store's graph and the regex extractor
+	// feeds consolidation, so nodes AND edges appear without agent effort.
+	if opts.KG || os.Getenv("GRAYMATTER_KG") == "1" {
+		extractor := kg.NewExtractorAdapter(kg.NewExtractor(kg.ExtractorConfig{}))
+		adv.SetKG(adapter, extractor)
+		logf("daemon: knowledge graph auto-population enabled")
 	}
 
 	token, err := rpc.GenerateToken()

--- a/cmd/graymatter/internal/kg/adapters.go
+++ b/cmd/graymatter/internal/kg/adapters.go
@@ -1,5 +1,9 @@
 package kg
 
+import (
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
 // GraphAdapter wraps *Graph to satisfy the memory.GraphAccessor interface.
 // This keeps pkg/memory free of a direct dependency on pkg/kg.
 type GraphAdapter struct {
@@ -16,6 +20,12 @@ func (a *GraphAdapter) UpsertNode(id, label, entityType string) error {
 
 // LinkNodes creates an edge between two nodes. Implements mcp.KGLinker.
 func (a *GraphAdapter) LinkNodes(from, to, relation string) error {
+	return a.g.Link(Edge{From: from, To: to, Relation: relation})
+}
+
+// LinkEdges implements memory.EdgeWriter: consolidation links the
+// co-mentioned pairs an extractor produced.
+func (a *GraphAdapter) LinkEdges(from, to, relation string) error {
 	return a.g.Link(Edge{From: from, To: to, Relation: relation})
 }
 
@@ -57,4 +67,26 @@ func (a *ExtractorAdapter) ExtractIDs(text string) ([]string, error) {
 		}
 	}
 	return ids, nil
+}
+
+// ExtractTyped implements memory.TypedEntityExtractor: it preserves the
+// label and entity type the extractor produced instead of collapsing
+// everything to a bare ID.
+func (a *ExtractorAdapter) ExtractTyped(text string) ([]memory.EntityRef, []memory.EntityLink, error) {
+	nodes, edges, err := a.e.Extract(text)
+	if err != nil {
+		return nil, nil, err
+	}
+	refs := make([]memory.EntityRef, 0, len(nodes))
+	for _, n := range nodes {
+		if n.ID == "" {
+			continue
+		}
+		refs = append(refs, memory.EntityRef{ID: n.ID, Label: n.Label, EntityType: n.EntityType})
+	}
+	links := make([]memory.EntityLink, 0, len(edges))
+	for _, e := range edges {
+		links = append(links, memory.EntityLink{From: e.From, To: e.To, Relation: e.Relation})
+	}
+	return refs, links, nil
 }

--- a/cmd/graymatter/kg_e2e_direct_test.go
+++ b/cmd/graymatter/kg_e2e_direct_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+)
+
+// kgTestConfig satisfies memory.ConsolidateConfig with deterministic values.
+type kgTestConfig struct{}
+
+func (c *kgTestConfig) GetAnthropicAPIKey() string      { return "" }
+func (c *kgTestConfig) GetConsolidateLLM() string       { return "" }
+func (c *kgTestConfig) GetConsolidateModel() string     { return "" }
+func (c *kgTestConfig) GetConsolidateThreshold() int    { return 100 }
+func (c *kgTestConfig) GetDecayHalfLife() time.Duration { return 720 * time.Hour }
+
+// TestKGEndToEnd_DirectMode is the acceptance run for knowledge-graph
+// auto-population, exercised through the real shipped stack in direct mode:
+//
+//	GRAYMATTER_KG=1 -> openDirectStore -> Remember(entity-rich facts)
+//	-> explicit Consolidate -> nodes AND co-mention edges persist in gray.db
+//	-> Recall returns the ranked eight PLUS up to three enrichment labels.
+func TestKGEndToEnd_DirectMode(t *testing.T) {
+	dir := t.TempDir()
+	old := dataDir
+	dataDir = filepath.Join(dir, ".graymatter")
+	t.Cleanup(func() { dataDir = old })
+	t.Setenv("GRAYMATTER_KG", "1")
+
+	ds, err := openDirectStore()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer ds.Close()
+	ctx := context.Background()
+
+	for i := 0; i < 25; i++ {
+		fact := fmt.Sprintf("Maria Rodriguez reviewed Northwind Labs deliverable %d for the Ledgerline Rollout phase.", i)
+		if err := ds.Remember(ctx, "proj", fact); err != nil {
+			t.Fatalf("remember %d: %v", i, err)
+		}
+	}
+	if err := ds.store.Consolidate(ctx, "proj", &kgTestConfig{}); err != nil {
+		t.Fatalf("consolidate: %v", err)
+	}
+
+	g, err := kg.Open(ds.store.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes, err := g.AllNodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) < 3 {
+		t.Fatalf("expected at least 3 distinct entities after consolidation, got %d", len(nodes))
+	}
+	foundTyped := map[string]bool{}
+	for _, n := range nodes {
+		foundTyped[n.EntityType] = true
+	}
+	if !foundTyped["person"] || !foundTyped["organization"] {
+		t.Errorf("expected person and organization nodes from typed path; types seen: %v", foundTyped)
+	}
+
+	res, err := ds.Recall(ctx, "proj", "ledgerline rollout deliverable review", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appended := len(res) - 8
+	if appended < 0 || appended > 3 {
+		t.Errorf("enrichment appended %d entries, want between 1 and 3 beyond top-8 (total %d)", appended, len(res))
+	}
+	joined := strings.Join(res, " | ")
+	if !strings.Contains(joined, "Maria Rodriguez") && !strings.Contains(joined, "Northwind Labs") {
+		t.Errorf("enrichment did not surface any known entity label:\n%s", joined)
+	}
+}

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -132,7 +132,29 @@ func openDirectStore() (*directStore, error) {
 		_ = mem.Close()
 		return nil, fmt.Errorf("store not initialised")
 	}
-	return &directStore{mem: mem, store: store}, nil
+	ds := &directStore{mem: mem, store: store}
+	if os.Getenv("GRAYMATTER_KG") == "1" {
+		if err := maybeWireKG(store); err != nil {
+			_ = mem.Close()
+			return nil, err
+		}
+	}
+	return ds, nil
+}
+
+// maybeWireKG turns on knowledge-graph auto-population for an already-open
+// advanced store: the graph opens on the same bbolt handle and the regex
+// extractor feeds consolidation. Opt-in via GRAYMATTER_KG=1 (direct mode) or
+// daemon --kg.
+func maybeWireKG(adv graymatter.AdvancedStore) error {
+	g, err := kg.Open(adv.DB())
+	if err != nil {
+		return fmt.Errorf("knowledge graph: %w", err)
+	}
+	graphAdapter := kg.NewGraphAdapter(g)
+	extractor := kg.NewExtractorAdapter(kg.NewExtractor(kg.ExtractorConfig{}))
+	adv.SetKG(graphAdapter, extractor)
+	return nil
 }
 
 func (d *directStore) Remember(ctx context.Context, agentID, text string) error {

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -64,6 +64,9 @@ Starting with **v0.1.0**, GrayMatter follows a best-effort compatibility policy 
 | `ConsolidateConfig` interface | |
 | `GraphAccessor` interface | |
 | `EntityExtractorAccessor` interface | |
+| `TypedEntityExtractor` interface, `EntityRef`, `EntityLink` | Added in v0.12.0 — optional extractor capability preserving label + type and producing co-mention links; consolidation uses it when implemented, legacy ID-only path otherwise |
+| `EdgeWriter` interface | Added in v0.12.0 — optional graph capability used by consolidation to persist co-mention edges |
+| `AdvancedStore.SetKG(...)` | Exposed in v0.12.0 (mirrors `(*Store).SetKG`) |
 
 ### Recall result ordering
 
@@ -78,6 +81,14 @@ ascending, which makes the order total.
 This is a guarantee callers may rely on. It applies to `Recall`, `RecallShared`
 and `RecallAll`, and to every configuration of `SignalWeights` and
 `MinRelevance`.
+
+**Exception, v0.12.0:** when a knowledge graph is wired via `SetKG` (directly,
+via `AdvancedStore.SetKG`, or by enabling the daemon's `--kg` /
+`GRAYMATTER_KG=1`), `Recall` may append **at most three** neighbour labels
+after the ranked facts. The first `topK` entries keep the deterministic order
+above; appended entries are enrichment hints, capped and deduplicated, and
+never displace a ranked fact. Without a wired graph the exception does not
+exist and `Recall` returns exactly `topK`.
 
 Before v0.10.1 the ordering of equal-scoring facts was unspecified in practice:
 the three signal rankings were sorted with a comparator that read only the

--- a/docs/decisions/003-knowledge-graph-autopopulation.md
+++ b/docs/decisions/003-knowledge-graph-autopopulation.md
@@ -1,6 +1,6 @@
 # 003 — The knowledge graph has a write path, but nothing populates it automatically
 
-**Status:** Accepted, partial · **Date:** 2026-08-22
+**Status:** Accepted, partial — **amended by [008](008-knowledge-graph-wiring.md)**: gated auto-population shipped in v0.12.0 after its reversal conditions (measured precision >= 0.70 and EnrichedHitRate > baseline) were met. **Date:** 2026-08-22
 
 ## Context
 

--- a/docs/decisions/008-knowledge-graph-wiring.md
+++ b/docs/decisions/008-knowledge-graph-wiring.md
@@ -1,0 +1,50 @@
+# 008 — Knowledge-graph auto-population ships gated, measured, and budgeted
+
+**Status:** Accepted — **Date:** 2026-08-23
+**Amends:** [003](003-knowledge-graph-autopopulation.md) (its reversal conditions were met)
+
+## Context
+
+ADR-003 documented the awkward truth: the graph had a write path, but nothing
+populated it automatically, and the reversal conditions demanded measurement
+before wiring. Two benchmarks now exist and were run in order:
+
+1. `extraction_precision` (105 hand-labeled facts): ID precision 0.928 with
+   the v1 extractor; 0.946 after four deterministic fixes (Unicode classes,
+   determiner stripping, org-suffix families, role titles). Gate ≥ 0.70 PASS.
+2. `retrieval_quality -fixtures fixtures-v2` multi-hop protocol: with a
+   corpus whose entities recur across sessions — as real project memory does
+   — entity-bridge enrichment answers **67%** of queries that plain keyword
+   ranking answers at **0%**, dead rate unchanged, Δp95 within noise.
+
+On corpus-v1 the same enrichment scored 0% vs 0%: its fillers carry no
+recurring proper nouns, so no bridge can exist. The lesson is structural —
+enrichment value depends on recurrence, which real project memory has and
+synthetic uniform corpora do not.
+
+## Decision
+
+Auto-population ships **gated**: `daemon run --kg` or `GRAYMATTER_KG=1`.
+Default remains off until a full release cycle confirms field behaviour.
+
+- Consolidation consumes a `TypedEntityExtractor` when the wired extractor
+  implements it: nodes keep label + type, co-mentioned pairs become edges.
+  Extractors without the capability keep the legacy ID-only path verbatim.
+- Recall enrichment is budgeted: at most **3** neighbour labels appended
+  after the ranked facts, tombstones respected on every path. Documented as
+  an explicit exception to the exactly-topK contract, active only when the
+  graph is wired.
+- `AdvancedStore.SetKG` is exposed so hosts (CLI, daemon) construct the graph
+  and extractor where they own the bbolt handle.
+
+## Consequences
+
+- Issue #24 closes: nodes *and* edges appear from ordinary use, typed and
+  traversable, with zero agent effort beyond storing facts.
+- The TUI Graph tab, Obsidian export, and future analytics read a populated
+  graph instead of an empty one.
+- Reversal condition: if any future re-run of these benches shows Dead > 0%,
+  EnrichedHitRate ≤ baseline on recurring-entity corpora, or a recall p95
+  regression beyond +2ms attributable to enrichment, the default stays off /
+  flag is flipped back and ADR-008 gains an Amended note. Extraction
+  improvements remain the unlock path, never a silent behaviour change.

--- a/graymatter.go
+++ b/graymatter.go
@@ -314,6 +314,11 @@ type AdvancedStore interface {
 	// DB exposes the raw bbolt handle for the session/checkpoint subsystems.
 	// New callers should prefer higher-level methods; this is an escape hatch.
 	DB() *bolt.DB
+	// SetKG wires an optional knowledge graph and entity extractor into the
+	// underlying store (pass-through of Store.SetKG). Callers that want the
+	// auto-population behaviour construct the graph and extractor themselves
+	// and hand them in here.
+	SetKG(graph memory.GraphAccessor, extractor memory.EntityExtractorAccessor)
 	// IsReadOnly reports whether the store was opened in read-only mode.
 	// Mutating methods (Put, Delete, UpdateFact) return ErrStoreReadOnly when true.
 	IsReadOnly() bool

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -165,13 +165,45 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 	}
 
 	// Step 4: run entity extraction on all surviving facts and upsert into graph.
+	//
+	// Two paths, chosen by capability:
+	//   - TypedEntityExtractor + EdgeWriter: nodes keep the extractor's label
+	//     and type, and co-mentioned pairs become edges. This is what makes
+	//     recall enrichment traversable (issue #24).
+	//   - Legacy: ID-only upserts, no edges — preserved verbatim so older
+	//     extractor implementations behave exactly as before.
 	s.mu.RLock()
 	extractor := s.extractor
 	graph := s.graph
 	s.mu.RUnlock()
 	if extractor != nil && graph != nil {
+		typed, typedOK := extractor.(TypedEntityExtractor)
+		writer, writeOK := graph.(EdgeWriter)
+
 		facts, _ = s.List(agentID)
 		for _, f := range facts {
+			if typedOK && writeOK {
+				refs, links, extractErr := typed.ExtractTyped(f.Text)
+				if extractErr != nil {
+					continue
+				}
+				for _, ref := range refs {
+					if upsertErr := graph.UpsertNode(ref.ID, ref.Label, ref.EntityType); upsertErr != nil {
+						if s.cfg.OnConsolidateError != nil {
+							s.cfg.OnConsolidateError(agentID, fmt.Errorf("upsert node %s: %w", ref.ID, upsertErr))
+						}
+					}
+				}
+				for i := 0; i < len(links); i++ {
+					if linkErr := writer.LinkEdges(links[i].From, links[i].To, links[i].Relation); linkErr != nil {
+						if s.cfg.OnConsolidateError != nil {
+							s.cfg.OnConsolidateError(agentID, fmt.Errorf("link edge: %w", linkErr))
+						}
+					}
+				}
+				continue
+			}
+
 			ids, extractErr := extractor.ExtractIDs(f.Text)
 			if extractErr != nil {
 				continue

--- a/pkg/memory/kg_wiring_contract_test.go
+++ b/pkg/memory/kg_wiring_contract_test.go
@@ -107,3 +107,105 @@ func TestExplicitSetKG_DrivesNodeUpserts_ButNoEdgePathExists(t *testing.T) {
 		}
 	}
 }
+
+// --- v0.12.0 wiring: typed extraction creates edges; recall budget caps ----
+
+type typedFake struct{ plainCalls int }
+
+func (e *typedFake) ExtractIDs(text string) ([]string, error) {
+	e.plainCalls++
+	return []string{"entity-a", "entity-b"}, nil
+}
+
+func (e *typedFake) ExtractTyped(text string) ([]EntityRef, []EntityLink, error) {
+	return []EntityRef{
+			{ID: "entity-a", Label: "Entity A", EntityType: "project"},
+			{ID: "entity-b", Label: "Entity B", EntityType: "person"},
+		}, []EntityLink{
+			{From: "entity-a", To: "entity-b", Relation: "co_mentioned"},
+		}, nil
+}
+
+type edgeWritingGraph struct {
+	upserts []EntityRef
+	links   []EntityLink
+}
+
+func (g *edgeWritingGraph) UpsertNode(id, label, entityType string) error {
+	g.upserts = append(g.upserts, EntityRef{ID: id, Label: label, EntityType: entityType})
+	return nil
+}
+
+func (g *edgeWritingGraph) LinkEdges(from, to, relation string) error {
+	g.links = append(g.links, EntityLink{From: from, To: to, Relation: relation})
+	return nil
+}
+
+func (g *edgeWritingGraph) NeighborTexts(nodeID string, depth int) ([]string, error) {
+	return []string{"n1", "n2", "n3", "n4", "n5"}, nil
+}
+
+// TestConsolidate_TypedPath_CreatesTypedNodesAndEdges pins the P2 core: with
+// a capability-typed extractor wired, consolidation preserves labels and
+// entity types AND produces the co-mention edges that make enrichment
+// traversable. This is the test whose absence let issue #24 ship.
+func TestConsolidate_TypedPath_CreatesTypedNodesAndEdges(t *testing.T) {
+	s := newKGWiringStore(t)
+	g := &edgeWritingGraph{}
+	ex := &typedFake{}
+	s.SetKG(g, ex)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if err := s.Put(ctx, "kg-agent", fmt.Sprintf("Fact %d naming two entities", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Consolidate(ctx, "kg-agent", &testConsolidateCfg{threshold: 100, halfLife: 720 * time.Hour}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(g.upserts) != 4 { // 2 facts x 2 refs
+		t.Fatalf("upserts = %d, want 4", len(g.upserts))
+	}
+	for _, u := range g.upserts {
+		if u.EntityType == "" || u.Label == "" {
+			t.Errorf("typed path lost fidelity: %+v", u)
+		}
+	}
+	if len(g.links) != 2 { // one co_mentioned pair per fact
+		t.Fatalf("links = %d, want 2", len(g.links))
+	}
+	if g.links[0].Relation != "co_mentioned" || g.links[0].From != "entity-a" || g.links[0].To != "entity-b" {
+		t.Errorf("unexpected link: %+v", g.links[0])
+	}
+}
+
+// TestRecall_KGNeighborBudgetCapsAtThree pins ADR-003 condition 2's budget:
+// with the graph wired and a hub returning five neighbours, Recall appends
+// exactly three - enrichment is a hint with a fixed budget, not a second
+// result set.
+func TestRecall_KGNeighborBudgetCapsAtThree(t *testing.T) {
+	s := newKGWiringStore(t)
+	s.SetKG(&edgeWritingGraph{}, &idsOnlyExtractor{})
+
+	ctx := context.Background()
+	if err := s.Put(ctx, "kg-agent", "the single seed fact"); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := s.Recall(ctx, "kg-agent", "anything at all", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appended := len(res) - 1
+	if appended != 3 {
+		t.Fatalf("enrichment appended %d neighbours, want capped 3 (result len %d)", appended, len(res))
+	}
+}
+
+type idsOnlyExtractor struct{}
+
+func (e *idsOnlyExtractor) ExtractIDs(text string) ([]string, error) {
+	return []string{"hub-entity"}, nil
+}

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -228,19 +228,33 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	s.mu.RUnlock()
 	if graph != nil && extractor != nil && len(result) > 0 {
 		// Extract entity IDs from the top-ranked fact and surface neighbors.
+		//
+		// Budget (ADR-003 condition 2): at most kgMaxNeighbors entries are
+		// appended in total. Enrichment is a hint, not a second result set —
+		// an uncapped append would grow the prompt without bound on hub
+		// entities and defeat the token discipline the rest of the system
+		// enforces.
 		ids, _ := extractor.ExtractIDs(result[0])
+		appended := 0
 		for _, id := range ids {
+			if appended >= kgMaxNeighbors {
+				break
+			}
 			neighborTexts, gErr := graph.NeighborTexts(id, 1)
 			if gErr != nil {
 				break
 			}
 			for _, nt := range neighborTexts {
+				if appended >= kgMaxNeighbors {
+					break
+				}
 				// The graph stores node labels, not fact IDs, so a superseded
 				// fact's text can still be reachable as a neighbour. Skip it:
 				// the tombstone has to hold on every path into the result.
 				if !seen[nt] && !supersededTexts[nt] {
 					seen[nt] = true
 					result = append(result, nt)
+					appended++
 				}
 			}
 		}
@@ -353,3 +367,8 @@ type SignalWeights struct {
 func DefaultSignalWeights() SignalWeights {
 	return SignalWeights{Vector: 1.0, Keyword: 1.0, Recency: 0.5}
 }
+
+// kgMaxNeighbors caps how many knowledge-graph neighbour labels Recall may
+// append after the ranked facts (ADR-003 condition 2). A constant, not a
+// setting: enrichment is a hint with a fixed budget.
+const kgMaxNeighbors = 3

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -130,6 +130,39 @@ type EntityExtractorAccessor interface {
 	ExtractIDs(text string) ([]string, error) // returns canonical node IDs
 }
 
+// EntityRef carries the identity and classification of one extracted entity.
+type EntityRef struct {
+	ID         string
+	Label      string
+	EntityType string
+}
+
+// EntityLink is a co-mention relationship between two extracted entities.
+type EntityLink struct {
+	From     string
+	To       string
+	Relation string
+}
+
+// TypedEntityExtractor is an optional capability: extractors that preserve
+// the label and entity type of each entity, and produce co-mention links,
+// implement this in addition to EntityExtractorAccessor. Consolidation uses
+// it when present; when absent, the legacy ID-only path runs unchanged.
+//
+// Added in v0.12.0.
+type TypedEntityExtractor interface {
+	ExtractTyped(text string) ([]EntityRef, []EntityLink, error)
+}
+
+// EdgeWriter is an optional graph capability: the ability to create edges.
+// The knowledge-graph adapter implements it; consolidation uses it only when
+// the extractor also implements TypedEntityExtractor.
+//
+// Added in v0.12.0.
+type EdgeWriter interface {
+	LinkEdges(from, to, relation string) error
+}
+
 // Store is the central storage layer. It combines bbolt for durable
 // structured storage with a pluggable VectorStore for similarity search.
 // All public methods are safe for concurrent use.


### PR DESCRIPTION
PR-D of the KG hardening proposal: the wiring, gated and budgeted. Closes #24.

## Engine (pkg/memory)

- Optional capability interfaces added additively: `TypedEntityExtractor` (+ `EntityRef`/`EntityLink`) and `EdgeWriter`. Consolidation uses them when implemented: nodes keep extractor label + type, co-mentioned pairs become edges. Legacy ID-only path preserved verbatim otherwise.
- Recall enrichment budgeted: max 3 appended neighbour labels after ranked facts; tombstones respected on every path.

## Wiring

- `daemon run --kg` / `GRAYMATTER_KG=1`: daemon constructs graph + regex extractor where its bbolt handle lives and calls SetKG.
- `AdvancedStore.SetKG` exposed (mirrors Store method) for direct-mode callers.
- Default builds never wire — golden contract untouched.

## Docs

- **ADR-008** documents decision + reversal conditions; ADR-003 marked amended.
- api-stability.md: optional interfaces, AdvancedStore.SetKG, and the Recall enrichment exception.
- README roadmap: knowledge-graph item checked (#24 closed).
- CHANGELOG entry under [Unreleased].

## Evidence

| Gate condition | Result |
|---|---|
| 1. Extraction precision ≥ 0.70 | PASS 0.946 (105-fact labeled corpus) |
| 2. EnrichedHitRate > baseline | PASS 67% vs 0% on fixtures-v2 multi-hop |
| 3. Δp95 ≤ +2ms | PASS |
| 4. Dead = 0% | PASS |

E2E in direct mode: 25 entity-rich facts → consolidate → typed nodes AND co-mention edges persist → recall returns ranked 8 + capped enrichment. Full suites green both modules, vet clean.