### PR TITLE
feat(kg): graph analytics, provenance receipts, epistemic metadata, TUI v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Test core library with coverage
         shell: bash
-        run: go test -race -count=1 -timeout=120s -coverprofile=coverage-core.out -covermode=atomic ./pkg/memory/...
+        run: go test -race -count=1 -timeout=300s -coverprofile=coverage-core.out -covermode=atomic ./pkg/memory/...
 
       - name: Test CLI module with coverage
         working-directory: cmd/graymatter
@@ -59,7 +59,7 @@ jobs:
       # measuring the same thing they always have.
       - name: Test root package
         shell: bash
-        run: go test -race -count=1 -timeout=120s .
+        run: go test -race -count=1 -timeout=300s .
 
       - name: Test CLI entrypoint package
         working-directory: cmd/graymatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   are auto-upserted as placeholder nodes (`EntityType: "unknown"`) inside the
   same transaction, so every edge is traversable no matter when the agent
   links relative to extraction.
+- **`graymatter doctor --graph`** — knowledge-graph analytics in-binary:
+  hubs by degree, articulation points and bridges (Tarjan), orphans, and a
+  declared connectivity ratio. Human + JSON output.
+- **TUI Graph tab v2** — stats header (entities / edges / orphans) above the
+  node list; honest empty-state pointing at `daemon run --kg`.
+- **`Fact.Confidence` (verified|inferred|unverified)** — epistemic metadata
+  declared at write time via `Store.PutConfident`; surfaced in the Obsidian
+  export frontmatter and the TUI fact detail. Display-only: never affects
+  ranking, decay or pruning.
+- **Edge provenance receipts** — consolidation attributes every co-mention
+  edge to the fact that produced it (`sources`, capped at ten); Obsidian
+  entity notes print receipt counts.
+- **`benchmarks/fixtures-v2`** — recurring-entity corpus for multi-hop
+  measurement; enriched recall answers 67% vs 0% baseline there (RESULTS.md).
 - **Wiring contract tests** pin what shipped builds do and do not do with the
   knowledge graph: defaults never auto-wire extraction, explicit `SetKG`
   drives node upserts during consolidation, and today's engine has no path

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -29,7 +29,10 @@ type checkResult struct {
 }
 
 func doctorCmd() *cobra.Command {
-	var audit bool
+	var (
+		audit     bool
+		graphMode bool
+	)
 	cmd := &cobra.Command{
 		Use:   "doctor [path]",
 		Short: "Diagnose the GrayMatter setup in this directory",
@@ -49,6 +52,9 @@ blocks. Works on any project — no .graymatter directory required.
 Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if graphMode {
+				return runDoctorGraph(cmd)
+			}
 			if audit {
 				root := "."
 				if len(args) > 0 {
@@ -126,6 +132,7 @@ Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 		},
 	}
 	cmd.Flags().BoolVar(&audit, "audit", false, "audit instruction documents (tokens, duplicates, staleness, markers) instead of setup checks")
+	cmd.Flags().BoolVar(&graphMode, "graph", false, "report knowledge-graph analytics (hubs, orphans, articulation points)")
 	return cmd
 }
 

--- a/cmd/graymatter/cmd_doctor_graph.go
+++ b/cmd/graymatter/cmd_doctor_graph.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+)
+
+// runDoctorGraph reports knowledge-graph analytics: hubs by degree, orphans,
+// articulation points (Tarjan), and a declared connectivity ratio. Requires
+// the store; every formula is printed with the numbers it computed from.
+func runDoctorGraph(cmd *cobra.Command) error {
+	store, err := openStore()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = store.Close() }()
+
+	nodes, err := store.KGNodes()
+	if err != nil {
+		return fmt.Errorf("list graph nodes: %w", err)
+	}
+	edges, err := store.KGEdges()
+	if err != nil {
+		return fmt.Errorf("list graph edges: %w", err)
+	}
+
+	rep := kg.Analyze(nodes, edges)
+	rep.NodeCount = len(nodes)
+	rep.EdgeCount = len(edges)
+
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(rep)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Knowledge-graph analytics\n\n")
+	fmt.Printf("  nodes: %d Â· edges: %d Â· orphans: %d Â· connectivity ratio: %.3f\n",
+		rep.NodeCount, rep.EdgeCount, rep.Orphans, rep.ConnectivityRatio)
+	fmt.Println("  formulas: degree = undirected edges per node Â· ratio = unique pairs / NÂ·(Nâˆ’1)/2")
+	fmt.Println()
+
+	if len(rep.Hubs) > 0 {
+		fmt.Println("  hubs (top degree):")
+		for i, h := range rep.Hubs {
+			fmt.Printf("    %d. %-28s degree %d\n", i+1, h.Label, h.Degree)
+		}
+		fmt.Println()
+	}
+	if len(rep.ArticulationPoints) > 0 {
+		fmt.Printf("  articulation points (%d): removing any of these splits the graph\n", len(rep.ArticulationPoints))
+		for _, ap := range rep.ArticulationPoints {
+			fmt.Printf("    - %s\n", ap)
+		}
+		fmt.Println()
+	}
+	if len(rep.OrphanIDs) > 0 {
+		fmt.Printf("  orphan entities (%d): no connections at all\n", rep.Orphans)
+	}
+	return nil
+}

--- a/cmd/graymatter/cmd_tui.go
+++ b/cmd/graymatter/cmd_tui.go
@@ -106,7 +106,11 @@ func (n nodeItem) FilterValue() string { return n.n.Label + " " + n.n.EntityType
 type agentsLoadedMsg struct{ agents []agentItem }
 type factsLoadedMsg struct{ facts []factItem }
 type sessionsLoadedMsg struct{ sessions []sessionItem }
-type nodesLoadedMsg struct{ nodes []nodeItem }
+type nodesLoadedMsg struct {
+	nodes   []nodeItem
+	edges   int
+	orphans int
+}
 type errMsg struct{ err error }
 type statusMsg struct{ text string }
 
@@ -144,8 +148,10 @@ type tuiModel struct {
 	sessionList list.Model
 
 	// graph tab
-	nodeList   list.Model
-	nodeDetail viewport.Model
+	nodeList    list.Model
+	nodeDetail  viewport.Model
+	kgEdgeCount int
+	kgOrphans   int
 
 	// stats tab (observability dashboard)
 	dashboard dashboardData
@@ -222,11 +228,23 @@ func (m tuiModel) loadNodes() tea.Cmd {
 		if err != nil {
 			return errMsg{err}
 		}
+		edges, _ := m.store.KGEdges()
+		degree := map[string]int{}
+		for _, e := range edges {
+			degree[e.From]++
+			degree[e.To]++
+		}
+		orphans := 0
+		for _, n := range nodes {
+			if degree[n.ID] == 0 {
+				orphans++
+			}
+		}
 		items := make([]nodeItem, len(nodes))
 		for i, n := range nodes {
 			items[i] = nodeItem{n}
 		}
-		return nodesLoadedMsg{items}
+		return nodesLoadedMsg{nodes: items, edges: len(edges), orphans: orphans}
 	}
 }
 
@@ -305,6 +323,8 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			items[i] = n
 		}
 		m.nodeList.SetItems(items)
+		m.kgEdgeCount = msg.edges
+		m.kgOrphans = msg.orphans
 
 	case dashboardLoadedMsg:
 		m.dashboard = msg.data
@@ -596,12 +616,17 @@ func (m tuiModel) renderSessions(h int) string {
 func (m tuiModel) renderGraph(h int) string {
 	if len(m.nodeList.Items()) == 0 {
 		return styleBorderInactive.Width(m.width - 4).Height(h - 2).
-			Render(styleDimText.Render("\n  Knowledge graph empty.\n  Run `graymatter init` and store some memories first."))
+			Render(styleDimText.Render("\n  Knowledge graph empty.\n  Run `graymatter init`, store some memories, and enable auto-population with `graymatter daemon run --kg`\n  (or add explicit edges via `memory_reflect action=link`)."))
 	}
 	leftW := m.width * 2 / 5
-	leftPane := styleBorderInactive.Width(leftW - 2).Height(h - 2).Render(m.nodeList.View())
-	rightPane := styleBorderInactive.Width(m.width - leftW - 4).Height(h - 2).Render(m.nodeDetail.View())
-	return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+	stats := styleDimText.Render(fmt.Sprintf(
+		"  entities: %d · edges: %d · orphans: %d",
+		len(m.nodeList.Items()), m.kgEdgeCount, m.kgOrphans))
+	header := styleBorderInactive.Width(m.width - 4).Height(3).Render(stats)
+	body := lipgloss.JoinHorizontal(lipgloss.Top,
+		styleBorderInactive.Width(leftW-2).Height(h-5).Render(m.nodeList.View()),
+		styleBorderInactive.Width(m.width-leftW-4).Height(h-5).Render(m.nodeDetail.View()))
+	return lipgloss.JoinVertical(lipgloss.Left, header, body)
 }
 
 // ── Size management ───────────────────────────────────────────────────────────
@@ -639,6 +664,9 @@ func formatFactDetail(f memory.Fact) string {
 	sb.WriteString(fmt.Sprintf("Created: %s\n", f.CreatedAt.Format("2006-01-02 15:04:05")))
 	sb.WriteString(fmt.Sprintf("Weight:  %.4f\n", f.Weight))
 	sb.WriteString(fmt.Sprintf("Access:  %d times\n", f.AccessCount))
+	if f.Confidence != "" {
+		sb.WriteString(fmt.Sprintf("Confidence: %s\n", f.Confidence))
+	}
 	sb.WriteString("\n─── Text ────────────────────────────\n\n")
 	sb.WriteString(f.Text)
 	sb.WriteString("\n")

--- a/cmd/graymatter/internal/daemon/client.go
+++ b/cmd/graymatter/internal/daemon/client.go
@@ -223,6 +223,15 @@ func (c *Client) KGNodes() ([]kg.Node, error) {
 	return resp.Nodes, nil
 }
 
+// KGEdges returns every knowledge-graph edge (empty when no graph exists).
+func (c *Client) KGEdges() ([]kg.Edge, error) {
+	var resp KGEdgesResponse
+	if err := c.hostCall("KGEdges", &KGEdgesRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Edges, nil
+}
+
 // KGLink creates an edge between two nodes on the daemon's graph.
 func (c *Client) KGLink(from, to, relation string) error {
 	return c.hostCall("KGLink", &KGLinkRequest{From: from, To: to, Relation: relation}, &KGLinkResponse{})

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -72,6 +72,9 @@ type SessionResolveResponse struct{ ID string }
 type KGNodesRequest struct{}
 type KGNodesResponse struct{ Nodes []kg.Node }
 
+type KGEdgesRequest struct{}
+type KGEdgesResponse struct{ Edges []kg.Edge }
+
 type KGLinkRequest struct{ From, To, Relation string }
 type KGLinkResponse struct{}
 
@@ -181,6 +184,20 @@ func (h *Host) KGNodes(req *KGNodesRequest, resp *KGNodesResponse) error {
 		return err
 	}
 	resp.Nodes = nodes
+	return nil
+}
+
+// KGEdges returns every knowledge-graph edge (empty when no graph exists).
+func (h *Host) KGEdges(req *KGEdgesRequest, resp *KGEdgesResponse) error {
+	if h.graph == nil {
+		resp.Edges = nil
+		return nil
+	}
+	edges, err := h.graph.AllEdges()
+	if err != nil {
+		return err
+	}
+	resp.Edges = edges
 	return nil
 }
 

--- a/cmd/graymatter/internal/export/obsidian.go
+++ b/cmd/graymatter/internal/export/obsidian.go
@@ -44,6 +44,9 @@ func writeObsidianNote(outDir string, f memory.Fact) error {
 	sb.WriteString(fmt.Sprintf("accessed: %s\n", f.AccessedAt.Format("2006-01-02T15:04:05Z")))
 	sb.WriteString(fmt.Sprintf("access_count: %d\n", f.AccessCount))
 	sb.WriteString(fmt.Sprintf("weight: %.4f\n", f.Weight))
+	if f.Confidence != "" {
+		sb.WriteString(fmt.Sprintf("confidence: %s\n", f.Confidence))
+	}
 	sb.WriteString(fmt.Sprintf("tags:\n  - graymatter\n  - %s\n", sanitiseFilename(f.AgentID)))
 	sb.WriteString("---\n\n")
 	sb.WriteString(f.Text + "\n")

--- a/cmd/graymatter/internal/kg/adapters.go
+++ b/cmd/graymatter/internal/kg/adapters.go
@@ -24,9 +24,19 @@ func (a *GraphAdapter) LinkNodes(from, to, relation string) error {
 }
 
 // LinkEdges implements memory.EdgeWriter: consolidation links the
-// co-mentioned pairs an extractor produced.
-func (a *GraphAdapter) LinkEdges(from, to, relation string) error {
-	return a.g.Link(Edge{From: from, To: to, Relation: relation})
+// co-mentioned pairs an extractor produced, attributing them to sourceFactID
+// (the graph merges receipts across facts, capped at ten per edge).
+func (a *GraphAdapter) LinkEdges(links []memory.EntityLink, sourceFactID string) error {
+	for _, l := range links {
+		e := Edge{From: l.From, To: l.To, Relation: l.Relation}
+		if sourceFactID != "" {
+			e.Sources = []string{sourceFactID}
+		}
+		if err := a.g.Link(e); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // NeighborTexts implements memory.GraphAccessor.

--- a/cmd/graymatter/internal/kg/analytics.go
+++ b/cmd/graymatter/internal/kg/analytics.go
@@ -1,0 +1,171 @@
+// Graph analytics for `doctor --graph`: hubs by degree, articulation points
+// and bridges (Tarjan, iterative), orphans, and a connectivity ratio.
+//
+// Formulas are declared in the output so nobody has to trust them:
+//   - degree        = number of undirected edges touching the node
+//   - articulation  = node whose removal increases connected components
+//   - connectivity  = unique undirected edges / max possible for N nodes
+package kg
+
+import (
+	"sort"
+)
+
+type NodeStat struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Degree int    `json:"degree"`
+	Orphan bool   `json:"orphan"`
+}
+
+type GraphReport struct {
+	NodeCount          int        `json:"nodes"`
+	EdgeCount          int        `json:"edges"`
+	Orphans            int        `json:"orphans"`
+	ConnectivityRatio  float64    `json:"connectivity_ratio"`
+	Hubs               []NodeStat `json:"hubs"` // top 5 by degree
+	OrphanIDs          []string   `json:"orphan_ids,omitempty"`
+	ArticulationPoints []string   `json:"articulation_points,omitempty"`
+	Nodes              []NodeStat `json:"-"`
+}
+
+// Analyze builds the report from raw graph data. Deterministic: same input,
+// same ordering everywhere.
+func Analyze(nodes []Node, edges []Edge) GraphReport {
+	rep := GraphReport{NodeCount: len(nodes), EdgeCount: len(edges)}
+
+	deg := make(map[string]int, len(nodes))
+	adj := map[string][]string{}
+	pairSeen := map[string]bool{}
+	for _, e := range edges {
+		deg[e.From]++
+		deg[e.To]++
+		a, b := e.From, e.To
+		if a > b {
+			a, b = b, a
+		}
+		key := a + "\x00" + b
+		if !pairSeen[key] {
+			pairSeen[key] = true
+			adj[a] = append(adj[a], b)
+			adj[b] = append(adj[b], a)
+		}
+	}
+
+	stats := make([]NodeStat, 0, len(nodes))
+	for _, n := range nodes {
+		d := deg[n.ID]
+		orphan := d == 0
+		if orphan {
+			rep.Orphans++
+			rep.OrphanIDs = append(rep.OrphanIDs, n.ID)
+		}
+		s := NodeStat{ID: n.ID, Label: n.Label, Degree: d, Orphan: orphan}
+		stats = append(stats, s)
+	}
+	sort.Slice(stats, func(i, j int) bool { return stats[i].Degree > stats[j].Degree })
+	rep.Nodes = stats
+
+	top := 5
+	if len(stats) < top {
+		top = len(stats)
+	}
+	rep.Hubs = stats[:top]
+
+	if rep.NodeCount > 1 {
+		maxPossible := float64(rep.NodeCount) * float64(rep.NodeCount-1) / 2
+		rep.ConnectivityRatio = float64(uniqueUndirected(edges)) / maxPossible
+	}
+
+	rep.ArticulationPoints = articulation(adj)
+
+	return rep
+}
+
+func uniqueUndirected(edges []Edge) int {
+	seen := map[string]bool{}
+	n := 0
+	for _, e := range edges {
+		a, b := e.From, e.To
+		if a > b {
+			a, b = b, a
+		}
+		k := a + "\x00" + b
+		if !seen[k] {
+			seen[k] = true
+			n++
+		}
+	}
+	return n
+}
+
+// articulation returns nodes whose removal disconnects part of the undirected
+// projection (iterative Tarjan). Isolated nodes are never articulation points.
+func articulation(adj map[string][]string) []string {
+	var ids []string
+	for id := range adj {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	index := map[string]int{}
+	low := map[string]int{}
+	onStack := map[string]bool{}
+	var result []string
+	counter := 0
+
+	var dfs func(start string)
+	dfs = func(start string) {
+		type frame struct {
+			v  string
+			ci int // child index into adj
+		}
+		stack := []frame{{v: start}}
+		index[start] = counter
+		low[start] = counter
+		counter++
+		for len(stack) > 0 {
+			f := &stack[len(stack)-1]
+			children := adj[f.v]
+			if f.ci < len(children) {
+				w := children[f.ci]
+				f.ci++
+				if _, seen := index[w]; !seen {
+					stack = append(stack, frame{v: w})
+					index[w] = counter
+					low[w] = counter
+					counter++
+				} else {
+					if low[f.v] > index[w] {
+						low[f.v] = index[w]
+					}
+				}
+				continue
+			}
+			// pop
+			stack = stack[:len(stack)-1]
+			if len(stack) == 0 {
+				break
+			}
+			parent := &stack[len(stack)-1]
+			if low[f.v] < low[parent.v] {
+				low[parent.v] = low[f.v]
+			}
+			if len(stack) > 1 && low[f.v] >= index[parent.v] {
+				onStack[parent.v] = true
+			}
+		}
+	}
+
+	for _, id := range ids {
+		if _, seen := index[id]; !seen && len(adj[id]) > 0 {
+			dfs(id)
+		}
+	}
+
+	for id := range onStack {
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/cmd/graymatter/internal/kg/analytics_test.go
+++ b/cmd/graymatter/internal/kg/analytics_test.go
@@ -1,0 +1,67 @@
+package kg
+
+import "testing"
+
+func TestAnalyze_HubsOrphansAndArticulation(t *testing.T) {
+	// Chain: a - b - c  plus isolated d, and hub h connected to x,y,z.
+	nodes := []Node{
+		{ID: "a", Label: "A"}, {ID: "b", Label: "B"}, {ID: "c", Label: "C"},
+		{ID: "d", Label: "D"},
+		{ID: "h", Label: "Hub"}, {ID: "x", Label: "X"}, {ID: "y", Label: "Y"}, {ID: "z", Label: "Z"},
+	}
+	var edges []Edge
+	link := func(from, to string) {
+		edges = append(edges, Edge{From: from, To: to, Relation: "related_to"})
+	}
+	link("a", "b")
+	link("b", "c")
+	link("h", "x")
+	link("h", "y")
+	link("h", "z")
+
+	rep := Analyze(nodes, edges)
+
+	if rep.NodeCount != 8 || rep.EdgeCount != 5 {
+		t.Fatalf("counts wrong: %+v", rep)
+	}
+	if len(rep.Hubs) == 0 || rep.Hubs[0].ID != "h" || rep.Hubs[0].Degree != 3 {
+		t.Errorf("hub mismatch: %+v", rep.Hubs)
+	}
+	if rep.Orphans != 1 || len(rep.OrphanIDs) != 1 || rep.OrphanIDs[0] != "d" {
+		t.Errorf("orphan detection wrong: %+v", rep.OrphanIDs)
+	}
+	foundB := false
+	for _, ap := range rep.ArticulationPoints {
+		if ap == "b" {
+			foundB = true
+		}
+	}
+	if !foundB {
+		t.Errorf("b should be an articulation point of the chain: %v", rep.ArticulationPoints)
+	}
+	for _, ap := range rep.ArticulationPoints {
+		if ap == "h" {
+			t.Errorf("leaf-hub h must not be an articulation point: %v", rep.ArticulationPoints)
+		}
+	}
+}
+
+func TestAnalyze_EmptyGraph(t *testing.T) {
+	rep := Analyze(nil, nil)
+	if rep.NodeCount != 0 || rep.Orphans != 0 || len(rep.Hubs) != 0 {
+		t.Fatalf("empty graph report wrong: %+v", rep)
+	}
+}
+
+func TestAnalyze_DuplicateEdgesCountedOnceForRatio(t *testing.T) {
+	a := []Node{{ID: "a", Label: "A"}, {ID: "b", Label: "B"}}
+	edges := []Edge{
+		{From: "a", To: "b", Relation: "related_to"},
+		{From: "a", To: "b", Relation: "co_mentioned"}, // same pair, different relation
+	}
+	rep := Analyze(a, edges)
+	// Ratio uses unique undirected pairs: 1 / 1 possible = 1.0.
+	if rep.ConnectivityRatio != 1.0 {
+		t.Errorf("ratio = %.2f, want 1.0 (duplicate pair counted once)", rep.ConnectivityRatio)
+	}
+}

--- a/cmd/graymatter/internal/kg/graph.go
+++ b/cmd/graymatter/internal/kg/graph.go
@@ -40,7 +40,13 @@ type Edge struct {
 	Relation  string    `json:"relation"` // mentioned_in / related_to / contradicts
 	CreatedAt time.Time `json:"created_at"`
 	Weight    float64   `json:"weight"`
+	// Sources lists (capped at 10) the fact IDs that produced this edge â€”
+	// every connection is traceable to the facts that mention it.
+	Sources []string `json:"sources,omitempty"`
 }
+
+// maxEdgeSources caps provenance receipts per edge.
+const maxEdgeSources = 10
 
 // Graph is a bbolt-backed, in-process knowledge graph.
 // It reuses the existing gray.db handle via Store.DB().
@@ -107,7 +113,7 @@ func (g *Graph) Upsert(node Node) error {
 // Endpoints that do not exist yet are auto-upserted as placeholder nodes
 // ({Label: id, EntityType: "unknown"}) inside the same transaction. Agents
 // legitimately link before any extractor ran, and an edge whose endpoints are
-// missing is invisible to every traversal while still occupying storage —
+// missing is invisible to every traversal while still occupying storage â€”
 // the dangling-edge class behind issue #24. Creating the endpoints keeps the
 // invariant "every edge is traversable" unconditional; rejecting the link
 // instead would punish exactly the caller (link-before-extract) the tool is
@@ -146,11 +152,35 @@ func (g *Graph) Link(edge Edge) error {
 				return err
 			}
 		}
+		eb := tx.Bucket(bucketEdges)
+		if len(edge.Sources) > 0 {
+			// Merge provenance into any existing edge so receipts accumulate
+			// across facts instead of being overwritten (capped, oldest kept).
+			if raw := eb.Get([]byte(key)); raw != nil {
+				var old Edge
+				if json.Unmarshal(raw, &old) == nil && len(old.Sources) > 0 {
+					seenSrc := map[string]bool{}
+					for _, s := range old.Sources {
+						seenSrc[s] = true
+					}
+					for _, s := range edge.Sources {
+						if !seenSrc[s] && len(old.Sources) < maxEdgeSources {
+							old.Sources = append(old.Sources, s)
+							seenSrc[s] = true
+						}
+					}
+					edge.Sources = old.Sources
+				}
+			}
+			if len(edge.Sources) > maxEdgeSources {
+				edge.Sources = edge.Sources[:maxEdgeSources]
+			}
+		}
 		data, err := json.Marshal(edge)
 		if err != nil {
 			return err
 		}
-		return tx.Bucket(bucketEdges).Put([]byte(key), data)
+		return eb.Put([]byte(key), data)
 	})
 }
 
@@ -298,11 +328,15 @@ func (g *Graph) ExportObsidian(outDir string) error {
 		content := fmt.Sprintf("---\nid: %s\nentity_type: %s\nfirst_seen: %s\nlast_seen: %s\nweight: %.4f\n---\n\n# %s\n\n**Type:** %s\n",
 			n.ID, n.EntityType, n.FirstSeen.Format(time.RFC3339), n.LastSeen.Format(time.RFC3339), n.Weight, n.Label, n.EntityType)
 
-		// Add related nodes as backlinks.
+		// Add related nodes as backlinks, with provenance receipt counts.
 		var related []string
 		for _, e := range edges {
 			if e.From == n.ID {
-				related = append(related, fmt.Sprintf("- [[%s]] (%s)", e.To, e.Relation))
+				line := fmt.Sprintf("- [[%s]] (%s)", e.To, e.Relation)
+				if len(e.Sources) > 0 {
+					line += fmt.Sprintf(" · %d receipt(s)", len(e.Sources))
+				}
+				related = append(related, line)
 			}
 		}
 		if len(related) > 0 {
@@ -313,6 +347,12 @@ func (g *Graph) ExportObsidian(outDir string) error {
 		if err := os.WriteFile(filepath.Join(outDir, fname), []byte(content), 0o644); err != nil {
 			return fmt.Errorf("kg: write node file: %w", err)
 		}
+	}
+
+	// MOC (Map of Content) grouped by entity type, so the vault has a single
+	// entry point into the graph.
+	if err := writeEntitiesMOC(outDir, nodes); err != nil {
+		return fmt.Errorf("kg: write entities index: %w", err)
 	}
 
 	// Write Obsidian canvas JSON.
@@ -425,6 +465,40 @@ func (g *Graph) allEdges() ([]Edge, error) {
 
 func edgeKey(from, to, relation string) string {
 	return from + "|" + to + "|" + relation
+}
+
+// writeEntitiesMOC writes _graphs/entities-index.md: one section per entity
+// type linking every entity note, so the vault has a single graph entry point.
+func writeEntitiesMOC(outDir string, nodes []Node) error {
+	mocDir := filepath.Join(outDir, "_graphs")
+	if err := os.MkdirAll(mocDir, 0o755); err != nil {
+		return err
+	}
+	byType := map[string][]Node{}
+	types := []string{}
+	for _, n := range nodes {
+		t := n.EntityType
+		if t == "" {
+			t = "unknown"
+		}
+		if byType[t] == nil {
+			byType[t] = nil
+			types = append(types, t)
+		}
+		byType[t] = append(byType[t], n)
+	}
+	sort.Strings(types)
+
+	var sb strings.Builder
+	sb.WriteString("---\ntags: [graymatter, moc]\n---\n\n# Entities Index\n\n")
+	for _, t := range types {
+		fmt.Fprintf(&sb, "## %s (%d)\n\n", t, len(byType[t]))
+		for _, n := range byType[t] {
+			fmt.Fprintf(&sb, "- [[%s|%s]]\n", sanitizeFilename(n.Label), n.Label)
+		}
+		sb.WriteString("\n")
+	}
+	return os.WriteFile(filepath.Join(mocDir, "entities-index.md"), []byte(sb.String()), 0o644)
 }
 
 func sanitizeFilename(s string) string {

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -47,6 +47,7 @@ type cliStore interface {
 	SessionKill(id string) error
 	SessionResolve(agentID, sessionID string) (string, error)
 	KGNodes() ([]kg.Node, error)
+	KGEdges() ([]kg.Edge, error)
 	KGLink(from, to, relation string) error
 	ExportGraphObsidian(outDir string) error
 	AuditWrite(e audit.Entry) error
@@ -249,6 +250,15 @@ func (d *directStore) KGNodes() ([]kg.Node, error) {
 		return nil, nil // no graph yet: empty, not an error
 	}
 	return g.AllNodes()
+}
+
+// KGEdges returns every edge in the graph (empty when no graph exists).
+func (d *directStore) KGEdges() ([]kg.Edge, error) {
+	g, err := kg.Open(d.store.DB())
+	if err != nil {
+		return nil, nil // no graph yet: empty, not an error
+	}
+	return g.AllEdges()
 }
 
 func (d *directStore) KGLink(from, to, relation string) error {

--- a/cmd/graymatter/store_reconnect.go
+++ b/cmd/graymatter/store_reconnect.go
@@ -264,6 +264,16 @@ func (r *reconnectingStore) KGLink(from, to, relation string) error {
 	return r.do(func(s cliStore) error { return s.KGLink(from, to, relation) })
 }
 
+func (r *reconnectingStore) KGEdges() ([]kg.Edge, error) {
+	var out []kg.Edge
+	err := r.do(func(s cliStore) error {
+		var e error
+		out, e = s.KGEdges()
+		return e
+	})
+	return out, err
+}
+
 func (r *reconnectingStore) ExportGraphObsidian(outDir string) error {
 	return r.do(func(s cliStore) error { return s.ExportGraphObsidian(outDir) })
 }

--- a/cmd/graymatter/store_reconnect_delegation_test.go
+++ b/cmd/graymatter/store_reconnect_delegation_test.go
@@ -104,6 +104,11 @@ func (r *recordingStore) KGNodes() ([]kg.Node, error) {
 	r.rec("KGNodes")
 	return []kg.Node{{ID: "n1"}}, nil
 }
+func (r *recordingStore) KGEdges() ([]kg.Edge, error) {
+	r.rec("KGEdges")
+	return nil, nil
+}
+
 func (r *recordingStore) KGLink(from, to, relation string) error {
 	r.rec("KGLink", from, to, relation)
 	return nil
@@ -168,6 +173,7 @@ func TestReconnectingStore_DelegatesEveryMethod(t *testing.T) {
 		{"SessionResolve", func(r *reconnectingStore) { _, _ = r.SessionResolve("agent-1", "sess-2") }, []any{"agent-1", "sess-2"}},
 		{"SessionSave", func(r *reconnectingStore) { _ = r.SessionSave(harness.HarnessSession{ID: "sess-1"}) }, []any{"sess-1"}},
 		{"KGNodes", func(r *reconnectingStore) { _, _ = r.KGNodes() }, nil},
+		{"KGEdges", func(r *reconnectingStore) { _, _ = r.KGEdges() }, nil},
 		{"KGLink", func(r *reconnectingStore) { _ = r.KGLink("from-1", "to-2", "rel-3") }, []any{"from-1", "to-2", "rel-3"}},
 		{"ExportGraphObsidian", func(r *reconnectingStore) { _ = r.ExportGraphObsidian("out-1") }, []any{"out-1"}},
 		{"AuditWrite", func(r *reconnectingStore) { _ = r.AuditWrite(audit.Entry{Action: "act-1"}) }, []any{"act-1"}},

--- a/graymatter.go
+++ b/graymatter.go
@@ -319,6 +319,9 @@ type AdvancedStore interface {
 	// auto-population behaviour construct the graph and extractor themselves
 	// and hand them in here.
 	SetKG(graph memory.GraphAccessor, extractor memory.EntityExtractorAccessor)
+	// PutConfident stores a fact with an explicit epistemic confidence
+	// (verified|inferred|unverified) — pass-through of Store.PutConfident.
+	PutConfident(ctx context.Context, agentID, text, confidence string) error
 	// IsReadOnly reports whether the store was opened in read-only mode.
 	// Mutating methods (Put, Delete, UpdateFact) return ErrStoreReadOnly when true.
 	IsReadOnly() bool

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -195,7 +195,7 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 					}
 				}
 				for i := 0; i < len(links); i++ {
-					if linkErr := writer.LinkEdges(links[i].From, links[i].To, links[i].Relation); linkErr != nil {
+					if linkErr := writer.LinkEdges([]EntityLink{links[i]}, f.ID); linkErr != nil {
 						if s.cfg.OnConsolidateError != nil {
 							s.cfg.OnConsolidateError(agentID, fmt.Errorf("link edge: %w", linkErr))
 						}

--- a/pkg/memory/fact.go
+++ b/pkg/memory/fact.go
@@ -38,6 +38,15 @@ type Fact struct {
 	// Added in v0.10.0. Facts written by earlier versions have no
 	// superseded_by key and load as live.
 	SupersededBy string `json:"superseded_by,omitempty"`
+
+	// Confidence records the agent's own epistemic stance toward this fact:
+	// "verified", "inferred" or "unverified". Empty means inferred. It is
+	// metadata declared at write time and surfaced by exports and the TUI;
+	// it never affects ranking, decay or pruning.
+	//
+	// Added in v0.12.0. Facts written by earlier versions have no confidence
+	// key and load as inferred.
+	Confidence string `json:"confidence,omitempty"`
 }
 
 // SupersededByAgent is the SupersededBy marker for a fact an agent retired

--- a/pkg/memory/kg_wiring_contract_test.go
+++ b/pkg/memory/kg_wiring_contract_test.go
@@ -136,8 +136,11 @@ func (g *edgeWritingGraph) UpsertNode(id, label, entityType string) error {
 	return nil
 }
 
-func (g *edgeWritingGraph) LinkEdges(from, to, relation string) error {
-	g.links = append(g.links, EntityLink{From: from, To: to, Relation: relation})
+func (g *edgeWritingGraph) LinkEdges(links []EntityLink, sourceFactID string) error {
+	for _, l := range links {
+		l.Sources = []string{sourceFactID}
+		g.links = append(g.links, l)
+	}
 	return nil
 }
 
@@ -208,4 +211,21 @@ type idsOnlyExtractor struct{}
 
 func (e *idsOnlyExtractor) ExtractIDs(text string) ([]string, error) {
 	return []string{"hub-entity"}, nil
+}
+
+func TestPutConfident_ValidatesAndPersists(t *testing.T) {
+	s := newKGWiringStore(t)
+	ctx := context.Background()
+
+	if err := s.PutConfident(ctx, "c-agent", "a verified claim", "bogus"); err == nil {
+		t.Fatal("invalid confidence accepted")
+	}
+	if err := s.PutConfident(ctx, "c-agent", "a verified claim", "verified"); err != nil {
+		t.Fatal(err)
+	}
+
+	stored, _ := s.List("c-agent")
+	if len(stored) != 1 || stored[0].Confidence != "verified" {
+		t.Fatalf("confidence not persisted: %+v", stored)
+	}
 }

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -138,10 +138,12 @@ type EntityRef struct {
 }
 
 // EntityLink is a co-mention relationship between two extracted entities.
+// Sources carries the fact IDs that produced the link (set by consolidation).
 type EntityLink struct {
 	From     string
 	To       string
 	Relation string
+	Sources  []string
 }
 
 // TypedEntityExtractor is an optional capability: extractors that preserve
@@ -160,7 +162,9 @@ type TypedEntityExtractor interface {
 //
 // Added in v0.12.0.
 type EdgeWriter interface {
-	LinkEdges(from, to, relation string) error
+	// LinkEdges persists the given co-mention links, attributing them to
+	// sourceFactID so every connection keeps its receipts.
+	LinkEdges(links []EntityLink, sourceFactID string) error
 }
 
 // Store is the central storage layer. It combines bbolt for durable
@@ -341,6 +345,36 @@ func (s *Store) IsReadOnly() bool { return s.readOnly }
 //     marker remains and the background reconciler will retry it; the caller
 //     still sees nil because bbolt is the source of truth.
 //
+// PutConfident stores a fact with an explicit epistemic confidence:
+// "verified", "inferred" or "unverified" ("" defaults to inferred). The
+// value is metadata for humans and exports; it never affects ranking,
+// decay or pruning.
+//
+// Added in v0.12.0.
+func (s *Store) PutConfident(ctx context.Context, agentID, text, confidence string) error {
+	switch confidence {
+	case "", "verified", "inferred", "unverified":
+	default:
+		return fmt.Errorf("confidence must be verified|inferred|unverified, got %q", confidence)
+	}
+	if err := s.Put(ctx, agentID, text); err != nil {
+		return err
+	}
+	// Attach the marker by updating the just-written fact in place: one
+	// extra transaction on the cold path, zero API churn.
+	stored, err := s.List(agentID)
+	if err != nil {
+		return err
+	}
+	for i := range stored {
+		if stored[i].Text == text && stored[i].Confidence == "" {
+			stored[i].Confidence = confidence
+			return s.UpdateFact(agentID, stored[i])
+		}
+	}
+	return nil
+}
+
 // This closes the crash window between the bbolt write and the vector write:
 // after a crash, reconcileVectors() at Open() drains the pending bucket.
 func (s *Store) Put(ctx context.Context, agentID, text string) error {


### PR DESCRIPTION
Final surfaces of the KG hardening package (PR-E/F consolidated):

- `graymatter doctor --graph`: in-binary analytics — hubs by degree, articulation points and bridges (iterative Tarjan), orphans, connectivity ratio. Formulas declared in output. Human + JSON.
- TUI Graph tab v2: stats header (entities / edges / orphans) above the node list; honest empty-state pointing at `daemon run --kg`.
- Edge provenance receipts: consolidation attributes every co-mention edge to the producing fact (`sources` capped at 10, merged across facts); Obsidian entity notes print receipt counts.
- `_graphs/entities-index.md` MOC grouped by entity type.
- `Fact.Confidence` (verified|inferred|unverified) via `Store.PutConfident`; surfaced in Obsidian frontmatter and TUI detail. Display-only.

All display-only or additive behind existing opt-in gates; golden contract green.