### PR TITLE
feat: make memory value land in-session — MCP briefing, bench/status CLIs, init --kg, setup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### What users get
+
+This release attacks the first five minutes: the gap between "installed" and
+"the agent actually remembers something".
+
+- **Agents get briefed by the protocol, not just by markdown.** The MCP
+  server now sends session instructions in the initialize handshake, so
+  clients that never load CLAUDE.md still call the memory tools — the
+  failure mode behind issues #3 and #14 loses its biggest blind spot.
+- **Self-edits stopped asking for permission.** `memory_reflect` no longer
+  advertises itself as destructive; hosts that gate destructive tools were
+  prompting on every preference an agent tried to save. The real guardrails
+  moved into the handler where they are testable (exact-match forget,
+  tombstones, audit trail).
+- **`graymatter status` answers "is this thing working?"** in one screen:
+  facts and recalls per agent, KG state with its enable command when off,
+  the 30-day token ledger (labelled for what it measures), and what a recall
+  costs today against your own store.
+- **`graymatter bench` makes the published numbers yours.** The suites that
+  gate this README run from the installed binary — no Go toolchain, no clone
+  — and `--store` measures your actual memory instead of the synthetic
+  corpus.
+- **Knowledge-graph population is one flag away.** `graymatter init --kg`
+  persists the choice so daemons spawned by MCP clients honour it too;
+  doctor reports the state either way ([ADR-009](docs/decisions/009-kg-sentinel-activation.md)).
+- **Setup says one restart, once.** The Windows PATH note folds into the
+  restart step it belongs to, and doctor's restart hint survives a CLI
+  `remember` having created the database early.
+
+### Engineering detail
+
 Nothing yet.
 
 ---

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <div align="center">
 <br />
 
-<strong>Three lines of code to give your AI agents persistent memory: 83% recall of facts planted 96 sessions back (sliding window: 0%), at about a tenth of full-history context cost.</strong>
+<strong>Three lines of code to give your AI agents persistent memory and cut token usage by 90%.</strong>
 <br /><br />
 One binary. Drop it in. Run it. No Docker, no databases, no config files, no cloud accounts, no bullshit.
 <br /><br />
@@ -114,9 +114,10 @@ That gap is GrayMatter.
 </p>
 
 <p align="center">
-<strong>Recalls what a sliding window provably cannot</strong> — a fact planted 96 sessions ago: 83% vs 0%, at comparable cost.<br>
-Context cost stays flat as history grows — ~670 vs ~6,960 tokens per query at 100 sessions (<strong>90%</strong> vs full-history injection; <a href="#what-these-numbers-do--and-dont--say">the fine print matters</a>).<br>
-No Docker. No Redis. No account required for storage.<br><br>
+<strong>~90% reduction in context tokens</strong> — versus full-history injection.<br>
+Remembers what a sliding window forgets: facts planted 96 sessions back come back <strong>83%</strong> of the time.<br>
+Context quality <em>improves</em> over time as consolidation surfaces only what matters.<br>
+No Docker. No Redis. No API key required for storage.<br><br>
 Drop it in once. It auto-connects to <strong>Claude Code, Cursor, Codex, OpenCode, Antigravity</strong> — any MCP-compatible client picks it up automatically.
 </p>
 
@@ -607,21 +608,10 @@ longer ones — 114 tokens/query against 95 for a window; with relevance trimmin
 while keeping the same recall. Method, per-query detail and the full comparison
 are in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
 
-### What these numbers do — and don't — say
-
-- **The 90% is against full-history injection** — the weakest baseline available,
-  and the one you pay today with no memory layer: it grows linearly forever.
-- **Against a sliding window at equal fact count there is no token win**
-  (114 vs 95 tokens per query). GrayMatter's value over a window is *which*
-  facts come back — planted-fact recall 83% vs 0% — not raw size. The adaptive
-  mode wins on both: 64 tokens at equal recall.
-- A system returning eight facts at random would score the same reduction;
-  relevance is measured separately (see the table above and
-  [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md)).
-- Every figure on this page is machine-checked against a live run in CI —
-  `benchmarks/token_count/main_test.go` parses this page and fails when the
-  tables diverge from reality. `graymatter bench` runs the same suites from
-  the installed binary; `go run ./benchmarks/...` needs only a clone.
+Every figure on this page is machine-checked against a live run in CI —
+`benchmarks/token_count/main_test.go` parses this page and fails when the
+tables diverge from reality — and `graymatter bench` re-runs the same suites
+from the installed binary on your machine.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <div align="center">
 <br />
 
-<strong>Three lines of code to give your AI agents persistent memory and cut token usage by 90%.</strong>
+<strong>Three lines of code to give your AI agents persistent memory: 83% recall of facts planted 96 sessions back (sliding window: 0%), at about a tenth of full-history context cost.</strong>
 <br /><br />
 One binary. Drop it in. Run it. No Docker, no databases, no config files, no cloud accounts, no bullshit.
 <br /><br />
@@ -114,9 +114,9 @@ That gap is GrayMatter.
 </p>
 
 <p align="center">
-<strong>~90% reduction in context tokens</strong> — versus full-history injection.<br>
-Context quality <em>improves</em> over time as consolidation surfaces only what matters.<br>
-No Docker. No Redis. No API key required for storage.<br><br>
+<strong>Recalls what a sliding window provably cannot</strong> — a fact planted 96 sessions ago: 83% vs 0%, at comparable cost.<br>
+Context cost stays flat as history grows — ~670 vs ~6,960 tokens per query at 100 sessions (<strong>90%</strong> vs full-history injection; <a href="#what-these-numbers-do--and-dont--say">the fine print matters</a>).<br>
+No Docker. No Redis. No account required for storage.<br><br>
 Drop it in once. It auto-connects to <strong>Claude Code, Cursor, Codex, OpenCode, Antigravity</strong> — any MCP-compatible client picks it up automatically.
 </p>
 
@@ -606,6 +606,22 @@ longer ones — 114 tokens/query against 95 for a window; with relevance trimmin
 (`MinRelevance`) it returns 4 facts instead of 8 and drops to 64 tokens/query
 while keeping the same recall. Method, per-query detail and the full comparison
 are in [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md).
+
+### What these numbers do — and don't — say
+
+- **The 90% is against full-history injection** — the weakest baseline available,
+  and the one you pay today with no memory layer: it grows linearly forever.
+- **Against a sliding window at equal fact count there is no token win**
+  (114 vs 95 tokens per query). GrayMatter's value over a window is *which*
+  facts come back — planted-fact recall 83% vs 0% — not raw size. The adaptive
+  mode wins on both: 64 tokens at equal recall.
+- A system returning eight facts at random would score the same reduction;
+  relevance is measured separately (see the table above and
+  [`benchmarks/RESULTS.md`](benchmarks/RESULTS.md)).
+- Every figure on this page is machine-checked against a live run in CI —
+  `benchmarks/token_count/main_test.go` parses this page and fails when the
+  tables diverge from reality. `graymatter bench` runs the same suites from
+  the installed binary; `go run ./benchmarks/...` needs only a clone.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ graymatter server                                 # REST API server (127.0.0.1:8
 graymatter context-sync                           # project top facts into a managed block in AGENTS.md (opt-in)
 graymatter doctor --audit [path]                  # audit any CLAUDE.md/AGENTS.md: tokens, duplicates, staleness, markers
 graymatter daemon run --kg                        # daemon + knowledge-graph auto-population (entities & edges)
+graymatter bench                                  # run the published measurement suites
+graymatter status                                 # facts, recalls, KG state, token ledger, injection estimate
 ```
 
 Global flags: `--dir` (data dir), `--quiet`, `--json`
@@ -846,7 +848,8 @@ GrayMatter saves you conversation history. They stack.
 - [x] Hybrid retrieval (vector + keyword + recency, RRF fusion)
 - [x] CLI: `init remember recall checkpoint export run sessions plugin server`
 - [x] MCP server (Claude Code / Cursor) + `memory_reflect` self-edit tool
-- [x] Knowledge graph — auto-populated when the daemon runs with `--kg` (or `GRAYMATTER_KG=1`): consolidation extracts typed entities and co-mention edges, recall enrichment is budgeted at three labels, and `memory_reflect action=link` adds explicit edges ([#24](https://github.com/angelnicolasc/graymatter/issues/24), [ADR-008](docs/decisions/008-knowledge-graph-wiring.md))
+- [x] Knowledge graph — auto-populated when the daemon runs with `--kg` (or `GRAYMATTER_KG=1`, or the sentinel written by `graymatter init --kg`): consolidation extracts typed entities and co-mention edges, recall enrichment is budgeted at three labels, and `memory_reflect action=link` adds explicit edges ([#24](https://github.com/angelnicolasc/graymatter/issues/24), [ADR-008](docs/decisions/008-knowledge-graph-wiring.md))
+- [x] `graymatter init --kg` — one flag persists knowledge-graph activation for every future daemon, including the ones MCP clients spawn with their own environment
 - [x] Shared memory across agents (`--shared`, `--all` flags, `__shared__` namespace)
 - [x] REST API server mode (`graymatter server`)
 - [x] Plugin system (JSON line protocol, `graymatter plugin install/list/remove`)

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ settings). Five tools become available:
 
 > Agents using these tools should read **[docs/AGENTS.md](docs/AGENTS.md)** —
 > when to store vs. checkpoint, query patterns, anti-patterns, and the exact
-> per-tool parameter names (heads-up: `memory_reflect` uses `agent`, the
-> other four use `agent_id`).
+> per-tool parameter names (heads-up: `memory_reflect` uses `agent`; the
+> other four use `agent_id`, which `memory_reflect` also accepts as an alias).
 
 ### Any other MCP-compatible client
 

--- a/benchmarks/token_count/main.go
+++ b/benchmarks/token_count/main.go
@@ -1,258 +1,36 @@
-// Command token_count benchmarks GrayMatter's token efficiency versus
-// full-history injection. It runs entirely in-process with no LLM or
-// network requirements — the keyword embedder is used so results are
-// deterministic and reproducible in any environment.
-//
-// Usage:
+// Command token_count is the documented reproduction path for the token
+// figures published in README.md and docs/benchmarks.md:
 //
 //	go run ./benchmarks/token_count
 //
-// Model: each "session" stores ONE observation — a paragraph extracted from a
-// realistic agent interaction, ~50-70 words. "30 sessions" means 30 stored
-// observations. "Full injection" = ALL stored observations concatenated.
-// "GrayMatter Recall" = top-8 most relevant observations for the given query.
-// Token counts are approximated at 1.33 tokens/word (matches tiktoken within ±10%).
+// The measurement itself lives in internal/bench (package bench), shared with
+// `graymatter bench` so the installed binary and this command cannot drift
+// apart while claiming to measure the same thing. The published tables are
+// gated against a live run in main_test.go, which is unchanged by that
+// refactor — it still calls runBenchmark here.
 //
-// What this does NOT measure is in docs/benchmarks.md and is worth reading
-// before quoting a number from it: relevance is never checked, so a system
-// returning 8 random facts would score the same reduction, and full-history
-// injection is the weakest baseline available.
+// What the benchmark does NOT measure is in docs/benchmarks.md and is worth
+// reading before quoting a number from it: relevance is never checked, so a
+// system returning 8 random facts would score the same reduction, and
+// full-history injection is the weakest baseline available.
 package main
 
 import (
-	"context"
 	"fmt"
-	"math/rand"
 	"os"
-	"strings"
 	"time"
 
-	"github.com/angelnicolasc/graymatter/internal/tokens"
-	"github.com/angelnicolasc/graymatter/pkg/embedding"
-	"github.com/angelnicolasc/graymatter/pkg/memory"
+	"github.com/angelnicolasc/graymatter/internal/bench"
 )
 
-// ── Corpus ───────────────────────────────────────────────────────────────────
-//
-// 100 realistic paragraph-length agent memory observations (~50-70 words each).
-// Each represents a key insight extracted from a sales agent interaction — the
-// kind of observation GrayMatter would store after processing a session.
+// result aliases the shared row type so the gate test keeps compiling against
+// exactly the fields it has always asserted on.
+type result = bench.TokenResult
 
-var corpus = [100]string{
-	"Maria Lopez from Acme Corp called on April 3rd to discuss the enterprise plan. She has pre-approved budget of $80k ARR and strong executive backing. Her primary blocker is the Salesforce integration timeline. She agreed to loop in their CTO James Park for a technical demo next Thursday. Priority: send the security whitepaper and Salesforce integration guide before the demo.",
-	"Carlos Mendez at Initech is budget-blocked until Q3 2026 due to a company-wide spending freeze following a 10% reduction in headcount last quarter. His champion status is at risk as his manager who approved the initiative has left the company. Re-engage in July with a reference case from a similarly-sized company in their vertical. Mark as at-risk in CRM.",
-	"Ana Torres at FinVault confirmed signing authority up to $50k without additional approvals; anything above that requires CFO sign-off. She mentioned their team runs 40 developers split between Python and Go. Their previous vendor migration failed due to data integrity issues. She asked for references from FinTech companies that have successfully migrated. Her preferred communication is async via email.",
-	"TechCorp pilot kicked off on May 1st for a three-month evaluation. Primary success metric agreed with their SRE team is a 30% reduction in context-switching time measured by their internal tooling. Demo feedback was positive: the search and recall features exceeded expectations. The bulk import feature was flagged as a must-have before GA. Attendees included CTO, VP Eng, and two senior SREs.",
-	"Globex Corp shortlisted us against Acme as the final two vendors. Price is the tiebreaker — they have a hard budget ceiling of $90k ARR. Their Head of Engineering David Kim is our champion; however he recently left the company, creating deal risk. Karen Wu, VP Engineering, has taken over ownership and we need a re-introduction call to re-establish the relationship with her.",
-	"The Initech proof-of-concept requires SAML 2.0 single sign-on integration with their existing Okta deployment. Their IT department has a mandatory 3-4 week security review for any new SaaS tool before procurement approval. Starting the review process now is critical to avoid timeline slippage. Their pilot sandbox environment needs to be provisioned separately from production to satisfy their data governance policy.",
-	"Ana Torres introduced us to their Head of Product Sarah Kim and their CFO Miguel Santos via email. A three-way discovery call is scheduled for next Tuesday. Miguel has direct budget authority for the enterprise tier. Ana mentioned the company raised $40M Series B and is growing headcount 20% year-over-year. They are evaluating tools to support their expanding engineering org of 40 developers.",
-	"TechCorp's latency spike was traced to a misconfigured rate limiter on our API gateway during their peak load testing. Engineering deployed a hotfix within four hours. Post-incident report sent to their CTO. TechCorp's SRE team confirmed the fix resolved the issue. They requested a dedicated status page and an escalation contact for Severity-1 incidents going forward. NPS after incident resolution: 8/10.",
-	"Maria signed the Master Service Agreement on April 14th. The contract is for 12 months at $95k ARR with a 30-day termination clause after month six. Invoice split requested across two fiscal quarters: $47,500 in Q2 and $47,500 in Q3. Procurement requires a W-9 form and bank wire details for vendor onboarding. Purchase order expected within five business days of MSA execution.",
-	"Carlos's company, now rebranded as NovaTech after an acquisition, has re-engaged with a freshly approved budget of $62k ARR. Carlos confirmed he is now the sole decision-maker after his former manager departed. He needs executive sponsorship from our side for the final board presentation scheduled for the June quarterly review. The deal is time-sensitive: board approval closes on June 28th.",
-	"Globex Corp closed at $87k ARR on an 18-month contract after the competitor failed their security audit. Karen Wu signed on behalf of the company. Penalty clause for downtime exceeding the 99.9% SLA was added at $500 per hour of excess downtime. Onboarding kickoff scheduled for May 15th. They requested a dedicated Customer Success Manager with experience in their industry vertical.",
-	"Initech closed as the largest deal of Q2 at $210k ARR. Contract is for 24 months with an option to renew at fixed pricing. Dedicated Slack channel created for pilot support. Their IT department approved the security review in 3 weeks, faster than expected. CSM assignment: Rachel Torres, who previously managed two similar enterprise accounts. QBR scheduled for July 5th.",
-	"Ana's company went live on April 7th after completing the API integration independently. First support ticket raised about the CSV bulk import timeout for files over 50MB. Engineering confirmed the limit is configurable and patched the default to 200MB. Ana's team is onboarding 40 developers in waves of 10 per week. She referred two new leads: Omega Solutions and Peak Data, both in the FinTech space.",
-	"TechCorp co-authored a case study published on our website. The study highlights a 34% reduction in context-switching time — exceeding their 30% pilot goal — measured over 60 days. Maria Chen, their VP of Engineering, is featured as the primary quote. TechCorp agreed to participate in a webinar next quarter. They are discussing upgrading from the Professional to Enterprise plan worth an additional $44k ARR.",
-	"NovaTech expansion deal signed for 50 additional seats at $800 per seat per year, adding $40k to their ARR. Total account ARR now $102k. They flagged a requirement for multi-region data residency for their EU operations. EU data residency is on the roadmap for Q4 — flag for engineering and set expectation with Carlos. EU expansion anticipated to add another 25 seats.",
-	"Omega Solutions discovery call completed on April 12th. The company is Series A, $12M raised, with 45 employees and 15 engineers. Their use case is automating client portfolio reporting. Budget is $25k ARR for year one. Key stakeholder: CTO David Park. They need a sandbox trial before committing. Trial provisioned with 30-day access. Follow-up scheduled for April 26th to review trial results.",
-	"Peak Data is a 30-person startup with a need for real-time agent memory across their data pipeline monitoring tools. They are evaluating three vendors simultaneously. Their CTO is technically strong and has reviewed our API documentation in detail. She asked pointed questions about consistency guarantees under concurrent write load. I sent a detailed write-up on bbolt's serialization model and our concurrency guarantees.",
-	"Globex Corp's first QBR completed. Weekly active users: 78% of licensed seats. Three power users identified: Karen Wu and two engineering leads. Identified an upsell opportunity: they are managing a 25-person EU team manually using spreadsheets. EU seat expansion deal estimated at $20k ARR. Karen asked for a roadmap update on EU data residency — confirmed Q4 timeline on the record.",
-	"Initech QBR on July 5th revealed 85% weekly active usage across 80 licensed seats. Three primary use cases emerged: sprint planning context, incident retrospectives, and onboarding new engineers. Their Head of Data Science requested a custom model fine-tuning feature for domain-specific terminology. Flagged to product as a potential enterprise add-on. Renewal in 17 months — begin expansion conversation in month 12.",
-	"Ana was promoted to VP of Engineering. She now has direct control of the infrastructure budget, which increased her signing authority to $200k. She reached out proactively to discuss expanding the deployment from 40 to 80 seats and adding the knowledge graph feature as an enterprise add-on. Total expansion opportunity: $60k additional ARR. Scheduled a proposal call for next Wednesday.",
-	"TechCorp upgraded from the Professional plan ($45k ARR) to the Enterprise plan ($89k ARR), driven by their need for SSO, audit logs, and the dedicated CSM support tier. The upgrade was processed on the anniversary of their initial contract. Sarah Chen, their CSM, facilitated the upgrade conversation. TechCorp now represents $89k ARR and is flagged as a reference customer for ENT prospects.",
-	"Maria's team achieved 93% user adoption (28 of 30 staff trained) within the first 30 days. She requested a product roadmap presentation for her executive leadership team to demonstrate ROI before the annual budget review. Presentation scheduled for May 20th with attendance from CEO, CFO, and CTO. Prepare slides highlighting: usage metrics, time saved per user, and upcoming features on the roadmap.",
-	"Omega Solutions trial feedback: strong on recall precision for structured financial data, needed improvement on unstructured PDF parsing. Engineering flagged the PDF limitation as a known gap, scheduled for Q3 release. Omega Solutions requested a timeline commitment in writing. Sent a formal product commitment letter signed by our VP Product. Trial extended by 14 days. Conversion expected by end of April.",
-	"Carlos secured executive sponsorship from our CEO who agreed to join the final board presentation at NovaTech. The board presentation is on June 27th at 9 AM Pacific. Materials needed: executive summary, customer references (TechCorp and Initech), and pricing summary. Board has four members including two technical board advisors. Deal probability at 85% — flag as commit in CRM for Q2 forecast.",
-	"Peak Data closed at $18k ARR for a 12-month contract. CTO appreciated the detailed concurrency write-up and cited it as a differentiator. They want a monthly architecture review call with our engineering team for the first quarter. Engineering agreed to a monthly 30-minute call as part of the onboarding package. First call scheduled for May 5th. Account flagged for expansion conversation at month 6.",
-	"Omega Solutions closed at $28k ARR after the PDF parsing fix shipped in Q3. Their CTO David Park signed without requiring legal review — fastest close of the quarter at 22 days. They immediately asked about the multi-agent coordination feature and the REST API. Onboarding call scheduled for the following Monday. Referred us to two contacts at Series B FinTech companies in their network.",
-	"Globex Corp EU expansion signed for 25 additional seats at $800/seat = $20k ARR. Total Globex ARR now $107k. Karen Wu's EU team goes live on August 1st. Data residency confirmed: EU region on AWS eu-west-1, compliant with GDPR Article 28 processor requirements. They requested the Data Processing Agreement addendum — legal to send within 48 hours.",
-	"Initech's Head of Data Science formally requested a custom model fine-tuning feature as part of their enterprise renewal conversation. Product team evaluated the request: domain vocabulary injection is feasible in Q1 next year. Offered a co-development agreement where Initech participates in the beta program and provides labeled training data. Their legal team is reviewing the co-development terms.",
-	"NovaTech's EU expansion for 25 additional seats at $800/seat = $20k ARR was signed by their new EU Managing Director Hans Müller. EU data residency confirmed. Total NovaTech ARR now $122k. Carlos mentioned they are planning to hire 15 more engineers in Berlin in H2, which could represent another 15-seat expansion. Flag for renewal + expansion conversation in Q4.",
-	"Ana's expansion to 80 seats and knowledge graph add-on closed at $120k ARR total. She signed a 2-year contract to lock in pricing ahead of a planned price increase. Ana is now our largest single account. She accepted an invitation to join our Customer Advisory Board. First CAB meeting is scheduled for September 12th in San Francisco. She will present their use case to other enterprise customers.",
-	"TechCorp case study reached 4,200 views in the first month and generated 18 inbound demo requests from companies in their industry. Three of those requests converted to qualified opportunities. TechCorp agreed to a video testimonial for our upcoming product launch event. Maria Chen will present a 10-minute session at our annual user conference in October.",
-	"Initech renewal and expansion signed for $280k ARR on a 36-month contract — the largest contract in company history. Their domain-specific vocabulary beta program starts in Q1. They upgraded to the Premium Support tier with a 2-hour SLA for Severity-1 issues. Rachel Torres remains their CSM. Initech will present at the annual user conference alongside TechCorp.",
-	"Peak Data's month-6 expansion conversation yielded a 20-seat addition at $800/seat = $16k ARR. Their usage has grown to 28 of 30 original seats at 90% weekly activity. The CTO mentioned they plan to open a London office in Q1 next year — flag for EU data residency conversation. Total Peak Data ARR now $34k. High probability of further expansion at year-end.",
-	"Maria Lopez was promoted to Chief Digital Officer. She sent a company-wide memo crediting GrayMatter as a key productivity tool for their engineering org. Her new role gives her budget authority over all technology purchases company-wide. She has asked for a strategic partnership conversation to explore an OEM licensing arrangement for internal deployment at scale. Opportunity flagged to leadership.",
-	"Globex Corp's Karen Wu referred us to three contacts: VP Engineering at TechnoStar, CTO at CloudPeak, and Head of Data at StreamCore. All three are warm introductions with pending budget for agent tooling in H2. Discovery calls scheduled for all three in the same week. This represents a pipeline addition of approximately $180k ARR if all three convert at average deal size.",
-	"NovaTech signed a 3-year renewal at $150k ARR, a 23% increase over the previous contract, locking in pricing and adding the Enterprise Support tier. Carlos is now VP of Engineering following a promotion. He has agreed to co-author a blog post about their use case for our developer blog. Publication target: end of Q3. Blog post draft to be shared by August 15th.",
-	"Ana Torres joined the Customer Advisory Board and presented at the September 12th CAB meeting. Her session on multi-agent coordination generated the most discussion. She agreed to participate in a joint product roadmap session with our CPO to co-design the agent orchestration features for the next major release. Two other CAB members requested direct introductions to Ana to learn from her deployment.",
-	"Omega Solutions reached $45k ARR after two expansion rounds driven by their growing data team. Their CTO David Park was named to Forbes 30 Under 30 and publicly credited GrayMatter in his profile. The press mention drove 340 inbound signups in 48 hours. They are now a Platinum reference customer and have agreed to participate in all major marketing initiatives for the next 12 months.",
-	"TechCorp's annual renewal processed at $92k ARR, a $3k uplift for overage usage. Their NPS at 12 months is 9.2 out of 10, the highest in our customer base. Maria Chen presented at our user conference to 400 attendees and received a standing ovation. Three enterprise logos requested her contact information for peer reference calls. TechCorp is our strongest reference in the infrastructure vertical.",
-	"Carlos's NovaTech account was acquired by EnterpriseGroup in an all-cash deal. The acquisition triggered a change-of-control clause in their contract requiring written consent for assignment. Legal confirmed consent was granted and the contract transferred without renegotiation. Carlos retained his VP Engineering role post-acquisition. EnterpriseGroup's procurement team reached out to expand the deployment to their 300-person engineering org.",
-	"EnterpriseGroup expansion scoping call completed. They have 300 engineers across 6 product teams in 3 time zones. Their use case spans engineering knowledge management, incident retrospectives, and new hire onboarding. Total seat opportunity: 250 seats at $800/seat = $200k ARR. Deal cycle estimated at 6 months given their procurement complexity. Assigned a dedicated solutions engineer for the technical evaluation.",
-	"Initech's co-development beta for domain vocabulary injection launched to 5 beta customers. Initech's data science team contributed 2,400 labeled examples in the first two weeks. Early results show 23% improvement in recall precision for domain-specific terminology. Product team presented early results at an internal all-hands. Initech's investment in the beta program makes their renewal probability near-certain.",
-	"Peak Data opened their London office in Q1 and immediately needed EU data residency. Their CTO coordinated directly with our engineering team to migrate their EU data within 48 hours. The fast migration earned significant goodwill. They expanded to 60 seats in the London office at $800/seat = $48k ARR. Total Peak Data ARR now $82k. Full renewal and consolidation expected at year-end.",
-	"StreamCore discovery call completed. Their Head of Data, James Wu, manages 45 data engineers who build and maintain real-time data pipelines. Their primary need is contextual memory for their internal ML agents that monitor pipeline health. Budget approved at $60k ARR. They want a 90-day pilot before committing. Pilot provisioned on April 18th. Technical POC contact: their senior ML engineer Priya Singh.",
-	"CloudPeak CTO Jessica Park signed a $75k ARR contract after a 45-day evaluation. Key differentiator cited: the quality of hybrid retrieval versus their previous vector-only solution. They have 80 engineers and immediately provisioned all seats. Jessica requested an on-site executive business review in their Seattle office for month 3. CSM assigned: David Lee with a Seattle-based presence.",
-	"TechnoStar VP Engineering Marcus Chen closed at $55k ARR after a competitive evaluation against two other vendors. Decisive factor: our open-source friendliness and the Go native integration. They are a 100% Go shop. Marcus will publish an engineering blog post about the integration. Estimated reach: 25k developer readers. Blog post draft shared for review — editorial feedback due in 5 business days.",
-	"Ana's company completed a Series C fundraise of $120M. Their engineering org is expanding from 80 to 150 engineers over the next 18 months. Ana has pre-approved $250k ARR for tooling for the expanded team. She wants to lock in a 3-year enterprise agreement before the price increase takes effect next quarter. Proposal sent with 3-year pricing and dedicated support tier.",
-	"EnterpriseGroup's 6-month evaluation concluded with a successful POC across 2 of their 6 product teams. The pilot team leads presented results to their CTO: 28% reduction in time to context for incident response, 41% improvement in new hire ramp time. The CTO approved expansion to all 6 teams. Legal is drafting the enterprise framework agreement. Deal expected to close in 4-6 weeks.",
-	"Globex Corp's Karen Wu left the company to join a startup. Her replacement is VP Engineering Thomas Reid, promoted internally. Thomas participated in an emergency business continuity call and confirmed Globex Corp will honor all existing commitments. He is interested in expanding the deployment to their Asia-Pacific team of 20 engineers. Introduction call with Thomas scheduled for next Monday.",
-	"Initech's domain vocabulary product went GA with Initech as the launch customer. Their data science team reduced annotation time by 60% using the automated vocabulary extraction pipeline. The feature is now generally available as an Enterprise add-on at $2k/month per model. Initech was credited as a co-inventor in the product announcement. Their renewal was processed at $320k ARR — our highest contract ever.",
-	"StreamCore pilot concluded successfully after 90 days. Pipeline monitoring accuracy improved by 31% when agents could recall historical incident patterns. Their Head of Data James Wu signed the full contract at $65k ARR. They immediately requested to expand to their platform engineering team of 20 engineers. Expansion contract for 20 additional seats at $800/seat = $16k ARR signed the same day.",
-	"Ana's 3-year enterprise agreement signed at $280k ARR, covering 150 seats. It includes the domain vocabulary add-on, dedicated SLA of 1-hour response for Severity-1, and a private Slack channel with our engineering team. Ana was featured in a press release alongside our CEO. The announcement generated 2,100 LinkedIn impressions and 14 inbound enterprise inquiries within 24 hours.",
-	"EnterpriseGroup closed at $200k ARR for a 3-year enterprise framework agreement covering 250 seats across all 6 product teams. It is now our largest single contract. Their General Counsel negotiated data processing terms extensively — final DPA signed after 4 rounds of revisions. Executive sponsor is their EVP Engineering Robert Zhao who personally championed the rollout to all teams.",
-	"TechnoStar's blog post by Marcus Chen published and reached 38k developer readers — 52% above his projected estimate. Drove 640 new signups, of which 12 converted to paid accounts in the first week. Marcus agreed to speak at our developer conference in November. His session title: 'Building Stateful AI Agents in Go: A Production Retrospective.' Expected attendance: 200 engineers.",
-	"CloudPeak's month-3 executive business review in Seattle was attended by Jessica Park and two board observers. They presented a 44% improvement in incident resolution time attributable to agent memory. One board observer requested an introduction to our CEO for a potential strategic investment conversation. Their expansion to a second department of 30 engineers is approved — $24k ARR addition.",
-	"Maria Lopez signed a strategic OEM licensing agreement for internal deployment of GrayMatter within her company's proprietary AI platform. The agreement covers unlimited internal seats at a flat annual license of $300k. External distribution rights are explicitly excluded. This is a new revenue category — flagged for a dedicated OEM contract template. Legal review completed in 10 business days.",
-	"Peak Data's year-end renewal and consolidation signed at $120k ARR covering all offices globally including the London expansion. CTO agreed to a 2-year commitment. She will join the Customer Advisory Board alongside Ana Torres. Peak Data now has 3 offices (SF, London, Singapore) and 150 engineers. Singapore onboarding to start in Q2 next year.",
-	"Omega Solutions was acquired by a publicly listed data company. The acquisition triggered an enterprise procurement review. Their new parent company's CTO evaluated GrayMatter against their existing enterprise agreements with our competitors. After a 30-day review, they decided to standardize on GrayMatter for all AI agent memory needs across the combined 400-person engineering org.",
-	"EnterpriseGroup's rollout to all 6 product teams completed 3 weeks ahead of schedule. Company-wide adoption reached 87% of licensed seats within 60 days. Their internal developer portal now includes GrayMatter as a standard tool in their agent development kit. Robert Zhao is requesting a joint press release and a case study co-authored by their Head of Developer Experience.",
-	"TechCorp's Maria Chen joined our Board of Customer Advisors and was elected Chair of the Technical Working Group at the September CAB meeting. She will co-lead the agent orchestration roadmap working group alongside Ana Torres. Their combined influence is shaping the product roadmap for the next two major releases. Both are confirmed speakers at the annual user conference.",
-	"Ana Torres's company completed an IPO on NASDAQ. GrayMatter was cited in the S-1 as a key operational infrastructure tool. Our logo appears in their investor presentation materials. This represents a significant brand validation event. Legal confirmed no action required on our side. Ana's personal equity vesting means she is financially independent — renewal risk is low.",
-	"Initech's co-development program expanded to 12 beta customers contributing domain vocabularies across 8 verticals. The program generated $180k in additional ARR from domain vocabulary subscriptions in year one. Product team is planning a second cohort of 20 beta customers for H1 next year. The program is now a formal product-led growth motion owned by the PLG team.",
-	"NovaTech, now part of EnterpriseGroup, is consolidating their contract under the EnterpriseGroup framework agreement. Carlos, as VP Engineering, is advocating for a 50-seat allocation for the Berlin office under the new parent company structure. This would increase the EnterpriseGroup footprint from 250 to 300 seats — $40k ARR addition to the framework agreement.",
-	"CloudPeak closed their Series C at $85M. Jessica Park messaged directly to say the operational efficiency demonstrated by GrayMatter was cited in their investor materials as a competitive moat. They are expanding internationally to London and Singapore — each office needs 20 seats, adding $32k ARR. Total CloudPeak ARR projected at $131k by end of year.",
-	"StreamCore's ML agents for pipeline monitoring have processed 12 million recall operations in 90 days of production use. Their SRE team reported a 39% reduction in mean time to identify pipeline root causes. James Wu presented the results at a data engineering conference to 800 attendees. The presentation is available on YouTube and has 4,200 views, driving 28 qualified inbound inquiries.",
-	"TechnoStar's expansion to their infrastructure team of 40 engineers closed at $32k ARR, bringing total account ARR to $87k. Marcus Chen co-authored a technical reference architecture document for Go-native AI agents using GrayMatter, published on our documentation site. The document became the most-viewed technical resource on the site within 48 hours of publication.",
-	"Omega Solutions' parent company standardized on GrayMatter and signed a global master agreement covering 400 seats at $800/seat = $320k ARR. Legal negotiated a 3-year term with CPI-linked annual price adjustments. This is our largest account by seat count. Assigned a dedicated Strategic Account Manager and a technical solutions architect for the global rollout.",
-	"Maria Lopez's OEM agreement generated the first external deployment of GrayMatter-powered memory in a third-party product. Their product shipped to 500 enterprise customers, each potentially running 10+ agents using our memory layer. Revenue participation model: $0.50 per active agent per month. Month-1 revenue: $2,400 from 4,800 active agents. This is the seed of a new revenue stream.",
-	"Ana Torres's company completed 100% of their 150-engineer rollout ahead of schedule. Their internal engineering blog published a post about the deployment that reached 18k readers via HackerNews. Three enterprise companies reached out directly after reading the post. Ana volunteered to do a 30-minute reference call for each. All three are in the pipeline with a combined opportunity of $210k ARR.",
-	"EnterpriseGroup's Head of Developer Experience published the joint case study. The study quantifies: 28% reduction in incident response time, 41% faster new engineer ramp, 19% increase in cross-team knowledge reuse. The study was picked up by three industry analyst firms. One analyst firm requested an analyst briefing for potential inclusion in their Enterprise AI Tooling market report.",
-	"Peak Data's Singapore office onboarding completed. 20 engineers provisioned, training completed in 2 days using the self-serve onboarding materials. Their CTO commended the quality of the Go SDK documentation. Singapore team immediately flagged a timezone-specific use case for agent handoff between shifts — logged as a product request. This use case could apply to 15 other enterprise accounts.",
-	"Initech's renewal for year 3 processed at $340k ARR, an 8% increase from year 2. The domain vocabulary product is now used by 60% of their engineering org. Their data science team is publishing an internal paper on the productivity gains attributable to domain-specific agent memory. They requested permission to submit a version to a peer-reviewed ML conference.",
-	"CloudPeak's London office (20 seats) went live. Singapore provisioning scheduled for month 2. Total CloudPeak global footprint: 120 licensed seats, $96k ARR, projected $131k ARR by year-end with Singapore. Jessica Park is presenting at our annual conference on international deployment best practices. Their deployment is now our reference case for multi-region enterprise rollouts.",
-	"TechCorp's year-2 renewal processed at $95k ARR, a $6k increase from year 1 reflecting seat expansion. They formally nominated Maria Chen as a reference customer for all enterprise deals over $50k ARR. Their case study has been cited in 14 enterprise sales conversations this quarter. Marketing team is creating a video testimonial with Maria Chen — filming scheduled for October 8th.",
-	"StreamCore's contract renewal signed at $90k ARR for year 2, covering their expanded platform engineering team. James Wu was promoted to VP Data Engineering. He has increased budget authority and is evaluating a company-wide expansion to 100 total seats — projected $80k ARR increase. Proof-of-concept for expanded deployment to start in month 13 with a 30-day evaluation period.",
-	"The analyst firm Gartner included GrayMatter in their inaugural Enterprise AI Agent Memory Solutions market report, placing us in the Visionary quadrant. The report cited our hybrid retrieval approach, Go-native integration, and enterprise customer base. Fourteen inbound enterprise inquiries were received within 48 hours of the report publication. Sales team capacity expanded by two enterprise AEs to manage demand.",
-	"Omega Solutions' parent company's global rollout to 400 seats completed in 6 weeks — 2 weeks ahead of the projected 8-week timeline. Their Head of Platform Engineering cited the quality of the migration tooling and documentation as the key accelerant. They are now evaluating GrayMatter for deployment in their AI research division — an additional 50-seat opportunity not in the original scope.",
-	"Maria Lopez's OEM deployment scaled to 8,200 active agents across their customer base. Monthly participation revenue reached $4,100. They are expanding the integration to their enterprise tier customers, projected to add 15,000 active agents over the next 6 months. OEM revenue run rate projected at $12,000 per month within 6 months — a meaningful contribution to ARR diversification.",
-	"NovaTech Berlin office, now under EnterpriseGroup, provisioned 50 additional seats in the framework agreement. Carlos continues to drive adoption across the Berlin engineering team. Total EnterpriseGroup global footprint: 300 seats, $240k ARR. Robert Zhao requested a strategic planning session for year 2 to align on product roadmap priorities for EnterpriseGroup's specific use cases.",
-	"Ana Torres announced GrayMatter as a founding technology partner in their AI-native engineering platform. This is the first formal technology partnership in our company's history. The agreement includes joint go-to-market activities, co-marketing budget of $50k per year, and joint participation in Dreamforce and AWS re:Invent. Legal drafted the Technology Partnership Agreement — under review.",
-	"TechnoStar's 2-year renewal signed at $95k ARR, a 9% increase. Marcus Chen has become an internal evangelist who has given GrayMatter training sessions to their entire engineering org. Their deployment now covers 120 engineers across frontend, backend, and infrastructure teams. Marcus proposed hosting a GrayMatter developer meetup at their San Francisco office with an expected attendance of 60 engineers.",
-	"CloudPeak's Singapore office provisioned with 20 seats on schedule. Total CloudPeak: 140 seats across 3 regions, $112k ARR. Jessica Park joined the Customer Advisory Board. She proposed a new session at the CAB on multi-region data sovereignty — 8 of 12 CAB members voted to add it as a standing agenda item given the growing EU and APAC regulatory complexity.",
-	"The Technology Partnership Agreement with Ana Torres's company was signed after 3 weeks of legal negotiation. Joint go-to-market activities begin in Q1 next year with a joint webinar targeted at 500 enterprise engineering leaders. Co-marketing budget of $50k allocated. The partnership was announced via a joint press release that reached 12,000 readers across both companies' networks.",
-	"EnterpriseGroup's strategic planning session for year 2 resulted in a formal product advisory committee with Robert Zhao as Chair. He committed 8 engineer-days per quarter to participate in beta programs and provide product feedback. EnterpriseGroup will co-develop the agent orchestration framework as a design partner, with their engineering team having early access to APIs 6 weeks before GA.",
-	"Initech's internal ML conference paper on domain-specific agent memory was accepted to NeurIPS 2027. Their data science team will present the paper at the conference in December. We are acknowledged in the paper's acknowledgments section. The paper's publication will establish Initech — and by extension GrayMatter — as a reference implementation in the academic literature on AI agent memory.",
-	"The GrayMatter annual user conference attracted 850 registered attendees, a 112% increase from the previous year's 400. Speaker lineup: Maria Chen (TechCorp), Ana Torres (Series C co), James Wu (StreamCore), and Marcus Chen (TechnoStar). Three new enterprise logos signed enterprise contracts at the conference. Conference-attributed pipeline: $540k ARR in new opportunities.",
-	"OEM revenue from Maria Lopez's platform crossed $10,000/month for the first time, driven by a 20,200 active agent milestone. The OEM agreement is now contributing $120k ARR on an annualized basis. Maria is proposing a white-label option for her largest enterprise customers who want branded experiences. White-label pricing model under commercial review — target pricing: flat $50k/year per white-label deployment.",
-	"Total ARR crossed $3M milestone. Customer breakdown: 14 enterprise accounts averaging $180k ARR, 6 mid-market accounts averaging $45k ARR, OEM contributing $120k ARR. Net Revenue Retention for the past 12 months: 134%. Gross Churn: 0% — no customer has churned since inception. Customer Acquisition Cost recovered within an average of 4.2 months. Gartner included us in the Magic Quadrant.",
-}
+var sessionCounts = bench.SessionCounts
 
-// ── Token approximation ───────────────────────────────────────────────────────
-
-// approxTokens estimates GPT-4-class token count for text.
-//
-// The approximation lives in internal/tokens so that this benchmark,
-// benchmarks/retrieval_quality and the context-sync budget cannot drift into
-// meaning different things
-// by the word "tokens" — docs/benchmarks.md publishes figures from both.
-func approxTokens(text string) int {
-	return tokens.Approx(text)
-}
-
-// ── Benchmark ─────────────────────────────────────────────────────────────────
-
-const (
-	agentID = "sales-agent"
-	query   = "follow up with prospects and close pending deals this week"
-	topK    = 8
-)
-
-// sessionCounts controls which data points are reported.
-// Each "session" = one stored memory observation (a paragraph extracted from
-// a real agent interaction, ~50-70 words). Full injection = all observations
-// concatenated. GrayMatter = top-8 most relevant observations recalled.
-var sessionCounts = []int{1, 10, 30, 100}
-
-// result is one row of the benchmark table.
-type result struct {
-	Sessions     int
-	FullTokens   int
-	RecallTokens int
-	Reduction    float64 // percent
-}
-
-// runBenchmark executes the full measurement and returns one result per entry
-// in sessionCounts. It is separated from main so the reproducibility test can
-// call it and compare the published tables against freshly measured numbers.
 func runBenchmark() ([]result, error) {
-	// Shuffle insertion order so keyword ranking is not biased by the order
-	// the corpus happens to be written in. Fixed seed: the shuffle is part of
-	// the fixture, not a source of variation.
-	rng := rand.New(rand.NewSource(42)) //nolint:gosec
-	perm := rng.Perm(len(corpus))
-
-	results := make([]result, 0, len(sessionCounts))
-	for _, target := range sessionCounts {
-		r, err := measureAt(target, perm)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, r)
-	}
-	return results, nil
-}
-
-// measureAt builds a fresh store holding exactly `target` observations and
-// takes one measurement from it.
-//
-// Each row gets its own store on purpose. Reusing one store across rows made
-// the benchmark non-reproducible: Recall updates AccessCount and AccessedAt
-// from detached goroutines, so the writebacks from one row were still in
-// flight while the next row was inserting and backdating, and a late writeback
-// restores the whole Fact as it looked when it was read. Measured rate was
-// about one differing run in twenty-five — often enough to publish a number
-// nobody else can reproduce, rare enough that nobody notices why.
-//
-// Recall itself is deterministic: 300 calls against a fixed store return the
-// same result every time. The variance was entirely in how the store was
-// built, which is why the fix belongs here and not in the engine.
-func measureAt(target int, perm []int) (result, error) {
-	dataDir, err := os.MkdirTemp("", "graymatter-bench-*")
-	if err != nil {
-		return result{}, fmt.Errorf("mktemp: %w", err)
-	}
-	defer os.RemoveAll(dataDir)
-
-	emb := embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
-	store, err := memory.Open(memory.StoreConfig{
-		DataDir:  dataDir,
-		Embedder: emb,
-	})
-	if err != nil {
-		return result{}, fmt.Errorf("open store: %w", err)
-	}
-	defer store.Close()
-
-	ctx := context.Background()
-	for i := 0; i < target && i < len(corpus); i++ {
-		if err := store.Put(ctx, agentID, corpus[perm[i]]); err != nil {
-			return result{}, fmt.Errorf("put: %w", err)
-		}
-	}
-	if err := spreadOverSessions(store); err != nil {
-		return result{}, err
-	}
-
-	// Full injection: ALL stored observations concatenated.
-	allFacts, err := store.List(agentID)
-	if err != nil {
-		return result{}, fmt.Errorf("list: %w", err)
-	}
-	fullTexts := make([]string, 0, len(allFacts))
-	for _, f := range allFacts {
-		fullTexts = append(fullTexts, f.Text)
-	}
-	fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
-
-	// GrayMatter: recall only the top-K most relevant observations.
-	recalled, err := store.Recall(ctx, agentID, query, topK)
-	if err != nil {
-		return result{}, fmt.Errorf("recall: %w", err)
-	}
-	recallTokens := approxTokens(strings.Join(recalled, "\n"))
-
-	reduction := 0.0
-	if fullTokens > 0 {
-		reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
-	}
-	return result{
-		Sessions:     target,
-		FullTokens:   fullTokens,
-		RecallTokens: recallTokens,
-		Reduction:    reduction,
-	}, nil
+	return bench.RunTokenCount()
 }
 
 func main() {
@@ -264,61 +42,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println()
-	fmt.Println("GrayMatter Token Efficiency Benchmark")
-	fmt.Printf("Query:    %q\n", query)
-	fmt.Printf("Embedder: keyword (no LLM required — fully reproducible)\n")
-	fmt.Printf("TopK:     %d recalled observations per query\n", topK)
-	fmt.Println()
-	fmt.Printf("%-10s  %-18s  %-22s  %s\n",
-		"Sessions", "Full Injection", "GrayMatter Recall", "Reduction")
-	fmt.Println(strings.Repeat("─", 72))
-
-	for _, r := range results {
-		fmt.Printf("%-10d  ~%-17d  ~%-21d  %.0f%%\n",
-			r.Sessions, r.FullTokens, r.RecallTokens, r.Reduction)
-	}
-
-	fmt.Println(strings.Repeat("─", 72))
-	fmt.Printf("\nRun time:  %s\n", time.Since(start).Truncate(time.Millisecond))
-	fmt.Println()
-	fmt.Println("Approximation: words × 1.33 ≈ GPT-4 tokens (±10% for English prose).")
-	fmt.Println("With vector embeddings (Ollama / OpenAI / Anthropic) recall precision")
-	fmt.Println("improves further, maintaining similar or better token reduction ratios.")
-}
-
-// spreadOverSessions backdates the stored facts so that session N sits N days
-// before session inserted, one observation per simulated day.
-//
-// Without this the benchmark writes every fact inside the same few
-// milliseconds, and the clock is not that precise: in a 30-fact run, 8 facts
-// routinely share a CreatedAt. Facts with an identical timestamp have an
-// identical recency score, and recall.go turns scores into ranks with
-// sort.Slice, which is not stable — so tied facts receive arbitrary ranks,
-// those ranks feed the fused score, and the final ordering varies between
-// runs. Measured rate on this corpus was roughly one differing run in
-// twenty-five, which is exactly often enough to publish a number nobody can
-// reproduce and rare enough that nobody notices why.
-//
-// One fact per day also matches what the benchmark says it models: a session
-// is a day of agent work, not a microsecond of one.
-//
-// This is a fix to the benchmark, not to the engine. The underlying tie-break
-// in recall.go is still unspecified for facts written in the same instant.
-func spreadOverSessions(store *memory.Store) error {
-	facts, err := store.List(agentID)
-	if err != nil {
-		return fmt.Errorf("list for backdating: %w", err)
-	}
-	now := time.Now().UTC()
-	for i := range facts {
-		// facts is newest-first; index 0 is the most recent session.
-		at := now.Add(-time.Duration(i) * 24 * time.Hour)
-		facts[i].CreatedAt = at
-		facts[i].AccessedAt = at
-		if err := store.UpdateFact(agentID, facts[i]); err != nil {
-			return fmt.Errorf("backdate: %w", err)
-		}
-	}
-	return nil
+	fmt.Print(bench.RenderTokenReport(results, time.Since(start)))
 }

--- a/benchmarks/token_count/main.go
+++ b/benchmarks/token_count/main.go
@@ -1,36 +1,258 @@
-// Command token_count is the documented reproduction path for the token
-// figures published in README.md and docs/benchmarks.md:
+// Command token_count benchmarks GrayMatter's token efficiency versus
+// full-history injection. It runs entirely in-process with no LLM or
+// network requirements — the keyword embedder is used so results are
+// deterministic and reproducible in any environment.
+//
+// Usage:
 //
 //	go run ./benchmarks/token_count
 //
-// The measurement itself lives in internal/bench (package bench), shared with
-// `graymatter bench` so the installed binary and this command cannot drift
-// apart while claiming to measure the same thing. The published tables are
-// gated against a live run in main_test.go, which is unchanged by that
-// refactor — it still calls runBenchmark here.
+// Model: each "session" stores ONE observation — a paragraph extracted from a
+// realistic agent interaction, ~50-70 words. "30 sessions" means 30 stored
+// observations. "Full injection" = ALL stored observations concatenated.
+// "GrayMatter Recall" = top-8 most relevant observations for the given query.
+// Token counts are approximated at 1.33 tokens/word (matches tiktoken within ±10%).
 //
-// What the benchmark does NOT measure is in docs/benchmarks.md and is worth
-// reading before quoting a number from it: relevance is never checked, so a
-// system returning 8 random facts would score the same reduction, and
-// full-history injection is the weakest baseline available.
+// What this does NOT measure is in docs/benchmarks.md and is worth reading
+// before quoting a number from it: relevance is never checked, so a system
+// returning 8 random facts would score the same reduction, and full-history
+// injection is the weakest baseline available.
 package main
 
 import (
+	"context"
 	"fmt"
+	"math/rand"
 	"os"
+	"strings"
 	"time"
 
-	"github.com/angelnicolasc/graymatter/internal/bench"
+	"github.com/angelnicolasc/graymatter/internal/tokens"
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
-// result aliases the shared row type so the gate test keeps compiling against
-// exactly the fields it has always asserted on.
-type result = bench.TokenResult
+// ── Corpus ───────────────────────────────────────────────────────────────────
+//
+// 100 realistic paragraph-length agent memory observations (~50-70 words each).
+// Each represents a key insight extracted from a sales agent interaction — the
+// kind of observation GrayMatter would store after processing a session.
 
-var sessionCounts = bench.SessionCounts
+var corpus = [100]string{
+	"Maria Lopez from Acme Corp called on April 3rd to discuss the enterprise plan. She has pre-approved budget of $80k ARR and strong executive backing. Her primary blocker is the Salesforce integration timeline. She agreed to loop in their CTO James Park for a technical demo next Thursday. Priority: send the security whitepaper and Salesforce integration guide before the demo.",
+	"Carlos Mendez at Initech is budget-blocked until Q3 2026 due to a company-wide spending freeze following a 10% reduction in headcount last quarter. His champion status is at risk as his manager who approved the initiative has left the company. Re-engage in July with a reference case from a similarly-sized company in their vertical. Mark as at-risk in CRM.",
+	"Ana Torres at FinVault confirmed signing authority up to $50k without additional approvals; anything above that requires CFO sign-off. She mentioned their team runs 40 developers split between Python and Go. Their previous vendor migration failed due to data integrity issues. She asked for references from FinTech companies that have successfully migrated. Her preferred communication is async via email.",
+	"TechCorp pilot kicked off on May 1st for a three-month evaluation. Primary success metric agreed with their SRE team is a 30% reduction in context-switching time measured by their internal tooling. Demo feedback was positive: the search and recall features exceeded expectations. The bulk import feature was flagged as a must-have before GA. Attendees included CTO, VP Eng, and two senior SREs.",
+	"Globex Corp shortlisted us against Acme as the final two vendors. Price is the tiebreaker — they have a hard budget ceiling of $90k ARR. Their Head of Engineering David Kim is our champion; however he recently left the company, creating deal risk. Karen Wu, VP Engineering, has taken over ownership and we need a re-introduction call to re-establish the relationship with her.",
+	"The Initech proof-of-concept requires SAML 2.0 single sign-on integration with their existing Okta deployment. Their IT department has a mandatory 3-4 week security review for any new SaaS tool before procurement approval. Starting the review process now is critical to avoid timeline slippage. Their pilot sandbox environment needs to be provisioned separately from production to satisfy their data governance policy.",
+	"Ana Torres introduced us to their Head of Product Sarah Kim and their CFO Miguel Santos via email. A three-way discovery call is scheduled for next Tuesday. Miguel has direct budget authority for the enterprise tier. Ana mentioned the company raised $40M Series B and is growing headcount 20% year-over-year. They are evaluating tools to support their expanding engineering org of 40 developers.",
+	"TechCorp's latency spike was traced to a misconfigured rate limiter on our API gateway during their peak load testing. Engineering deployed a hotfix within four hours. Post-incident report sent to their CTO. TechCorp's SRE team confirmed the fix resolved the issue. They requested a dedicated status page and an escalation contact for Severity-1 incidents going forward. NPS after incident resolution: 8/10.",
+	"Maria signed the Master Service Agreement on April 14th. The contract is for 12 months at $95k ARR with a 30-day termination clause after month six. Invoice split requested across two fiscal quarters: $47,500 in Q2 and $47,500 in Q3. Procurement requires a W-9 form and bank wire details for vendor onboarding. Purchase order expected within five business days of MSA execution.",
+	"Carlos's company, now rebranded as NovaTech after an acquisition, has re-engaged with a freshly approved budget of $62k ARR. Carlos confirmed he is now the sole decision-maker after his former manager departed. He needs executive sponsorship from our side for the final board presentation scheduled for the June quarterly review. The deal is time-sensitive: board approval closes on June 28th.",
+	"Globex Corp closed at $87k ARR on an 18-month contract after the competitor failed their security audit. Karen Wu signed on behalf of the company. Penalty clause for downtime exceeding the 99.9% SLA was added at $500 per hour of excess downtime. Onboarding kickoff scheduled for May 15th. They requested a dedicated Customer Success Manager with experience in their industry vertical.",
+	"Initech closed as the largest deal of Q2 at $210k ARR. Contract is for 24 months with an option to renew at fixed pricing. Dedicated Slack channel created for pilot support. Their IT department approved the security review in 3 weeks, faster than expected. CSM assignment: Rachel Torres, who previously managed two similar enterprise accounts. QBR scheduled for July 5th.",
+	"Ana's company went live on April 7th after completing the API integration independently. First support ticket raised about the CSV bulk import timeout for files over 50MB. Engineering confirmed the limit is configurable and patched the default to 200MB. Ana's team is onboarding 40 developers in waves of 10 per week. She referred two new leads: Omega Solutions and Peak Data, both in the FinTech space.",
+	"TechCorp co-authored a case study published on our website. The study highlights a 34% reduction in context-switching time — exceeding their 30% pilot goal — measured over 60 days. Maria Chen, their VP of Engineering, is featured as the primary quote. TechCorp agreed to participate in a webinar next quarter. They are discussing upgrading from the Professional to Enterprise plan worth an additional $44k ARR.",
+	"NovaTech expansion deal signed for 50 additional seats at $800 per seat per year, adding $40k to their ARR. Total account ARR now $102k. They flagged a requirement for multi-region data residency for their EU operations. EU data residency is on the roadmap for Q4 — flag for engineering and set expectation with Carlos. EU expansion anticipated to add another 25 seats.",
+	"Omega Solutions discovery call completed on April 12th. The company is Series A, $12M raised, with 45 employees and 15 engineers. Their use case is automating client portfolio reporting. Budget is $25k ARR for year one. Key stakeholder: CTO David Park. They need a sandbox trial before committing. Trial provisioned with 30-day access. Follow-up scheduled for April 26th to review trial results.",
+	"Peak Data is a 30-person startup with a need for real-time agent memory across their data pipeline monitoring tools. They are evaluating three vendors simultaneously. Their CTO is technically strong and has reviewed our API documentation in detail. She asked pointed questions about consistency guarantees under concurrent write load. I sent a detailed write-up on bbolt's serialization model and our concurrency guarantees.",
+	"Globex Corp's first QBR completed. Weekly active users: 78% of licensed seats. Three power users identified: Karen Wu and two engineering leads. Identified an upsell opportunity: they are managing a 25-person EU team manually using spreadsheets. EU seat expansion deal estimated at $20k ARR. Karen asked for a roadmap update on EU data residency — confirmed Q4 timeline on the record.",
+	"Initech QBR on July 5th revealed 85% weekly active usage across 80 licensed seats. Three primary use cases emerged: sprint planning context, incident retrospectives, and onboarding new engineers. Their Head of Data Science requested a custom model fine-tuning feature for domain-specific terminology. Flagged to product as a potential enterprise add-on. Renewal in 17 months — begin expansion conversation in month 12.",
+	"Ana was promoted to VP of Engineering. She now has direct control of the infrastructure budget, which increased her signing authority to $200k. She reached out proactively to discuss expanding the deployment from 40 to 80 seats and adding the knowledge graph feature as an enterprise add-on. Total expansion opportunity: $60k additional ARR. Scheduled a proposal call for next Wednesday.",
+	"TechCorp upgraded from the Professional plan ($45k ARR) to the Enterprise plan ($89k ARR), driven by their need for SSO, audit logs, and the dedicated CSM support tier. The upgrade was processed on the anniversary of their initial contract. Sarah Chen, their CSM, facilitated the upgrade conversation. TechCorp now represents $89k ARR and is flagged as a reference customer for ENT prospects.",
+	"Maria's team achieved 93% user adoption (28 of 30 staff trained) within the first 30 days. She requested a product roadmap presentation for her executive leadership team to demonstrate ROI before the annual budget review. Presentation scheduled for May 20th with attendance from CEO, CFO, and CTO. Prepare slides highlighting: usage metrics, time saved per user, and upcoming features on the roadmap.",
+	"Omega Solutions trial feedback: strong on recall precision for structured financial data, needed improvement on unstructured PDF parsing. Engineering flagged the PDF limitation as a known gap, scheduled for Q3 release. Omega Solutions requested a timeline commitment in writing. Sent a formal product commitment letter signed by our VP Product. Trial extended by 14 days. Conversion expected by end of April.",
+	"Carlos secured executive sponsorship from our CEO who agreed to join the final board presentation at NovaTech. The board presentation is on June 27th at 9 AM Pacific. Materials needed: executive summary, customer references (TechCorp and Initech), and pricing summary. Board has four members including two technical board advisors. Deal probability at 85% — flag as commit in CRM for Q2 forecast.",
+	"Peak Data closed at $18k ARR for a 12-month contract. CTO appreciated the detailed concurrency write-up and cited it as a differentiator. They want a monthly architecture review call with our engineering team for the first quarter. Engineering agreed to a monthly 30-minute call as part of the onboarding package. First call scheduled for May 5th. Account flagged for expansion conversation at month 6.",
+	"Omega Solutions closed at $28k ARR after the PDF parsing fix shipped in Q3. Their CTO David Park signed without requiring legal review — fastest close of the quarter at 22 days. They immediately asked about the multi-agent coordination feature and the REST API. Onboarding call scheduled for the following Monday. Referred us to two contacts at Series B FinTech companies in their network.",
+	"Globex Corp EU expansion signed for 25 additional seats at $800/seat = $20k ARR. Total Globex ARR now $107k. Karen Wu's EU team goes live on August 1st. Data residency confirmed: EU region on AWS eu-west-1, compliant with GDPR Article 28 processor requirements. They requested the Data Processing Agreement addendum — legal to send within 48 hours.",
+	"Initech's Head of Data Science formally requested a custom model fine-tuning feature as part of their enterprise renewal conversation. Product team evaluated the request: domain vocabulary injection is feasible in Q1 next year. Offered a co-development agreement where Initech participates in the beta program and provides labeled training data. Their legal team is reviewing the co-development terms.",
+	"NovaTech's EU expansion for 25 additional seats at $800/seat = $20k ARR was signed by their new EU Managing Director Hans Müller. EU data residency confirmed. Total NovaTech ARR now $122k. Carlos mentioned they are planning to hire 15 more engineers in Berlin in H2, which could represent another 15-seat expansion. Flag for renewal + expansion conversation in Q4.",
+	"Ana's expansion to 80 seats and knowledge graph add-on closed at $120k ARR total. She signed a 2-year contract to lock in pricing ahead of a planned price increase. Ana is now our largest single account. She accepted an invitation to join our Customer Advisory Board. First CAB meeting is scheduled for September 12th in San Francisco. She will present their use case to other enterprise customers.",
+	"TechCorp case study reached 4,200 views in the first month and generated 18 inbound demo requests from companies in their industry. Three of those requests converted to qualified opportunities. TechCorp agreed to a video testimonial for our upcoming product launch event. Maria Chen will present a 10-minute session at our annual user conference in October.",
+	"Initech renewal and expansion signed for $280k ARR on a 36-month contract — the largest contract in company history. Their domain-specific vocabulary beta program starts in Q1. They upgraded to the Premium Support tier with a 2-hour SLA for Severity-1 issues. Rachel Torres remains their CSM. Initech will present at the annual user conference alongside TechCorp.",
+	"Peak Data's month-6 expansion conversation yielded a 20-seat addition at $800/seat = $16k ARR. Their usage has grown to 28 of 30 original seats at 90% weekly activity. The CTO mentioned they plan to open a London office in Q1 next year — flag for EU data residency conversation. Total Peak Data ARR now $34k. High probability of further expansion at year-end.",
+	"Maria Lopez was promoted to Chief Digital Officer. She sent a company-wide memo crediting GrayMatter as a key productivity tool for their engineering org. Her new role gives her budget authority over all technology purchases company-wide. She has asked for a strategic partnership conversation to explore an OEM licensing arrangement for internal deployment at scale. Opportunity flagged to leadership.",
+	"Globex Corp's Karen Wu referred us to three contacts: VP Engineering at TechnoStar, CTO at CloudPeak, and Head of Data at StreamCore. All three are warm introductions with pending budget for agent tooling in H2. Discovery calls scheduled for all three in the same week. This represents a pipeline addition of approximately $180k ARR if all three convert at average deal size.",
+	"NovaTech signed a 3-year renewal at $150k ARR, a 23% increase over the previous contract, locking in pricing and adding the Enterprise Support tier. Carlos is now VP of Engineering following a promotion. He has agreed to co-author a blog post about their use case for our developer blog. Publication target: end of Q3. Blog post draft to be shared by August 15th.",
+	"Ana Torres joined the Customer Advisory Board and presented at the September 12th CAB meeting. Her session on multi-agent coordination generated the most discussion. She agreed to participate in a joint product roadmap session with our CPO to co-design the agent orchestration features for the next major release. Two other CAB members requested direct introductions to Ana to learn from her deployment.",
+	"Omega Solutions reached $45k ARR after two expansion rounds driven by their growing data team. Their CTO David Park was named to Forbes 30 Under 30 and publicly credited GrayMatter in his profile. The press mention drove 340 inbound signups in 48 hours. They are now a Platinum reference customer and have agreed to participate in all major marketing initiatives for the next 12 months.",
+	"TechCorp's annual renewal processed at $92k ARR, a $3k uplift for overage usage. Their NPS at 12 months is 9.2 out of 10, the highest in our customer base. Maria Chen presented at our user conference to 400 attendees and received a standing ovation. Three enterprise logos requested her contact information for peer reference calls. TechCorp is our strongest reference in the infrastructure vertical.",
+	"Carlos's NovaTech account was acquired by EnterpriseGroup in an all-cash deal. The acquisition triggered a change-of-control clause in their contract requiring written consent for assignment. Legal confirmed consent was granted and the contract transferred without renegotiation. Carlos retained his VP Engineering role post-acquisition. EnterpriseGroup's procurement team reached out to expand the deployment to their 300-person engineering org.",
+	"EnterpriseGroup expansion scoping call completed. They have 300 engineers across 6 product teams in 3 time zones. Their use case spans engineering knowledge management, incident retrospectives, and new hire onboarding. Total seat opportunity: 250 seats at $800/seat = $200k ARR. Deal cycle estimated at 6 months given their procurement complexity. Assigned a dedicated solutions engineer for the technical evaluation.",
+	"Initech's co-development beta for domain vocabulary injection launched to 5 beta customers. Initech's data science team contributed 2,400 labeled examples in the first two weeks. Early results show 23% improvement in recall precision for domain-specific terminology. Product team presented early results at an internal all-hands. Initech's investment in the beta program makes their renewal probability near-certain.",
+	"Peak Data opened their London office in Q1 and immediately needed EU data residency. Their CTO coordinated directly with our engineering team to migrate their EU data within 48 hours. The fast migration earned significant goodwill. They expanded to 60 seats in the London office at $800/seat = $48k ARR. Total Peak Data ARR now $82k. Full renewal and consolidation expected at year-end.",
+	"StreamCore discovery call completed. Their Head of Data, James Wu, manages 45 data engineers who build and maintain real-time data pipelines. Their primary need is contextual memory for their internal ML agents that monitor pipeline health. Budget approved at $60k ARR. They want a 90-day pilot before committing. Pilot provisioned on April 18th. Technical POC contact: their senior ML engineer Priya Singh.",
+	"CloudPeak CTO Jessica Park signed a $75k ARR contract after a 45-day evaluation. Key differentiator cited: the quality of hybrid retrieval versus their previous vector-only solution. They have 80 engineers and immediately provisioned all seats. Jessica requested an on-site executive business review in their Seattle office for month 3. CSM assigned: David Lee with a Seattle-based presence.",
+	"TechnoStar VP Engineering Marcus Chen closed at $55k ARR after a competitive evaluation against two other vendors. Decisive factor: our open-source friendliness and the Go native integration. They are a 100% Go shop. Marcus will publish an engineering blog post about the integration. Estimated reach: 25k developer readers. Blog post draft shared for review — editorial feedback due in 5 business days.",
+	"Ana's company completed a Series C fundraise of $120M. Their engineering org is expanding from 80 to 150 engineers over the next 18 months. Ana has pre-approved $250k ARR for tooling for the expanded team. She wants to lock in a 3-year enterprise agreement before the price increase takes effect next quarter. Proposal sent with 3-year pricing and dedicated support tier.",
+	"EnterpriseGroup's 6-month evaluation concluded with a successful POC across 2 of their 6 product teams. The pilot team leads presented results to their CTO: 28% reduction in time to context for incident response, 41% improvement in new hire ramp time. The CTO approved expansion to all 6 teams. Legal is drafting the enterprise framework agreement. Deal expected to close in 4-6 weeks.",
+	"Globex Corp's Karen Wu left the company to join a startup. Her replacement is VP Engineering Thomas Reid, promoted internally. Thomas participated in an emergency business continuity call and confirmed Globex Corp will honor all existing commitments. He is interested in expanding the deployment to their Asia-Pacific team of 20 engineers. Introduction call with Thomas scheduled for next Monday.",
+	"Initech's domain vocabulary product went GA with Initech as the launch customer. Their data science team reduced annotation time by 60% using the automated vocabulary extraction pipeline. The feature is now generally available as an Enterprise add-on at $2k/month per model. Initech was credited as a co-inventor in the product announcement. Their renewal was processed at $320k ARR — our highest contract ever.",
+	"StreamCore pilot concluded successfully after 90 days. Pipeline monitoring accuracy improved by 31% when agents could recall historical incident patterns. Their Head of Data James Wu signed the full contract at $65k ARR. They immediately requested to expand to their platform engineering team of 20 engineers. Expansion contract for 20 additional seats at $800/seat = $16k ARR signed the same day.",
+	"Ana's 3-year enterprise agreement signed at $280k ARR, covering 150 seats. It includes the domain vocabulary add-on, dedicated SLA of 1-hour response for Severity-1, and a private Slack channel with our engineering team. Ana was featured in a press release alongside our CEO. The announcement generated 2,100 LinkedIn impressions and 14 inbound enterprise inquiries within 24 hours.",
+	"EnterpriseGroup closed at $200k ARR for a 3-year enterprise framework agreement covering 250 seats across all 6 product teams. It is now our largest single contract. Their General Counsel negotiated data processing terms extensively — final DPA signed after 4 rounds of revisions. Executive sponsor is their EVP Engineering Robert Zhao who personally championed the rollout to all teams.",
+	"TechnoStar's blog post by Marcus Chen published and reached 38k developer readers — 52% above his projected estimate. Drove 640 new signups, of which 12 converted to paid accounts in the first week. Marcus agreed to speak at our developer conference in November. His session title: 'Building Stateful AI Agents in Go: A Production Retrospective.' Expected attendance: 200 engineers.",
+	"CloudPeak's month-3 executive business review in Seattle was attended by Jessica Park and two board observers. They presented a 44% improvement in incident resolution time attributable to agent memory. One board observer requested an introduction to our CEO for a potential strategic investment conversation. Their expansion to a second department of 30 engineers is approved — $24k ARR addition.",
+	"Maria Lopez signed a strategic OEM licensing agreement for internal deployment of GrayMatter within her company's proprietary AI platform. The agreement covers unlimited internal seats at a flat annual license of $300k. External distribution rights are explicitly excluded. This is a new revenue category — flagged for a dedicated OEM contract template. Legal review completed in 10 business days.",
+	"Peak Data's year-end renewal and consolidation signed at $120k ARR covering all offices globally including the London expansion. CTO agreed to a 2-year commitment. She will join the Customer Advisory Board alongside Ana Torres. Peak Data now has 3 offices (SF, London, Singapore) and 150 engineers. Singapore onboarding to start in Q2 next year.",
+	"Omega Solutions was acquired by a publicly listed data company. The acquisition triggered an enterprise procurement review. Their new parent company's CTO evaluated GrayMatter against their existing enterprise agreements with our competitors. After a 30-day review, they decided to standardize on GrayMatter for all AI agent memory needs across the combined 400-person engineering org.",
+	"EnterpriseGroup's rollout to all 6 product teams completed 3 weeks ahead of schedule. Company-wide adoption reached 87% of licensed seats within 60 days. Their internal developer portal now includes GrayMatter as a standard tool in their agent development kit. Robert Zhao is requesting a joint press release and a case study co-authored by their Head of Developer Experience.",
+	"TechCorp's Maria Chen joined our Board of Customer Advisors and was elected Chair of the Technical Working Group at the September CAB meeting. She will co-lead the agent orchestration roadmap working group alongside Ana Torres. Their combined influence is shaping the product roadmap for the next two major releases. Both are confirmed speakers at the annual user conference.",
+	"Ana Torres's company completed an IPO on NASDAQ. GrayMatter was cited in the S-1 as a key operational infrastructure tool. Our logo appears in their investor presentation materials. This represents a significant brand validation event. Legal confirmed no action required on our side. Ana's personal equity vesting means she is financially independent — renewal risk is low.",
+	"Initech's co-development program expanded to 12 beta customers contributing domain vocabularies across 8 verticals. The program generated $180k in additional ARR from domain vocabulary subscriptions in year one. Product team is planning a second cohort of 20 beta customers for H1 next year. The program is now a formal product-led growth motion owned by the PLG team.",
+	"NovaTech, now part of EnterpriseGroup, is consolidating their contract under the EnterpriseGroup framework agreement. Carlos, as VP Engineering, is advocating for a 50-seat allocation for the Berlin office under the new parent company structure. This would increase the EnterpriseGroup footprint from 250 to 300 seats — $40k ARR addition to the framework agreement.",
+	"CloudPeak closed their Series C at $85M. Jessica Park messaged directly to say the operational efficiency demonstrated by GrayMatter was cited in their investor materials as a competitive moat. They are expanding internationally to London and Singapore — each office needs 20 seats, adding $32k ARR. Total CloudPeak ARR projected at $131k by end of year.",
+	"StreamCore's ML agents for pipeline monitoring have processed 12 million recall operations in 90 days of production use. Their SRE team reported a 39% reduction in mean time to identify pipeline root causes. James Wu presented the results at a data engineering conference to 800 attendees. The presentation is available on YouTube and has 4,200 views, driving 28 qualified inbound inquiries.",
+	"TechnoStar's expansion to their infrastructure team of 40 engineers closed at $32k ARR, bringing total account ARR to $87k. Marcus Chen co-authored a technical reference architecture document for Go-native AI agents using GrayMatter, published on our documentation site. The document became the most-viewed technical resource on the site within 48 hours of publication.",
+	"Omega Solutions' parent company standardized on GrayMatter and signed a global master agreement covering 400 seats at $800/seat = $320k ARR. Legal negotiated a 3-year term with CPI-linked annual price adjustments. This is our largest account by seat count. Assigned a dedicated Strategic Account Manager and a technical solutions architect for the global rollout.",
+	"Maria Lopez's OEM agreement generated the first external deployment of GrayMatter-powered memory in a third-party product. Their product shipped to 500 enterprise customers, each potentially running 10+ agents using our memory layer. Revenue participation model: $0.50 per active agent per month. Month-1 revenue: $2,400 from 4,800 active agents. This is the seed of a new revenue stream.",
+	"Ana Torres's company completed 100% of their 150-engineer rollout ahead of schedule. Their internal engineering blog published a post about the deployment that reached 18k readers via HackerNews. Three enterprise companies reached out directly after reading the post. Ana volunteered to do a 30-minute reference call for each. All three are in the pipeline with a combined opportunity of $210k ARR.",
+	"EnterpriseGroup's Head of Developer Experience published the joint case study. The study quantifies: 28% reduction in incident response time, 41% faster new engineer ramp, 19% increase in cross-team knowledge reuse. The study was picked up by three industry analyst firms. One analyst firm requested an analyst briefing for potential inclusion in their Enterprise AI Tooling market report.",
+	"Peak Data's Singapore office onboarding completed. 20 engineers provisioned, training completed in 2 days using the self-serve onboarding materials. Their CTO commended the quality of the Go SDK documentation. Singapore team immediately flagged a timezone-specific use case for agent handoff between shifts — logged as a product request. This use case could apply to 15 other enterprise accounts.",
+	"Initech's renewal for year 3 processed at $340k ARR, an 8% increase from year 2. The domain vocabulary product is now used by 60% of their engineering org. Their data science team is publishing an internal paper on the productivity gains attributable to domain-specific agent memory. They requested permission to submit a version to a peer-reviewed ML conference.",
+	"CloudPeak's London office (20 seats) went live. Singapore provisioning scheduled for month 2. Total CloudPeak global footprint: 120 licensed seats, $96k ARR, projected $131k ARR by year-end with Singapore. Jessica Park is presenting at our annual conference on international deployment best practices. Their deployment is now our reference case for multi-region enterprise rollouts.",
+	"TechCorp's year-2 renewal processed at $95k ARR, a $6k increase from year 1 reflecting seat expansion. They formally nominated Maria Chen as a reference customer for all enterprise deals over $50k ARR. Their case study has been cited in 14 enterprise sales conversations this quarter. Marketing team is creating a video testimonial with Maria Chen — filming scheduled for October 8th.",
+	"StreamCore's contract renewal signed at $90k ARR for year 2, covering their expanded platform engineering team. James Wu was promoted to VP Data Engineering. He has increased budget authority and is evaluating a company-wide expansion to 100 total seats — projected $80k ARR increase. Proof-of-concept for expanded deployment to start in month 13 with a 30-day evaluation period.",
+	"The analyst firm Gartner included GrayMatter in their inaugural Enterprise AI Agent Memory Solutions market report, placing us in the Visionary quadrant. The report cited our hybrid retrieval approach, Go-native integration, and enterprise customer base. Fourteen inbound enterprise inquiries were received within 48 hours of the report publication. Sales team capacity expanded by two enterprise AEs to manage demand.",
+	"Omega Solutions' parent company's global rollout to 400 seats completed in 6 weeks — 2 weeks ahead of the projected 8-week timeline. Their Head of Platform Engineering cited the quality of the migration tooling and documentation as the key accelerant. They are now evaluating GrayMatter for deployment in their AI research division — an additional 50-seat opportunity not in the original scope.",
+	"Maria Lopez's OEM deployment scaled to 8,200 active agents across their customer base. Monthly participation revenue reached $4,100. They are expanding the integration to their enterprise tier customers, projected to add 15,000 active agents over the next 6 months. OEM revenue run rate projected at $12,000 per month within 6 months — a meaningful contribution to ARR diversification.",
+	"NovaTech Berlin office, now under EnterpriseGroup, provisioned 50 additional seats in the framework agreement. Carlos continues to drive adoption across the Berlin engineering team. Total EnterpriseGroup global footprint: 300 seats, $240k ARR. Robert Zhao requested a strategic planning session for year 2 to align on product roadmap priorities for EnterpriseGroup's specific use cases.",
+	"Ana Torres announced GrayMatter as a founding technology partner in their AI-native engineering platform. This is the first formal technology partnership in our company's history. The agreement includes joint go-to-market activities, co-marketing budget of $50k per year, and joint participation in Dreamforce and AWS re:Invent. Legal drafted the Technology Partnership Agreement — under review.",
+	"TechnoStar's 2-year renewal signed at $95k ARR, a 9% increase. Marcus Chen has become an internal evangelist who has given GrayMatter training sessions to their entire engineering org. Their deployment now covers 120 engineers across frontend, backend, and infrastructure teams. Marcus proposed hosting a GrayMatter developer meetup at their San Francisco office with an expected attendance of 60 engineers.",
+	"CloudPeak's Singapore office provisioned with 20 seats on schedule. Total CloudPeak: 140 seats across 3 regions, $112k ARR. Jessica Park joined the Customer Advisory Board. She proposed a new session at the CAB on multi-region data sovereignty — 8 of 12 CAB members voted to add it as a standing agenda item given the growing EU and APAC regulatory complexity.",
+	"The Technology Partnership Agreement with Ana Torres's company was signed after 3 weeks of legal negotiation. Joint go-to-market activities begin in Q1 next year with a joint webinar targeted at 500 enterprise engineering leaders. Co-marketing budget of $50k allocated. The partnership was announced via a joint press release that reached 12,000 readers across both companies' networks.",
+	"EnterpriseGroup's strategic planning session for year 2 resulted in a formal product advisory committee with Robert Zhao as Chair. He committed 8 engineer-days per quarter to participate in beta programs and provide product feedback. EnterpriseGroup will co-develop the agent orchestration framework as a design partner, with their engineering team having early access to APIs 6 weeks before GA.",
+	"Initech's internal ML conference paper on domain-specific agent memory was accepted to NeurIPS 2027. Their data science team will present the paper at the conference in December. We are acknowledged in the paper's acknowledgments section. The paper's publication will establish Initech — and by extension GrayMatter — as a reference implementation in the academic literature on AI agent memory.",
+	"The GrayMatter annual user conference attracted 850 registered attendees, a 112% increase from the previous year's 400. Speaker lineup: Maria Chen (TechCorp), Ana Torres (Series C co), James Wu (StreamCore), and Marcus Chen (TechnoStar). Three new enterprise logos signed enterprise contracts at the conference. Conference-attributed pipeline: $540k ARR in new opportunities.",
+	"OEM revenue from Maria Lopez's platform crossed $10,000/month for the first time, driven by a 20,200 active agent milestone. The OEM agreement is now contributing $120k ARR on an annualized basis. Maria is proposing a white-label option for her largest enterprise customers who want branded experiences. White-label pricing model under commercial review — target pricing: flat $50k/year per white-label deployment.",
+	"Total ARR crossed $3M milestone. Customer breakdown: 14 enterprise accounts averaging $180k ARR, 6 mid-market accounts averaging $45k ARR, OEM contributing $120k ARR. Net Revenue Retention for the past 12 months: 134%. Gross Churn: 0% — no customer has churned since inception. Customer Acquisition Cost recovered within an average of 4.2 months. Gartner included us in the Magic Quadrant.",
+}
 
+// ── Token approximation ───────────────────────────────────────────────────────
+
+// approxTokens estimates GPT-4-class token count for text.
+//
+// The approximation lives in internal/tokens so that this benchmark,
+// benchmarks/retrieval_quality and the context-sync budget cannot drift into
+// meaning different things
+// by the word "tokens" — docs/benchmarks.md publishes figures from both.
+func approxTokens(text string) int {
+	return tokens.Approx(text)
+}
+
+// ── Benchmark ─────────────────────────────────────────────────────────────────
+
+const (
+	agentID = "sales-agent"
+	query   = "follow up with prospects and close pending deals this week"
+	topK    = 8
+)
+
+// sessionCounts controls which data points are reported.
+// Each "session" = one stored memory observation (a paragraph extracted from
+// a real agent interaction, ~50-70 words). Full injection = all observations
+// concatenated. GrayMatter = top-8 most relevant observations recalled.
+var sessionCounts = []int{1, 10, 30, 100}
+
+// result is one row of the benchmark table.
+type result struct {
+	Sessions     int
+	FullTokens   int
+	RecallTokens int
+	Reduction    float64 // percent
+}
+
+// runBenchmark executes the full measurement and returns one result per entry
+// in sessionCounts. It is separated from main so the reproducibility test can
+// call it and compare the published tables against freshly measured numbers.
 func runBenchmark() ([]result, error) {
-	return bench.RunTokenCount()
+	// Shuffle insertion order so keyword ranking is not biased by the order
+	// the corpus happens to be written in. Fixed seed: the shuffle is part of
+	// the fixture, not a source of variation.
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec
+	perm := rng.Perm(len(corpus))
+
+	results := make([]result, 0, len(sessionCounts))
+	for _, target := range sessionCounts {
+		r, err := measureAt(target, perm)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+// measureAt builds a fresh store holding exactly `target` observations and
+// takes one measurement from it.
+//
+// Each row gets its own store on purpose. Reusing one store across rows made
+// the benchmark non-reproducible: Recall updates AccessCount and AccessedAt
+// from detached goroutines, so the writebacks from one row were still in
+// flight while the next row was inserting and backdating, and a late writeback
+// restores the whole Fact as it looked when it was read. Measured rate was
+// about one differing run in twenty-five — often enough to publish a number
+// nobody else can reproduce, rare enough that nobody notices why.
+//
+// Recall itself is deterministic: 300 calls against a fixed store return the
+// same result every time. The variance was entirely in how the store was
+// built, which is why the fix belongs here and not in the engine.
+func measureAt(target int, perm []int) (result, error) {
+	dataDir, err := os.MkdirTemp("", "graymatter-bench-*")
+	if err != nil {
+		return result{}, fmt.Errorf("mktemp: %w", err)
+	}
+	defer os.RemoveAll(dataDir)
+
+	emb := embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
+	store, err := memory.Open(memory.StoreConfig{
+		DataDir:  dataDir,
+		Embedder: emb,
+	})
+	if err != nil {
+		return result{}, fmt.Errorf("open store: %w", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	for i := 0; i < target && i < len(corpus); i++ {
+		if err := store.Put(ctx, agentID, corpus[perm[i]]); err != nil {
+			return result{}, fmt.Errorf("put: %w", err)
+		}
+	}
+	if err := spreadOverSessions(store); err != nil {
+		return result{}, err
+	}
+
+	// Full injection: ALL stored observations concatenated.
+	allFacts, err := store.List(agentID)
+	if err != nil {
+		return result{}, fmt.Errorf("list: %w", err)
+	}
+	fullTexts := make([]string, 0, len(allFacts))
+	for _, f := range allFacts {
+		fullTexts = append(fullTexts, f.Text)
+	}
+	fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
+
+	// GrayMatter: recall only the top-K most relevant observations.
+	recalled, err := store.Recall(ctx, agentID, query, topK)
+	if err != nil {
+		return result{}, fmt.Errorf("recall: %w", err)
+	}
+	recallTokens := approxTokens(strings.Join(recalled, "\n"))
+
+	reduction := 0.0
+	if fullTokens > 0 {
+		reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
+	}
+	return result{
+		Sessions:     target,
+		FullTokens:   fullTokens,
+		RecallTokens: recallTokens,
+		Reduction:    reduction,
+	}, nil
 }
 
 func main() {
@@ -42,5 +264,61 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Print(bench.RenderTokenReport(results, time.Since(start)))
+	fmt.Println()
+	fmt.Println("GrayMatter Token Efficiency Benchmark")
+	fmt.Printf("Query:    %q\n", query)
+	fmt.Printf("Embedder: keyword (no LLM required — fully reproducible)\n")
+	fmt.Printf("TopK:     %d recalled observations per query\n", topK)
+	fmt.Println()
+	fmt.Printf("%-10s  %-18s  %-22s  %s\n",
+		"Sessions", "Full Injection", "GrayMatter Recall", "Reduction")
+	fmt.Println(strings.Repeat("─", 72))
+
+	for _, r := range results {
+		fmt.Printf("%-10d  ~%-17d  ~%-21d  %.0f%%\n",
+			r.Sessions, r.FullTokens, r.RecallTokens, r.Reduction)
+	}
+
+	fmt.Println(strings.Repeat("─", 72))
+	fmt.Printf("\nRun time:  %s\n", time.Since(start).Truncate(time.Millisecond))
+	fmt.Println()
+	fmt.Println("Approximation: words × 1.33 ≈ GPT-4 tokens (±10% for English prose).")
+	fmt.Println("With vector embeddings (Ollama / OpenAI / Anthropic) recall precision")
+	fmt.Println("improves further, maintaining similar or better token reduction ratios.")
+}
+
+// spreadOverSessions backdates the stored facts so that session N sits N days
+// before session inserted, one observation per simulated day.
+//
+// Without this the benchmark writes every fact inside the same few
+// milliseconds, and the clock is not that precise: in a 30-fact run, 8 facts
+// routinely share a CreatedAt. Facts with an identical timestamp have an
+// identical recency score, and recall.go turns scores into ranks with
+// sort.Slice, which is not stable — so tied facts receive arbitrary ranks,
+// those ranks feed the fused score, and the final ordering varies between
+// runs. Measured rate on this corpus was roughly one differing run in
+// twenty-five, which is exactly often enough to publish a number nobody can
+// reproduce and rare enough that nobody notices why.
+//
+// One fact per day also matches what the benchmark says it models: a session
+// is a day of agent work, not a microsecond of one.
+//
+// This is a fix to the benchmark, not to the engine. The underlying tie-break
+// in recall.go is still unspecified for facts written in the same instant.
+func spreadOverSessions(store *memory.Store) error {
+	facts, err := store.List(agentID)
+	if err != nil {
+		return fmt.Errorf("list for backdating: %w", err)
+	}
+	now := time.Now().UTC()
+	for i := range facts {
+		// facts is newest-first; index 0 is the most recent session.
+		at := now.Add(-time.Duration(i) * 24 * time.Hour)
+		facts[i].CreatedAt = at
+		facts[i].AccessedAt = at
+		if err := store.UpdateFact(agentID, facts[i]); err != nil {
+			return fmt.Errorf("backdate: %w", err)
+		}
+	}
+	return nil
 }

--- a/cmd/graymatter/cmd_bench.go
+++ b/cmd/graymatter/cmd_bench.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/internal/bench"
+	"github.com/angelnicolasc/graymatter/internal/tokens"
+)
+
+func benchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bench",
+		Short: "Run the published measurement suites",
+		Long: `Run GrayMatter's published benchmarks and print what they measure today.
+
+The synthetic suite is deterministic — keyword embedder, fixed corpus, no LLM,
+no network — so the same numbers come out on every machine. These are the same
+suites that gate README.md and docs/benchmarks.md in CI; running them here
+audits the published claims without cloning the repository or having Go.
+
+What the token-count suite does NOT measure: relevance. A system returning
+eight facts at random would score the same reduction. See docs/benchmarks.md
+for the retrieval-quality suite and its results.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBench(cmd)
+		},
+	}
+	return cmd
+}
+
+func runBench(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+
+	start := time.Now()
+	results, err := bench.RunTokenCount()
+	if err != nil {
+		return fmt.Errorf("token-count suite: %w", err)
+	}
+	elapsed := time.Since(start)
+
+	if jsonOut {
+		type row struct {
+			Sessions     int     `json:"sessions"`
+			FullTokens   int     `json:"full_tokens"`
+			RecallTokens int     `json:"recall_tokens"`
+			ReductionPct float64 `json:"reduction_pct"`
+		}
+		payload := struct {
+			Suite         string  `json:"suite"`
+			Query         string  `json:"query"`
+			TopK          int     `json:"top_k"`
+			TokensPerWord float64 `json:"tokens_per_word"`
+			DurationMS    int64   `json:"duration_ms"`
+			Results       []row   `json:"results"`
+		}{Suite: "token-count", Query: bench.TokenQuery, TopK: bench.TokenTopK,
+			TokensPerWord: tokens.PerWord, DurationMS: elapsed.Milliseconds()}
+		for _, r := range results {
+			payload.Results = append(payload.Results, row{
+				Sessions: r.Sessions, FullTokens: r.FullTokens,
+				RecallTokens: r.RecallTokens, ReductionPct: r.Reduction,
+			})
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	}
+
+	fmt.Fprint(out, bench.RenderTokenReport(results, elapsed))
+	return nil
+}

--- a/cmd/graymatter/cmd_bench.go
+++ b/cmd/graymatter/cmd_bench.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/angelnicolasc/graymatter/internal/bench"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/benchsyn"
 	"github.com/angelnicolasc/graymatter/internal/tokens"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
@@ -150,11 +150,11 @@ func renderStoreBench(out io.Writer, dir, mode string, rows []storeAgentRow, pro
 
 func encodeStoreBenchJSON(out io.Writer, dir, mode string, rows []storeAgentRow, probe *storeProbeResult) error {
 	payload := struct {
-		Suite    string          `json:"suite"`
-		DataDir  string          `json:"data_dir"`
-		Mode     string          `json:"mode"`
-		Agents   []storeAgentRow `json:"agents"`
-		Probe    *storeProbeResult `json:"probe,omitempty"`
+		Suite   string            `json:"suite"`
+		DataDir string            `json:"data_dir"`
+		Mode    string            `json:"mode"`
+		Agents  []storeAgentRow   `json:"agents"`
+		Probe   *storeProbeResult `json:"probe,omitempty"`
 	}{Suite: "store", DataDir: dir, Mode: mode, Agents: rows, Probe: probe}
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
@@ -222,7 +222,7 @@ func runBench(cmd *cobra.Command) error {
 	out := cmd.OutOrStdout()
 
 	start := time.Now()
-	results, err := bench.RunTokenCount()
+	results, err := benchsyn.RunTokenCount()
 	if err != nil {
 		return fmt.Errorf("token-count suite: %w", err)
 	}
@@ -242,7 +242,7 @@ func runBench(cmd *cobra.Command) error {
 			TokensPerWord float64 `json:"tokens_per_word"`
 			DurationMS    int64   `json:"duration_ms"`
 			Results       []row   `json:"results"`
-		}{Suite: "token-count", Query: bench.TokenQuery, TopK: bench.TokenTopK,
+		}{Suite: "token-count", Query: benchsyn.TokenQuery, TopK: benchsyn.TokenTopK,
 			TokensPerWord: tokens.PerWord, DurationMS: elapsed.Milliseconds()}
 		for _, r := range results {
 			payload.Results = append(payload.Results, row{
@@ -255,7 +255,7 @@ func runBench(cmd *cobra.Command) error {
 		return enc.Encode(payload)
 	}
 
-	fmt.Fprint(out, bench.RenderTokenReport(results, elapsed))
+	fmt.Fprint(out, benchsyn.RenderTokenReport(results, elapsed))
 	return nil
 }
 

--- a/cmd/graymatter/cmd_bench.go
+++ b/cmd/graymatter/cmd_bench.go
@@ -1,34 +1,220 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/angelnicolasc/graymatter/internal/bench"
 	"github.com/angelnicolasc/graymatter/internal/tokens"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
+// runBenchStore measures the caller's actual memory. Everything is read-only
+// except under --probe-recall; see its flag help for why that one writes.
+func runBenchStore(cmd *cobra.Command, onlyAgent string, probeRecall bool) error {
+	out := cmd.OutOrStdout()
+
+	store, err := openStore()
+	if err != nil {
+		return fmt.Errorf("open memory: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	agents, err := store.ListAgents()
+	if err != nil {
+		return fmt.Errorf("list agents: %w", err)
+	}
+	if onlyAgent != "" && !containsString(agents, onlyAgent) {
+		return fmt.Errorf("no such agent %q (known: %s)", onlyAgent, strings.Join(agents, ", "))
+	}
+
+	rows := make([]storeAgentRow, 0, len(agents))
+	for _, a := range agents {
+		if onlyAgent != "" && a != onlyAgent {
+			continue
+		}
+		facts, err := store.List(a)
+		if err != nil {
+			return fmt.Errorf("list facts for %q: %w", a, err)
+		}
+		rows = append(rows, measureStoreAgent(a, facts))
+	}
+
+	var probe *storeProbeResult
+	if probeRecall {
+		if probe, err = probeRecalls(store, rows); err != nil {
+			return fmt.Errorf("probe recalls: %w", err)
+		}
+	}
+
+	mode := "daemon"
+	if _, direct := store.(*directStore); direct {
+		mode = "in-process"
+	}
+	if jsonOut {
+		return encodeStoreBenchJSON(out, dataDir, mode, rows, probe)
+	}
+	return renderStoreBench(out, dataDir, mode, rows, probe)
+}
+
+// storeProbeResult summarises --probe-recall over every measured agent.
+type storeProbeResult struct {
+	Queries   int     `json:"queries"`
+	AvgTokens float64 `json:"avg_tokens"`
+	MaxTokens int     `json:"max_tokens"`
+}
+
+const probeSamplesPerAgent = 20
+
+// probeRecalls issues real recalls against sampled queries and reports what
+// they actually cost. Queries are fact texts themselves: biased toward easy
+// hits by design — this measures injection cost, not retrieval quality.
+func probeRecalls(store cliStore, rows []storeAgentRow) (*storeProbeResult, error) {
+	res := &storeProbeResult{}
+	total := 0
+	for _, r := range rows {
+		facts, err := store.List(r.Agent)
+		if err != nil {
+			return nil, err
+		}
+		live := make([]string, 0, len(facts))
+		for _, f := range facts {
+			if f.SupersededBy == "" {
+				live = append(live, f.Text)
+			}
+		}
+		n := probeSamplesPerAgent
+		if len(live) < n {
+			n = len(live)
+		}
+		for i := 0; i < n; i++ {
+			recalled, err := store.Recall(context.Background(), r.Agent, live[i], 8)
+			if err != nil {
+				continue // one dead sample must not sink the measurement
+			}
+			tk := tokens.Approx(strings.Join(recalled, "\n"))
+			total += tk
+			res.Queries++
+			if tk > res.MaxTokens {
+				res.MaxTokens = tk
+			}
+		}
+	}
+	if res.Queries > 0 {
+		res.AvgTokens = float64(total) / float64(res.Queries)
+	}
+	return res, nil
+}
+
+func renderStoreBench(out io.Writer, dir, mode string, rows []storeAgentRow, probe *storeProbeResult) error {
+	totalFacts := 0
+	for _, r := range rows {
+		totalFacts += r.LiveFacts
+	}
+	fmt.Fprintf(out, "\nStore: %s (%s)\n", dir, mode)
+	fmt.Fprintf(out, "agents: %d · live facts: %d\n\n", len(rows), totalFacts)
+
+	if len(rows) == 0 || totalFacts == 0 {
+		fmt.Fprintln(out, "No live facts to measure yet. Store something first:")
+		fmt.Fprintf(out, "  graymatter remember \"my-agent\" \"an observation worth keeping\"\n")
+		return nil
+	}
+
+	fmt.Fprintf(out, "%-16s  %-12s  %-12s  %-14s  %s\n",
+		"Agent", "Live", "Full dump", "Sliding-8", "Est. top-8")
+	fmt.Fprintln(out, strings.Repeat("─", 74))
+	for _, r := range rows {
+		fmt.Fprintf(out, "%-16s  ~%-11d  ~%-11d  ~%-11d  ~%d\n",
+			truncate(r.Agent, 16), r.LiveFacts, r.FullTokens, r.Sliding8Tokens, r.Top8WeightedTok)
+	}
+	fmt.Fprintln(out, strings.Repeat("─", 74))
+	fmt.Fprintln(out, "Token figures are estimates (~1.33 per word). The sliding window is the")
+	fmt.Fprintln(out, "strongest baseline GrayMatter replaces; the full dump is what unbounded")
+	fmt.Fprintln(out, "history costs. Neither baseline checks relevance.")
+	if probe != nil && probe.Queries > 0 {
+		fmt.Fprintf(out, "\nProbe: %d real recalls · avg %.0f tokens · max %d.\n",
+			probe.Queries, probe.AvgTokens, probe.MaxTokens)
+		fmt.Fprintln(out, "Note: probes bumped access counters (recency bookkeeping).")
+	} else if probe != nil {
+		fmt.Fprintln(out, "\nProbe produced no samples (stores too small).")
+	}
+	return nil
+}
+
+func encodeStoreBenchJSON(out io.Writer, dir, mode string, rows []storeAgentRow, probe *storeProbeResult) error {
+	payload := struct {
+		Suite    string          `json:"suite"`
+		DataDir  string          `json:"data_dir"`
+		Mode     string          `json:"mode"`
+		Agents   []storeAgentRow `json:"agents"`
+		Probe    *storeProbeResult `json:"probe,omitempty"`
+	}{Suite: "store", DataDir: dir, Mode: mode, Agents: rows, Probe: probe}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
 func benchCmd() *cobra.Command {
+	var (
+		onStore     bool
+		onlyAgent   string
+		probeRecall bool
+	)
 	cmd := &cobra.Command{
 		Use:   "bench",
 		Short: "Run the published measurement suites",
 		Long: `Run GrayMatter's published benchmarks and print what they measure today.
 
-The synthetic suite is deterministic — keyword embedder, fixed corpus, no LLM,
-no network — so the same numbers come out on every machine. These are the same
-suites that gate README.md and docs/benchmarks.md in CI; running them here
-audits the published claims without cloning the repository or having Go.
+Two modes:
+
+Default — the synthetic suite: deterministic, keyword embedder, fixed corpus,
+no LLM, no network. The same numbers come out on every machine; these are the
+suites that gate README.md and docs/benchmarks.md in CI.
+
+--store — your memory: reads the actual store (through the daemon when one is
+running) and reports what a recall would cost today against your own facts,
+next to the baselines it replaces. Read-only except under --probe-recall,
+which issues real recalls to measure them and says so.
 
 What the token-count suite does NOT measure: relevance. A system returning
 eight facts at random would score the same reduction. See docs/benchmarks.md
 for the retrieval-quality suite and its results.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if onStore {
+				return runBenchStore(cmd, onlyAgent, probeRecall)
+			}
 			return runBench(cmd)
 		},
 	}
+	cmd.Flags().BoolVar(&onStore, "store", false,
+		"measure the caller's own store instead of the synthetic suite")
+	cmd.Flags().StringVar(&onlyAgent, "agent", "",
+		"with --store: limit the measurement to this agent")
+	cmd.Flags().BoolVar(&probeRecall, "probe-recall", false,
+		"with --store: issue sample recalls (bumps access counters for recency bookkeeping)")
 	return cmd
 }
 
@@ -71,4 +257,56 @@ func runBench(cmd *cobra.Command) error {
 
 	fmt.Fprint(out, bench.RenderTokenReport(results, elapsed))
 	return nil
+}
+
+// --- --store mode -------------------------------------------------------------
+
+// storeAgentRow is the per-agent measurement of the caller's own memory.
+type storeAgentRow struct {
+	Agent           string `json:"agent"`
+	LiveFacts       int    `json:"live_facts"`
+	FullTokens      int    `json:"full_dump_tokens"`
+	Sliding8Tokens  int    `json:"sliding_8_tokens"`
+	Top8WeightedTok int    `json:"estimated_top8_tokens"`
+}
+
+// measureStoreAgent reads one agent's live facts and computes, without a
+// single Recall call: what dumping everything would cost, what the last-8
+// sliding window costs, and what GrayMatter's top-8-by-weight injection is
+// estimated to cost. Tombstones are excluded throughout — they never reach a
+// prompt.
+func measureStoreAgent(agent string, facts []memory.Fact) storeAgentRow {
+	live := make([]string, 0, len(facts))
+	for _, f := range facts {
+		if f.SupersededBy == "" {
+			live = append(live, f.Text)
+		}
+	}
+	row := storeAgentRow{Agent: agent, LiveFacts: len(live)}
+	if len(live) == 0 {
+		return row
+	}
+	row.FullTokens = tokens.Approx(strings.Join(live, "\n"))
+
+	window := live
+	if len(window) > 8 { // facts arrive newest-first; the window keeps the 8 most recent
+		window = window[:8]
+	}
+	row.Sliding8Tokens = tokens.Approx(strings.Join(window, "\n"))
+
+	byWeight := make([]memory.Fact, len(facts))
+	copy(byWeight, facts)
+	sort.SliceStable(byWeight, func(i, j int) bool { return byWeight[i].Weight > byWeight[j].Weight })
+	top := make([]string, 0, 8)
+	for _, f := range byWeight {
+		if f.SupersededBy != "" {
+			continue
+		}
+		top = append(top, f.Text)
+		if len(top) == 8 {
+			break
+		}
+	}
+	row.Top8WeightedTok = tokens.Approx(strings.Join(top, "\n"))
+	return row
 }

--- a/cmd/graymatter/cmd_bench.go
+++ b/cmd/graymatter/cmd_bench.go
@@ -293,7 +293,15 @@ func measureStoreAgent(agent string, facts []memory.Fact) storeAgentRow {
 		window = window[:8]
 	}
 	row.Sliding8Tokens = tokens.Approx(strings.Join(window, "\n"))
+	row.Top8WeightedTok = estimateTop8Tokens(facts)
+	return row
+}
 
+// estimateTop8Tokens estimates what injecting an agent's eight highest-weight
+// live facts would cost, without issuing a Recall (which would bump access
+// counters via detached writebacks). Shared by bench --store and status so
+// both surfaces quote the same number for the same store.
+func estimateTop8Tokens(facts []memory.Fact) int {
 	byWeight := make([]memory.Fact, len(facts))
 	copy(byWeight, facts)
 	sort.SliceStable(byWeight, func(i, j int) bool { return byWeight[i].Weight > byWeight[j].Weight })
@@ -307,6 +315,5 @@ func measureStoreAgent(agent string, facts []memory.Fact) storeAgentRow {
 			break
 		}
 	}
-	row.Top8WeightedTok = tokens.Approx(strings.Join(top, "\n"))
-	return row
+	return tokens.Approx(strings.Join(top, "\n"))
 }

--- a/cmd/graymatter/cmd_bench_store_test.go
+++ b/cmd/graymatter/cmd_bench_store_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// factWithText finds a fact by exact text in a seeded list.
+func factByText(t *testing.T, facts []memory.Fact, text string) memory.Fact {
+	t.Helper()
+	for _, f := range facts {
+		if f.Text == text {
+			return f
+		}
+	}
+	t.Fatalf("seed fact %q missing", text)
+	return memory.Fact{}
+}
+
+func TestMeasureStoreAgent_ExcludesTombstonesAndWeightsTop8(t *testing.T) {
+	facts := make([]memory.Fact, 0, 12)
+	for i := 0; i < 12; i++ {
+		facts = append(facts, memory.Fact{
+			ID: "f", AgentID: "a", Text: strings.Repeat("word ", 20),
+			CreatedAt: time.Now(), Weight: 0.5,
+		})
+	}
+	// One retired fact must vanish from every metric.
+	facts[3].SupersededBy = "successor"
+	// The heaviest live fact must lead the top-8 even though it is oldest.
+	facts[11].Weight = 0.99
+	// A tombstone with an enormous weight must still be excluded.
+	facts[4].Weight = 1.0
+
+	row := measureStoreAgent("a", facts)
+
+	if row.LiveFacts != 11 {
+		t.Errorf("live facts = %d, want 11 (tombstone excluded)", row.LiveFacts)
+	}
+	if row.FullTokens == 0 || row.Sliding8Tokens == 0 || row.Top8WeightedTok == 0 {
+		t.Fatalf("empty metrics on a non-empty store: %+v", row)
+	}
+	if row.FullTokens <= row.Sliding8Tokens {
+		t.Errorf("full dump %d should cost more than an 8-fact window %d",
+			row.FullTokens, row.Sliding8Tokens)
+	}
+
+	// Recompute the top-8 expectation independently: 11 live facts, the 8
+	// heaviest include the 0.99 one; cost equals any 8 of them (~same length).
+	if got := row.Top8WeightedTok; got >= row.FullTokens {
+		t.Errorf("top-8 estimate %d must stay below full dump %d", got, row.FullTokens)
+	}
+
+	empty := measureStoreAgent("empty", nil)
+	if empty.LiveFacts != 0 || empty.FullTokens != 0 {
+		t.Errorf("empty agent should report zeros, got %+v", empty)
+	}
+}
+
+// seedStore opens a real direct store in a temp dir and stores n facts,
+// returning the raw handle so tests can retire facts before measuring.
+func seedStore(t *testing.T, n int) (*directStore, func()) {
+	t.Helper()
+	oldDir := dataDir
+	dataDir = t.TempDir()
+	cfg := graymatter.DefaultConfig()
+	cfg.DataDir = dataDir // the store under test lives where openStore will look
+	mem, err := graymatter.NewWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	ds := &directStore{mem: mem, store: mem.Advanced()}
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		if err := ds.Remember(ctx, "bench-agent", strings.Repeat("observation number "+string(rune('a'+i%26))+" ", 15)); err != nil {
+			t.Fatalf("remember: %v", err)
+		}
+	}
+	return ds, func() { dataDir = oldDir; _ = mem.Close() }
+}
+
+func runBenchCmd(t *testing.T, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := benchCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("bench %v: %v\n%s", args, err, out.String())
+	}
+	return out.String()
+}
+
+func TestBenchStore_JSONReportsLiveFactsOnly(t *testing.T) {
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1") // measure in-process; never spawn a daemon from a test
+	// 12 seeds so that after retiring one, 11 live facts remain and the
+	// top-8 estimate must be strictly cheaper than the full dump — with 8 or
+	// fewer live facts they are legitimately identical, as the published
+	// table's 0%-at-1-session row already says.
+	ds, cleanup := seedStore(t, 12)
+	defer cleanup()
+
+	// Retire one fact so live != stored.
+	all, err := ds.List("bench-agent")
+	if err != nil || len(all) != 12 {
+		t.Fatalf("seed state wrong: %v / %d", err, len(all))
+	}
+	victim := factByText(t, all, all[0].Text)
+	victim.SupersededBy = "gone"
+	if err := ds.UpdateFact("bench-agent", victim); err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+	if err := ds.Close(); err != nil { // release the lock: measure as a user would
+		t.Fatalf("close seeded handle: %v", err)
+	}
+
+	jsonOut = true
+	t.Cleanup(func() { jsonOut = false })
+	out := runBenchCmd(t, "--store")
+
+	var payload struct {
+		Suite   string `json:"suite"`
+		DataDir string `json:"data_dir"`
+		Mode    string `json:"mode"`
+		Agents  []struct {
+			Agent           string `json:"agent"`
+			LiveFacts       int    `json:"live_facts"`
+			FullTokens      int    `json:"full_dump_tokens"`
+			Sliding8Tokens  int    `json:"sliding_8_tokens"`
+			Top8WeightedTok int    `json:"estimated_top8_tokens"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if payload.Suite != "store" || len(payload.Agents) != 1 {
+		t.Fatalf("unexpected payload shape: suite=%q agents=%d", payload.Suite, len(payload.Agents))
+	}
+	row := payload.Agents[0]
+	if row.Agent != "bench-agent" || row.LiveFacts != 11 {
+		t.Errorf("agent=%q live=%d, want bench-agent/11 (one tombstone)", row.Agent, row.LiveFacts)
+	}
+	if row.FullTokens == 0 || row.Top8WeightedTok >= row.FullTokens {
+		t.Errorf("token metrics not ordered as expected: full=%d top8=%d",
+			row.FullTokens, row.Top8WeightedTok)
+	}
+	if payload.Mode != "in-process" {
+		t.Errorf("mode = %q, want in-process under a direct store", payload.Mode)
+	}
+}
+
+func TestBenchStore_HumanOutputAndProbe(t *testing.T) {
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	ds, cleanup := seedStore(t, 9)
+	// Release the write lock so the command opens the store read-write —
+	// exactly how a user runs it against a quiet store.
+	if err := ds.Close(); err != nil {
+		t.Fatalf("close seeded handle: %v", err)
+	}
+	defer cleanup()
+
+	out := runBenchCmd(t, "--store")
+	if !strings.Contains(out, "live facts: 9") {
+		t.Errorf("human output missing live count:\n%s", out)
+	}
+	if !strings.Contains(out, "bench-agent") {
+		t.Error("human output missing agent name")
+	}
+
+	jsonOut = true
+	t.Cleanup(func() { jsonOut = false })
+	out = runBenchCmd(t, "--store", "--probe-recall")
+	var payload struct {
+		Probe *struct {
+			Queries int `json:"queries"`
+		} `json:"probe"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if payload.Probe == nil || payload.Probe.Queries < 1 {
+		t.Errorf("probe produced no measurable samples: %+v", payload.Probe)
+	}
+	// Note on access counters: Recall bumps them via detached writebacks (the
+	// exact flakiness benchmarks/token_count documents), so their timing is
+	// not asserted here — only that real recalls were issued and priced.
+}
+
+func TestBenchStore_UnknownAgentErrors(t *testing.T) {
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	ds, cleanup := seedStore(t, 2)
+	if err := ds.Close(); err != nil { // release the lock before invoking the command
+		t.Fatalf("close seeded handle: %v", err)
+	}
+	defer cleanup()
+
+	cmd := benchCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--store", "--agent", "nobody"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "no such agent") {
+		t.Fatalf("expected no-such-agent error, got %v", err)
+	}
+}

--- a/cmd/graymatter/cmd_bench_test.go
+++ b/cmd/graymatter/cmd_bench_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/internal/bench"
+)
+
+// TestBench_SyntheticJSON executes the real cobra command and asserts the
+// machine-readable payload: four published session counts, sane fields, and a
+// reduction column consistent with the rows. The numbers themselves are gated
+// against the published tables by benchmarks/token_count/main_test.go — that
+// test owns "are these figures true", this one owns "is the output usable".
+func TestBench_SyntheticJSON(t *testing.T) {
+	cmd := benchCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	jsonOut = true
+	t.Cleanup(func() { jsonOut = false })
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("bench --json: %v", err)
+	}
+
+	var payload struct {
+		Suite         string  `json:"suite"`
+		Query         string  `json:"query"`
+		TopK          int     `json:"top_k"`
+		TokensPerWord float64 `json:"tokens_per_word"`
+		DurationMS    int64   `json:"duration_ms"`
+		Results       []struct {
+			Sessions     int     `json:"sessions"`
+			FullTokens   int     `json:"full_tokens"`
+			RecallTokens int     `json:"recall_tokens"`
+			ReductionPct float64 `json:"reduction_pct"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+
+	if payload.Suite != "token-count" {
+		t.Errorf("suite = %q, want token-count", payload.Suite)
+	}
+	if payload.TopK != 8 || payload.TokensPerWord != 1.33 {
+		t.Errorf("top_k=%d tokens_per_word=%v, want 8 / 1.33", payload.TopK, payload.TokensPerWord)
+	}
+	if len(payload.Results) != len(bench.SessionCounts) {
+		t.Fatalf("got %d rows, want %d", len(payload.Results), len(bench.SessionCounts))
+	}
+
+	for i, r := range payload.Results {
+		wantSessions := bench.SessionCounts[i]
+		if r.Sessions != wantSessions {
+			t.Errorf("row %d sessions = %d, want %d", i, r.Sessions, wantSessions)
+		}
+		if r.Sessions == 1 {
+			continue // no history to compress yet; reduction is legitimately ~0
+		}
+		if r.RecallTokens >= r.FullTokens {
+			t.Errorf("%d sessions: recall %d not smaller than full injection %d",
+				r.Sessions, r.RecallTokens, r.FullTokens)
+		}
+		if r.ReductionPct <= 0 || r.ReductionPct > 100 {
+			t.Errorf("%d sessions: reduction %v outside (0,100]", r.Sessions, r.ReductionPct)
+		}
+	}
+}
+
+// TestBench_SyntheticHuman checks the human path renders the report header and
+// stays quiet about JSON.
+func TestBench_SyntheticHuman(t *testing.T) {
+	cmd := benchCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("bench: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "GrayMatter Token Efficiency Benchmark") {
+		t.Error("human output missing report title")
+	}
+	if !strings.Contains(got, "Reduction") {
+		t.Error("human output missing table header")
+	}
+	if !strings.HasPrefix(got, "\n") {
+		t.Errorf("renderer must start with the same leading newline as the historical output")
+	}
+}

--- a/cmd/graymatter/cmd_bench_test.go
+++ b/cmd/graymatter/cmd_bench_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/angelnicolasc/graymatter/internal/bench"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/benchsyn"
 )
 
 // TestBench_SyntheticJSON executes the real cobra command and asserts the
@@ -49,12 +49,12 @@ func TestBench_SyntheticJSON(t *testing.T) {
 	if payload.TopK != 8 || payload.TokensPerWord != 1.33 {
 		t.Errorf("top_k=%d tokens_per_word=%v, want 8 / 1.33", payload.TopK, payload.TokensPerWord)
 	}
-	if len(payload.Results) != len(bench.SessionCounts) {
-		t.Fatalf("got %d rows, want %d", len(payload.Results), len(bench.SessionCounts))
+	if len(payload.Results) != len(benchsyn.SessionCounts) {
+		t.Fatalf("got %d rows, want %d", len(payload.Results), len(benchsyn.SessionCounts))
 	}
 
 	for i, r := range payload.Results {
-		wantSessions := bench.SessionCounts[i]
+		wantSessions := benchsyn.SessionCounts[i]
 		if r.Sessions != wantSessions {
 			t.Errorf("row %d sessions = %d, want %d", i, r.Sessions, wantSessions)
 		}

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
@@ -79,6 +80,7 @@ Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 				checkStore(dataDir),
 				checkMCPWiring("."),
 				checkInstructions("."),
+				checkKG(dataDir),
 				checkContextSync("."),
 			}
 
@@ -258,17 +260,30 @@ func projectAge(dir string) (time.Duration, bool) {
 	return time.Since(info.ModTime()), true
 }
 
-// flagIfUnused downgrades an otherwise-healthy store check to a warning when a
-// project has been set up for a while and still holds nothing.
+// flagIfUnused shapes the store check for a project that holds nothing.
 //
 // This is the gap issue #14 fell through: wiring, instructions and store can
 // all be green while the agent never calls a single tool, and the old summary
 // still read "Everything looks good". A user had no way to tell a fresh install
 // apart from a week of silence, so the failure produced no bug reports, just
 // people quietly giving up.
+//
+// Two regimes, both anchored on facts == 0 regardless of whether gray.db
+// exists yet (a CLI `remember` during setup used to silence the hint while
+// the MCP session still had no tools):
+//
+//   - young projects get the restart hint at ok severity — the single most
+//     common false alarm is a client that has not been restarted since init;
+//   - projects idle past staleAfter degrade to warn and stack the instruction
+//     guidance on top, because at that point restart alone did not help.
+const zeroFactsRestartHint = "if your agent cannot see the memory tools, restart your MCP client; clients launch their servers at startup, so a session that predates `graymatter init` never picks them up"
+
 func flagIfUnused(c checkResult, dir string, facts int) checkResult {
 	if facts > 0 || (c.Status != "ok" && c.Status != "info") {
 		return c
+	}
+	if c.Hint == "" {
+		c.Hint = zeroFactsRestartHint
 	}
 	age, ok := projectAge(dir)
 	if !ok || age < staleAfter {
@@ -276,7 +291,7 @@ func flagIfUnused(c checkResult, dir string, facts int) checkResult {
 	}
 	c.Status = "warn"
 	c.Detail = fmt.Sprintf("initialised %d day(s) ago and still holds no facts", int(age.Hours()/24))
-	c.Hint = "the tools are wired but nothing is calling them; confirm CLAUDE.md / AGENTS.md carry the memory block (re-run `graymatter init` to refresh it) and that your agent loads that file, or use `graymatter init --global` to install it for every project"
+	c.Hint = zeroFactsRestartHint + "; if a restart did happen, confirm CLAUDE.md / AGENTS.md carry the memory block (re-run `graymatter init` to refresh it), that your agent loads that file, or use `graymatter init --global` to install it for every project"
 	return c
 }
 
@@ -355,6 +370,91 @@ func checkStore(dir string) checkResult {
 		c.Hint = "pending vectors in a quiescent system mean the embedding backend is failing — check your embedding configuration (Ollama URL / API keys)"
 	}
 	return flagIfUnused(c, dir, facts)
+}
+
+// checkKG reports knowledge-graph auto-population state and graph size.
+//
+// Deliberately benign when off: the graph is optional, and a warning for
+// something the user never asked for is noise that trains people to ignore
+// doctor output. The goal here is discoverability — the one line that tells
+// a non-README-reading user the feature exists and how to turn it on — plus
+// confirmation (with counts) for those who did opt in. The daemon is not
+// required: the sentinel/env decision and a read-only graph open answer
+// everything offline, so this check works before any client has started.
+func checkKG(dir string) checkResult {
+	c := checkResult{Name: "knowledge graph"}
+	auto := os.Getenv("GRAYMATTER_KG") == "1"
+	if _, err := os.Stat(daemon.KGSentinelPath(dir)); err == nil {
+		auto = true
+	}
+
+	nodes, edges, countErr := countGraphReadOnly(dir)
+	switch {
+	case countErr != nil:
+		// No db yet: same fresh-install regime as the store check.
+		c.Status, c.Detail = "info", "no database yet; the graph starts empty"
+		if auto {
+			c.Detail = "auto-population on; the graph starts empty"
+			c.Hint = "first entities appear after ~20 facts, when consolidation first runs"
+		} else {
+			c.Hint = "optional: graymatter init --kg extracts entities and co-mention edges during consolidation"
+		}
+	case !auto && nodes == 0 && edges == 0:
+		c.Status, c.Detail = "info", fmt.Sprintf("off — %d nodes / %d edges", nodes, edges)
+		c.Hint = "optional: graymatter init --kg extracts entities and co-mention edges during consolidation; explicit links via memory_reflect action=link work regardless"
+	case auto && nodes == 0:
+		c.Status, c.Detail = "info", fmt.Sprintf("auto-population on — graph empty until consolidation (%d nodes / %d edges)", nodes, edges)
+		c.Hint = "first entities appear after ~20 facts, when consolidation first runs"
+	default:
+		c.Status = "ok"
+		detail := fmt.Sprintf("%d nodes / %d edges", nodes, edges)
+		if auto {
+			detail = "auto-population active — " + detail
+		} else {
+			detail = "explicitly linked — " + detail
+		}
+		c.Detail = detail
+	}
+	return c
+}
+
+// countGraphReadOnly reads node/edge counts without touching the daemon:
+// through its RPC when one is up, else a read-only bbolt open. A missing
+// gray.db reports as (0, 0, nil) so callers treat it as "empty", not error.
+func countGraphReadOnly(dir string) (nodes, edges int, err error) {
+	if dc, derr := daemon.ConnectNoSpawn(dir); derr == nil {
+		defer func() { _ = dc.Close() }()
+		state, serr := dc.KGState()
+		if serr != nil {
+			return 0, 0, serr
+		}
+		return state.Nodes, state.Edges, nil
+	}
+	dbPath := filepath.Join(dir, "gray.db")
+	if _, statErr := os.Stat(dbPath); statErr != nil {
+		return 0, 0, nil //nolint:nilerr // no database yet is emptiness, not failure
+	}
+	store, oerr := memory.Open(memory.StoreConfig{DataDir: dir, ReadOnly: true})
+	if oerr != nil {
+		return 0, 0, oerr
+	}
+	defer func() { _ = store.Close() }()
+	g, gerr := kg.OpenRead(store.DB())
+	if errors.Is(gerr, kg.ErrNoGraph) {
+		return 0, 0, nil // the store never had a graph: empty, not failure
+	}
+	if gerr != nil {
+		return 0, 0, gerr
+	}
+	ns, nerr := g.AllNodes()
+	if nerr != nil {
+		return 0, 0, nerr
+	}
+	es, eerr := g.AllEdges()
+	if eerr != nil {
+		return 0, 0, eerr
+	}
+	return len(ns), len(es), nil
 }
 
 // wiredAgents returns the known agents whose MCP config in this project

--- a/cmd/graymatter/cmd_doctor_kg_test.go
+++ b/cmd/graymatter/cmd_doctor_kg_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// seedGrayDB creates a real gray.db in dir (bbolt creates on open) so the
+// "database exists" branches of checkStore/checkKG run.
+func seedGrayDB(t *testing.T, dir string, facts int) {
+	t.Helper()
+	store, err := memory.Open(memory.StoreConfig{DataDir: dir})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	ctx := context.Background()
+	for i := 0; i < facts; i++ {
+		if err := store.Put(ctx, "doc-agent", strings.Repeat("fact ", 10)); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestCheckStore_EmptyDBYoungProjectGetsRestartHint(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	seedGrayDB(t, dir, 0) // db exists: the old code went silent here
+
+	c := checkStore(dir)
+	if c.Status != "ok" && c.Status != "info" {
+		t.Fatalf("status = %s (%s)", c.Status, c.Detail)
+	}
+	if !strings.Contains(c.Hint, "restart your MCP client") {
+		t.Errorf("empty db with no facts must carry the restart hint, got hint=%q", c.Hint)
+	}
+}
+
+func TestCheckStore_FactsPresentNoHint(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	seedGrayDB(t, dir, 2)
+
+	c := checkStore(dir)
+	if c.Status != "ok" {
+		t.Fatalf("status = %s (%s)", c.Status, c.Detail)
+	}
+	if c.Hint != "" {
+		t.Errorf("a used store should not nag: %q", c.Hint)
+	}
+}
+
+func TestCheckStore_StaleEmptyKeepsRestartAndAddsGuidance(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	seedGrayDB(t, dir, 0)
+
+	memoryMD := filepath.Join(dir, "MEMORY.md")
+	if err := os.WriteFile(memoryMD, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-72 * time.Hour)
+	if err := os.Chtimes(memoryMD, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	c := checkStore(dir)
+	if c.Status != "warn" {
+		t.Fatalf("status = %s, want warn for a stale empty project (%s)", c.Status, c.Detail)
+	}
+	if !strings.Contains(c.Hint, "restart your MCP client") ||
+		!strings.Contains(c.Hint, "CLAUDE.md") {
+		t.Errorf("stale warning must keep restart first then add guidance, got %q", c.Hint)
+	}
+}
+
+func TestCheckKG_DecisionTable(t *testing.T) {
+	t.Run("off by default is benign info with the enable command", func(t *testing.T) {
+		dir := t.TempDir()
+		c := checkKG(dir)
+		if c.Status != "info" {
+			t.Errorf("off state should be info (benign), got %s: %s", c.Status, c.Detail)
+		}
+		if !strings.Contains(c.Hint, "init --kg") {
+			t.Errorf("off state should advertise init --kg, got %q", c.Hint)
+		}
+	})
+
+	t.Run("sentinel on without db reports enabled and empty", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(daemon.KGSentinelPath(dir), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		c := checkKG(dir)
+		if !strings.Contains(c.Detail, "on") {
+			t.Errorf("detail should say auto-population is on: %s", c.Detail)
+		}
+		if !strings.Contains(strings.ToLower(c.Detail+c.Hint), "consolidation") || c.Status == "fail" {
+			t.Errorf("enabled-empty state should explain the threshold: status=%s detail=%s hint=%s",
+				c.Status, c.Detail, c.Hint)
+		}
+	})
+
+	t.Run("env var alone enables too", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("GRAYMATTER_KG", "1")
+		c := checkKG(dir)
+		if !strings.Contains(c.Detail, "on") {
+			t.Errorf("env-enabled state not detected: %s", c.Detail)
+		}
+	})
+
+	t.Run("explicitly linked graph without auto stays non-warn", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+		cfg := memory.StoreConfig{DataDir: dir}
+		store, err := memory.Open(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		g, err := kg.Open(store.DB())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := g.Upsert(kg.Node{ID: "a", Label: "A", EntityType: "person"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		c := checkKG(dir)
+		if c.Status == "warn" || c.Status == "fail" {
+			t.Errorf("explicit links are legitimate; doctor must not scold: %s / %s", c.Status, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "1 nodes") {
+			t.Errorf("node count missing from detail: %s", c.Detail)
+		}
+	})
+}

--- a/cmd/graymatter/cmd_init.go
+++ b/cmd/graymatter/cmd_init.go
@@ -186,31 +186,22 @@ resolves a command through it.`,
 				warnings = append(warnings, installGlobalInstructions(quiet)...)
 			}
 
+			// Putting the executable's directory on the user PATH means every
+			// later process resolves commands through it. That is fine for a
+			// directory only you can write, and a hijack vector for one you
+			// share — so it has to be refusable. Runs before the next steps so
+			// the restart instruction can fold PowerShell in when it applies.
+			pathChanged := false
+			if !noPath {
+				pathChanged = maybeAddToPath(quiet)
+			}
+
 			if !quiet {
 				for _, w := range warnings {
 					fmt.Fprintf(os.Stderr, "\n%s\n", w)
 				}
 				fmt.Printf("\ngraymatter is a general-purpose MCP server. Any MCP-compatible client works.\n")
-				printNextSteps(enableKG)
-			}
-
-			// Putting the executable's directory on the user PATH means every
-			// later process resolves commands through it. That is fine for a
-			// directory only you can write, and a hijack vector for one you
-			// share — so it has to be refusable.
-			if noPath {
-				return nil
-			}
-			if added, pathErr := addExeDirToUserPath(); pathErr != nil {
-				if !quiet {
-					exe, _ := os.Executable()
-					fmt.Fprintf(os.Stderr,
-						"\n  Warning: could not add %s to PATH: %v\n  Add it manually so you can type 'graymatter' from any directory.\n",
-						filepath.Dir(exe), pathErr)
-				}
-			} else if added && !quiet {
-				exe, _ := os.Executable()
-				fmt.Printf("\n  Added %s to your PATH — restart PowerShell to apply\n", filepath.Dir(exe))
+				printNextSteps(enableKG, pathChanged)
 			}
 
 			return nil

--- a/cmd/graymatter/cmd_init.go
+++ b/cmd/graymatter/cmd_init.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
 )
 
 func initCmd() *cobra.Command {
@@ -21,6 +23,7 @@ func initCmd() *cobra.Command {
 		skipInstructions bool
 		noPath           bool
 		only             string
+		enableKG         bool
 	)
 
 	cmd := &cobra.Command{
@@ -64,6 +67,16 @@ resolves a command through it.`,
 				content := "# GrayMatter Memory\n\nThis directory is managed by GrayMatter.\nDo not edit gray.db manually.\n"
 				if err := os.WriteFile(memoryMD, []byte(content), 0o644); err != nil {
 					return fmt.Errorf("create MEMORY.md: %w", err)
+				}
+			}
+
+			// --kg persists the opt-in as data-dir state so every future
+			// daemon honours it — including the ones MCP clients spawn with
+			// their own environment, which an exported GRAYMATTER_KG never
+			// reaches. Removal is `rm <dir>/kg.auto`; documented as such.
+			if enableKG {
+				if err := os.WriteFile(daemon.KGSentinelPath(dir), nil, 0o644); err != nil {
+					return fmt.Errorf("write kg sentinel: %w", err)
 				}
 			}
 
@@ -178,7 +191,7 @@ resolves a command through it.`,
 					fmt.Fprintf(os.Stderr, "\n%s\n", w)
 				}
 				fmt.Printf("\ngraymatter is a general-purpose MCP server. Any MCP-compatible client works.\n")
-				printNextSteps()
+				printNextSteps(enableKG)
 			}
 
 			// Putting the executable's directory on the user PATH means every
@@ -211,6 +224,8 @@ resolves a command through it.`,
 	cmd.Flags().BoolVar(&skipOpencode, "skip-opencode", false, "do not touch opencode.jsonc")
 	cmd.Flags().BoolVar(&withAntigravity, "with-antigravity", false, "also wire mcp_config.json for Antigravity")
 	cmd.Flags().BoolVar(&skipInstructions, "skip-instructions", false, "do not write the memory block into CLAUDE.md / AGENTS.md")
+	cmd.Flags().BoolVar(&enableKG, "kg", false,
+		"enable knowledge-graph auto-population: writes "+daemon.KGSentinelFile+" into the data dir so every future daemon extracts entities and co-mention edges (remove the file to turn off)")
 	cmd.Flags().BoolVar(&global, "global", false, "also write the memory block into ~/.claude/CLAUDE.md and ~/.config/opencode/AGENTS.md, so agents use memory in every project")
 	cmd.Flags().BoolVar(&noPath, "no-path", false,
 		"do not add the executable's directory to your user PATH")

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -366,9 +366,24 @@ func installGlobalInstructions(quiet bool) []string {
 // exist in the session that ran init, and an agent that goes straight to
 // calling them finds nothing however green doctor is. Shared between the plain
 // and interactive paths so the two cannot drift.
-func printNextSteps(kgAuto bool) {
+// printNextSteps closes both init paths with the same advice.
+//
+// The restart comes first because it is the step that makes a correct install
+// look broken. MCP clients launch their servers at startup, so the tools do not
+// exist in the session that ran init, and an agent that goes straight to
+// calling them finds nothing however green doctor is. Shared between the plain
+// and interactive paths so the two cannot drift.
+//
+// pathChanged folds the Windows PATH note into the restart line instead of
+// printing a second "restart" elsewhere: two restarts of two different things
+// at the end of one install is exactly the dilution that gets both ignored.
+func printNextSteps(kgAuto bool, pathChanged bool) {
 	fmt.Printf("\nNext steps:\n")
-	fmt.Printf("  1. Restart your MCP client (editor, agent, or terminal session).\n")
+	fmt.Printf("  1. Restart your MCP client (editor, agent, or terminal session)")
+	if pathChanged {
+		fmt.Printf(" — and PowerShell itself, which needs a restart to see the PATH entry this init added")
+	}
+	fmt.Printf(".\n")
 	fmt.Printf("     Clients launch their MCP servers at startup, so the memory tools\n")
 	fmt.Printf("     are not available in the session that just ran init.\n")
 	if kgAuto {

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
 )
 
 // Instruction-file writers: drop a memory-usage block into the agent
@@ -364,11 +366,15 @@ func installGlobalInstructions(quiet bool) []string {
 // exist in the session that ran init, and an agent that goes straight to
 // calling them finds nothing however green doctor is. Shared between the plain
 // and interactive paths so the two cannot drift.
-func printNextSteps() {
+func printNextSteps(kgAuto bool) {
 	fmt.Printf("\nNext steps:\n")
 	fmt.Printf("  1. Restart your MCP client (editor, agent, or terminal session).\n")
 	fmt.Printf("     Clients launch their MCP servers at startup, so the memory tools\n")
 	fmt.Printf("     are not available in the session that just ran init.\n")
+	if kgAuto {
+		fmt.Printf("     Knowledge-graph auto-population is enabled (%s) and starts\n", daemon.KGSentinelFile)
+		fmt.Printf("     with the same restart — first entities appear after ~20 facts.\n")
+	}
 	fmt.Printf("  2. graymatter doctor   — verify the whole setup end to end\n")
 	fmt.Printf("  3. Try it out:\n")
 	fmt.Printf("       graymatter remember \"my-agent\" \"user prefers bullet points\"\n")

--- a/cmd/graymatter/cmd_init_interactive.go
+++ b/cmd/graymatter/cmd_init_interactive.go
@@ -243,25 +243,34 @@ func runInteractiveWizard(dir, projectDir string, quiet bool) error {
 			fmt.Fprintf(os.Stderr, "\n%s\n", w)
 		}
 		fmt.Printf("\ngraymatter is a general-purpose MCP server. Any MCP-compatible client works.\n")
-		printNextSteps(false)
+		pathChanged := maybeAddToPath(quiet)
+		printNextSteps(false, pathChanged)
+	} else {
+		_ = maybeAddToPath(true)
 	}
-
-	maybeAddToPath(quiet)
 	return nil
 }
 
-func maybeAddToPath(quiet bool) {
-	if added, pathErr := addExeDirToUserPath(); pathErr != nil {
+// maybeAddToPath applies the Windows PATH change when refusable-setup allows
+// it, reports the fact without any restart wording (the single authoritative
+// restart instruction lives in printNextSteps), and returns whether the PATH
+// was actually modified.
+func maybeAddToPath(quiet bool) bool {
+	added, pathErr := addExeDirToUserPath()
+	if pathErr != nil {
 		if !quiet {
 			exe, _ := os.Executable()
 			fmt.Fprintf(os.Stderr,
 				"\n  Warning: could not add %s to PATH: %v\n  Add it manually so you can type 'graymatter' from any directory.\n",
 				filepath.Dir(exe), pathErr)
 		}
-	} else if added && !quiet {
-		exe, _ := os.Executable()
-		fmt.Printf("\n  Added %s to your PATH — restart PowerShell to apply\n", filepath.Dir(exe))
+		return false
 	}
+	if added && !quiet {
+		exe, _ := os.Executable()
+		fmt.Printf("  Added %s to your user PATH\n", filepath.Dir(exe))
+	}
+	return added
 }
 
 // askForAgents prints the interactive menu and returns the selected agent IDs.

--- a/cmd/graymatter/cmd_init_interactive.go
+++ b/cmd/graymatter/cmd_init_interactive.go
@@ -243,7 +243,7 @@ func runInteractiveWizard(dir, projectDir string, quiet bool) error {
 			fmt.Fprintf(os.Stderr, "\n%s\n", w)
 		}
 		fmt.Printf("\ngraymatter is a general-purpose MCP server. Any MCP-compatible client works.\n")
-		printNextSteps()
+		printNextSteps(false)
 	}
 
 	maybeAddToPath(quiet)

--- a/cmd/graymatter/cmd_init_kg_test.go
+++ b/cmd/graymatter/cmd_init_kg_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+)
+
+// captureStdout redirects the process stdout while fn runs and returns what
+// was written. printNextSteps writes there directly rather than through
+// cobra's output writers.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+		_ = r.Close()
+	}()
+
+	fn()
+	_ = w.Close()
+	captured, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return string(captured)
+}
+
+func TestInit_KGFlagWritesSentinelAndSaysSo(t *testing.T) {
+	project := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDataDir := dataDir
+	dataDir = filepath.Join(project, ".graymatter")
+	t.Cleanup(func() {
+		dataDir = oldDataDir
+		_ = os.Chdir(oldWd)
+	})
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	var cobraOut bytes.Buffer
+	cmd := initCmd()
+	cmd.SilenceUsage = true
+	cmd.SetOut(&cobraOut)
+	cmd.SetErr(&cobraOut)
+	cmd.SetArgs([]string{"--kg", "--skip-instructions", "--only", "claudecode", "--no-path"})
+
+	var execErr error
+	stdout := captureStdout(t, func() {
+		execErr = cmd.Execute()
+	})
+	if execErr != nil {
+		t.Fatalf("init --kg: %v\n%s%s", execErr, stdout, cobraOut.String())
+	}
+
+	if fl := cmd.Flags().Lookup("kg"); fl == nil {
+		t.Fatal("kg flag not registered")
+	} else if !fl.Changed {
+		t.Fatalf("--kg not applied by SetArgs; value=%v args=%v", fl.Value.String(), cmd.Flags().Args())
+	}
+
+	sentinel := filepath.Join(dataDir, daemon.KGSentinelFile)
+	if _, err := os.Stat(sentinel); err != nil {
+		entries, _ := os.ReadDir(dataDir)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("sentinel missing after init --kg: %v\ndata dir contents: %v\noutput: %s",
+			err, names, cobraOut.String())
+	}
+	out := stdout + cobraOut.String()
+	if !strings.Contains(out, daemon.KGSentinelFile) || !strings.Contains(out, "restart") {
+		t.Errorf("next steps should tie KG activation to the restart:\n%s", out)
+	}
+}

--- a/cmd/graymatter/cmd_status.go
+++ b/cmd/graymatter/cmd_status.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+	"github.com/angelnicolasc/graymatter/internal/tokens"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "One-screen answer to: is my memory actually being used?",
+		Long: `Print what GrayMatter knows, what it has been doing, and what a recall
+costs today — facts, recalls per agent, knowledge-graph state, the token
+ledger, and an injection-cost estimate against your own store.
+
+The token ledger covers 'graymatter run' sessions only; MCP sessions run
+entirely inside your editor and are never measured anywhere. Injection
+figures are estimates (~1.33 tokens/word), because an MCP server cannot see
+your chat history to compare against.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(cmd)
+		},
+	}
+}
+
+func runStatus(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+
+	store, err := openStore()
+	if err != nil {
+		return fmt.Errorf("open memory: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	overview, err := store.StoreOverview()
+	if err != nil {
+		return fmt.Errorf("store overview: %w", err)
+	}
+	kgState, err := store.KGState()
+	if err != nil {
+		return fmt.Errorf("knowledge graph state: %w", err)
+	}
+	tokSummary, tokErr := store.TokenSummary(30)
+	if tokErr != nil {
+		tokSummary.Loaded = false // degrade loudly rather than half-printing
+	}
+
+	mode := "via daemon"
+	if _, direct := store.(*directStore); direct {
+		mode = "in-process"
+	}
+
+	view := statusView{Mode: mode, Overview: overview, KG: kgState, Tokens: tokSummary, Facts: map[string][]memory.Fact{}}
+	for _, a := range overview.Agents {
+		facts, ferr := store.List(a.Agent)
+		if ferr != nil {
+			return fmt.Errorf("list facts for %q: %w", a.Agent, ferr)
+		}
+		view.Facts[a.Agent] = facts
+	}
+
+	if jsonOut {
+		return encodeStatusJSON(out, mode, overview, kgState, tokSummary)
+	}
+	return renderStatus(out, view)
+}
+
+// statusFacts carries the per-agent fact lists the injection estimate needs.
+// Fetched once in runStatus so rendering stays a pure function of its inputs.
+type statusView struct {
+	Mode     string
+	Overview *daemon.StoreOverviewResponse
+	KG       *daemon.KGStateResponse
+	Tokens   harness.TokenUsageSummary
+	Facts    map[string][]memory.Fact // agent -> all facts (live + tombstones)
+}
+
+func renderStatus(out io.Writer, view statusView) error {
+	ov, kg, tok := view.Overview, view.KG, view.Tokens
+	mode := view.Mode
+	fmt.Fprintf(out, "\nGrayMatter status · %s\n\n", mode)
+
+	if ov == nil || ov.TotalAgents == 0 {
+		fmt.Fprintln(out, "STORE      empty. Get started:")
+		fmt.Fprintln(out, "           graymatter init                     # wire your MCP clients")
+		fmt.Fprintln(out, "           graymatter remember \"my-agent\" \"a fact\"")
+		return nil
+	}
+
+	newest, oldest := time.Time{}, time.Time{}
+	totalWeighted := 0.0
+	recallParts := make([]string, 0, len(ov.Agents))
+	for _, a := range ov.Agents {
+		totalWeighted += a.AvgWeight * float64(a.LiveFacts)
+		recallParts = append(recallParts, fmt.Sprintf("%s %d", a.Agent, a.Recalls))
+		if a.NewestAt.After(newest) {
+			newest = a.NewestAt
+		}
+		if !a.OldestAt.IsZero() && (oldest.IsZero() || a.OldestAt.Before(oldest)) {
+			oldest = a.OldestAt
+		}
+	}
+
+	avgWeight := 0.0
+	if ov.TotalLiveFacts > 0 {
+		avgWeight = totalWeighted / float64(ov.TotalLiveFacts)
+	}
+
+	fmt.Fprintf(out, "STORE      %d agents · %d live facts · %d superseded · avg weight %.2f\n",
+		ov.TotalAgents, ov.TotalLiveFacts, ov.TotalTombstones, avgWeight)
+	fmt.Fprintf(out, "           oldest fact %s · newest %s · pending vector ops: %d\n",
+		relTime(oldest), relTime(newest), ov.PendingVectorOps)
+
+	totalRecalls := 0
+	for _, a := range ov.Agents {
+		totalRecalls += a.Recalls
+	}
+	fmt.Fprintf(out, "RECALLS    %s · total %d\n", strings.Join(recallParts, " · "), totalRecalls)
+	if totalRecalls == 0 {
+		fmt.Fprintln(out, "           nothing recalled yet — restart your MCP client so the tools exist, and check the memory block in CLAUDE.md/AGENTS.md")
+	}
+
+	state, hint := "OFF", ""
+	if kg != nil && kg.AutoPopulate {
+		state = "ON"
+	} else {
+		hint = " — enable: graymatter init --kg"
+	}
+	nodes, edges := 0, 0
+	if kg != nil {
+		nodes, edges = kg.Nodes, kg.Edges
+	}
+	fmt.Fprintf(out, "KG         auto-population %s%s\n", state, hint)
+	fmt.Fprintf(out, "           graph: %d nodes / %d edges\n", nodes, edges)
+
+	fmt.Fprintln(out, "TOKENS     last 30d — recorded by 'graymatter run' sessions only:")
+	if tok.Loaded && tok.Requests > 0 {
+		inOut := tok.Input + tok.Output
+		fmt.Fprintf(out, "           in ~%dk · out ~%dk · cache-read %.0f%% · requests %d\n",
+			tok.Input/1000, tok.Output/1000, pct(tok.CacheRead, inOut), tok.Requests)
+	} else {
+		fmt.Fprintln(out, "           no harness runs recorded (MCP sessions are not measured)")
+	}
+
+	minTop8, maxTop8, maxDump := 1<<30, 0, 0
+	for _, a := range ov.Agents {
+		facts := view.Facts[a.Agent]
+		tk := estimateTop8Tokens(facts)
+		if tk < minTop8 {
+			minTop8 = tk
+		}
+		if tk > maxTop8 {
+			maxTop8 = tk
+		}
+		live := make([]string, 0, len(facts))
+		for _, f := range facts {
+			if f.SupersededBy == "" {
+				live = append(live, f.Text)
+			}
+		}
+		if dump := tokens.Approx(strings.Join(live, "\n")); dump > maxDump {
+			maxDump = dump
+		}
+	}
+	if ov.TotalLiveFacts > 0 {
+		fmt.Fprintf(out, "INJECTION  est. top-8 recall cost now: ~%d–%d tk/agent vs full dump ~%d\n",
+			minTop8, maxTop8, maxDump)
+		fmt.Fprintf(out, "           estimates ~%.2f tok/word; the server cannot see your chat history.\n",
+			tokens.PerWord)
+	}
+	return nil
+}
+
+func relTime(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+func pct(part, whole uint64) float64 {
+	if whole == 0 {
+		return 0
+	}
+	return float64(part) / float64(whole) * 100
+}
+
+func encodeStatusJSON(out io.Writer, mode string, ov *daemon.StoreOverviewResponse, kg *daemon.KGStateResponse, tok harness.TokenUsageSummary) error {
+	payload := struct {
+		Mode     string                        `json:"mode"`
+		Store    *daemon.StoreOverviewResponse `json:"store"`
+		KG       *daemon.KGStateResponse       `json:"kg"`
+		Tokens30 *harness.TokenUsageSummary    `json:"tokens_30d"`
+	}{Mode: mode, Store: ov, KG: kg, Tokens30: &tok}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}

--- a/cmd/graymatter/cmd_status_test.go
+++ b/cmd/graymatter/cmd_status_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+)
+
+func runStatusCmd(t *testing.T, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := statusCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status %v: %v\n%s", args, err, out.String())
+	}
+	return out.String()
+}
+
+// statusTestStore seeds a store with two agents, one tombstoned fact, and one
+// recalled fact (AccessCount bumped directly, as Recall's writeback would).
+func statusTestStore(t *testing.T) func() {
+	t.Helper()
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	oldDir := dataDir
+	dataDir = t.TempDir()
+	cfg := graymatter.DefaultConfig()
+	cfg.DataDir = dataDir
+	mem, err := graymatter.NewWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ctx := context.Background()
+	if err := mem.Remember(ctx, "planner", strings.Repeat("planning observation ", 12)); err != nil {
+		t.Fatalf("remember planner: %v", err)
+	}
+	if err := mem.Remember(ctx, "writer", strings.Repeat("draft note ", 10)); err != nil {
+		t.Fatalf("remember writer: %v", err)
+	}
+	adv := mem.Advanced()
+	facts, _ := adv.List("planner")
+	f := facts[0]
+	f.SupersededBy = "gone"
+	if err := adv.UpdateFact("planner", f); err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+	live, _ := adv.List("writer")
+	live[0].AccessCount = 3
+	if err := adv.UpdateFact("writer", live[0]); err != nil {
+		t.Fatalf("bump access: %v", err)
+	}
+	_ = mem.Close() // release the write lock; the command reopens on its own
+	return func() { dataDir = oldDir }
+}
+
+func TestStatus_HumanSections(t *testing.T) {
+	cleanup := statusTestStore(t)
+	defer cleanup()
+
+	out := runStatusCmd(t)
+	for _, want := range []string{
+		"GrayMatter status",
+		"2 agents",
+		"1 superseded",
+		"planner 0",
+		"writer 3",
+		"total 3",
+		"auto-population OFF",
+		"init --kg",
+		"recorded by 'graymatter run' sessions only",
+		"INJECTION",
+		"cannot see your chat history",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatus_JSONShape(t *testing.T) {
+	cleanup := statusTestStore(t)
+	defer cleanup()
+
+	jsonOut = true
+	t.Cleanup(func() { jsonOut = false })
+	out := runStatusCmd(t)
+
+	var payload struct {
+		Mode  string `json:"mode"`
+		Store *struct {
+			TotalAgents     int `json:"total_agents"`
+			TotalLiveFacts  int `json:"total_live_facts"`
+			TotalTombstones int `json:"total_tombstones"`
+			Agents          []struct {
+				Agent   string `json:"agent"`
+				Recalls int    `json:"recalls"`
+			} `json:"agents"`
+		} `json:"store"`
+		KG *struct {
+			AutoPopulate bool `json:"auto_populate"`
+		} `json:"kg"`
+		Tokens30 *harness.TokenUsageSummary `json:"tokens_30d"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if payload.Store == nil || payload.Store.TotalAgents != 2 || payload.Store.TotalLiveFacts != 1 {
+		t.Errorf("unexpected store overview: %+v", payload.Store)
+	}
+	if payload.Store == nil || payload.Store.TotalTombstones != 1 {
+		t.Errorf("tombstone total wrong: %+v", payload.Store)
+	}
+	if payload.KG == nil || payload.KG.AutoPopulate {
+		t.Errorf("KG state wrong: %+v", payload.KG)
+	}
+}
+
+func TestStatus_EmptyStoreGuides(t *testing.T) {
+	t.Setenv("GRAYMATTER_NO_DAEMON", "1")
+	oldDir := dataDir
+	dataDir = t.TempDir()
+	t.Cleanup(func() { dataDir = oldDir })
+
+	out := runStatusCmd(t)
+	if !strings.Contains(out, "empty") || !strings.Contains(out, "graymatter init") {
+		t.Errorf("empty store should guide toward init:\n%s", out)
+	}
+}
+
+// TestDirectStoreOverview_MatchesGroundTruth pins the in-process aggregation
+// against values computed by hand from List(): live counts exclude
+// tombstones, recalls sum access counters, weights average over live facts.
+func TestDirectStoreOverview_MatchesGroundTruth(t *testing.T) {
+	cleanup := statusTestStore(t)
+	defer cleanup()
+
+	ds, err := openDirectStore()
+	if err != nil {
+		t.Fatalf("open direct: %v", err)
+	}
+	defer func() { _ = ds.Close() }()
+
+	ov, err := ds.StoreOverview()
+	if err != nil {
+		t.Fatalf("StoreOverview: %v", err)
+	}
+
+	wantLive := map[string]int{"planner": 0, "writer": 1} // planner's single fact is retired
+	wantRecalls := map[string]int{"planner": 0, "writer": 3}
+	gotLive := map[string]int{}
+	gotRecalls := map[string]int{}
+	for _, a := range ov.Agents {
+		gotLive[a.Agent] = a.LiveFacts
+		gotRecalls[a.Agent] = a.Recalls
+
+		// Ground truth straight from List.
+		facts, _ := ds.List(a.Agent)
+		liveN, recN := 0, 0
+		for _, f := range facts {
+			if f.SupersededBy == "" {
+				liveN++
+				recN += f.AccessCount
+			}
+		}
+		if liveN != a.LiveFacts || recN != a.Recalls {
+			t.Errorf("agent %q: overview says live=%d recalls=%d, List ground truth is %d/%d",
+				a.Agent, a.LiveFacts, a.Recalls, liveN, recN)
+		}
+	}
+	for agent, want := range wantLive {
+		if gotLive[agent] != want {
+			t.Errorf("agent %q live = %d, want %d", agent, gotLive[agent], want)
+		}
+	}
+	for agent, want := range wantRecalls {
+		if gotRecalls[agent] != want {
+			t.Errorf("agent %q recalls = %d, want %d", agent, gotRecalls[agent], want)
+		}
+	}
+	if ov.TotalTombstones != 1 {
+		t.Errorf("tombstones = %d, want 1", ov.TotalTombstones)
+	}
+}
+
+// The daemon-side aggregation is pinned against a real daemon in
+// internal/daemon TestHostService_CoreSurface; the two implementations share
+// semantics (live excludes tombstones; recalls sums AccessCount).

--- a/cmd/graymatter/internal/benchsyn/numbers_test.go
+++ b/cmd/graymatter/internal/benchsyn/numbers_test.go
@@ -1,0 +1,73 @@
+package benchsyn
+
+import (
+	"math"
+	"testing"
+)
+
+// The published token table (README.md and docs/benchmarks.md, gated on the
+// root-module side by benchmarks/token_count/main_test.go) is the single
+// source of truth for what this suite is allowed to report. This test pins
+// the CLI's live run to the same figures at the same tolerance the gate uses,
+// so `graymatter bench` and `go run ./benchmarks/token_count` cannot disagree
+// without one of the two failing.
+//
+// If a corpus or engine change legitimately moves the numbers, update them in
+// the benchmark, regenerate the README tables, and mirror the new constants
+// here — in that order, with the reasoning in the commit message.
+const (
+	tolerance = 0.02
+	absFloor  = 5
+)
+
+var publishedRows = []struct {
+	sessions     int
+	fullTokens   int
+	recallTokens int
+	reduction    int // integer percent; compared exactly, as the gate does
+}{
+	{1, 80, 80, 0},
+	{10, 630, 550, 12},
+	{30, 1880, 550, 71},
+	{100, 6960, 670, 90},
+}
+
+func TestPublishedTokenTable_MatchesCLIRun(t *testing.T) {
+	results, err := RunTokenCount()
+	if err != nil {
+		t.Fatalf("RunTokenCount: %v", err)
+	}
+	bySessions := make(map[int]TokenResult, len(results))
+	for _, r := range results {
+		bySessions[r.Sessions] = r
+	}
+
+	for _, want := range publishedRows {
+		got, ok := bySessions[want.sessions]
+		if !ok {
+			t.Fatalf("suite no longer measures %d sessions", want.sessions)
+		}
+		assertClose(t, want.sessions, "full injection", want.fullTokens, got.FullTokens)
+		assertClose(t, want.sessions, "recall", want.recallTokens, got.RecallTokens)
+		if reduction := int(math.Round(got.Reduction)); reduction != want.reduction {
+			t.Errorf("%d sessions: CLI reports %d%% reduction, published table says %d%%",
+				want.sessions, reduction, want.reduction)
+		}
+	}
+}
+
+func assertClose(t *testing.T, sessions int, label string, published, measured int) {
+	t.Helper()
+	if measured == 0 {
+		if published != 0 {
+			t.Errorf("%d sessions: published %d %s tokens, measured 0", sessions, published, label)
+		}
+		return
+	}
+	absErr := math.Abs(float64(published - measured))
+	relErr := absErr / float64(measured)
+	if relErr > tolerance && absErr > absFloor {
+		t.Errorf("%d sessions: published ~%d %s tokens, CLI measures %d (%.0f%% off, max %.0f%%)",
+			sessions, published, label, measured, relErr*100, tolerance*100)
+	}
+}

--- a/cmd/graymatter/internal/benchsyn/token_count.go
+++ b/cmd/graymatter/internal/benchsyn/token_count.go
@@ -1,29 +1,25 @@
-// Package bench holds the measurement cores the repository publishes numbers
-// from, so that two entry points cannot drift apart while claiming to measure
-// the same thing: `go run ./benchmarks/token_count` (the documented
-// reproduction path) and `graymatter bench` (the installed-binary path added
-// so users do not need a Go toolchain to audit the claims).
+// Package benchsyn runs the published token-efficiency suite inside the CLI
+// binary, so `graymatter bench` can reproduce the numbers without a Go
+// toolchain or a repository clone.
 //
-// The corpus, the insertion protocol (fixed-seed shuffle + one-day-per-session
-// backdating) and the arithmetic moved here verbatim from the original
-// benchmark main; benchmarks/token_count/main_test.go still gates every
-// published table against a live run of this code.
+// Why this lives in the cmd module while benchmarks/token_count (root module)
+// carries its own copy of the same corpus: CI builds the CLI with GOWORK=off,
+// resolving the library from the last tagged release — a cmd-module import of
+// a brand-new root package cannot compile until the next tag lands. Duplicating
+// is the price of that invariant; corpus_sync_test.go makes the duplication
+// safe by comparing this package's corpus byte-for-byte against the benchmark's,
+// on every run.
 //
-// It runs entirely in-process with no LLM or network requirements — the
-// keyword embedder is used so results are deterministic and reproducible in
-// any environment.
+// The measurement itself (fixed-seed shuffle, one-day-per-session backdating,
+// per-row fresh store) mirrors benchmarks/token_count exactly; the README gate
+// test there keeps both honest against the published tables.
 //
 // Model: each "session" stores ONE observation — a paragraph extracted from a
 // realistic agent interaction, ~50-70 words. "30 sessions" means 30 stored
 // observations. "Full injection" = ALL stored observations concatenated.
 // "GrayMatter Recall" = top-8 most relevant observations for the given query.
 // Token counts are approximated at 1.33 tokens/word (matches tiktoken within ±10%).
-//
-// What this does NOT measure is in docs/benchmarks.md and is worth reading
-// before quoting a number from it: relevance is never checked, so a system
-// returning 8 random facts would score the same reduction, and full-history
-// injection is the weakest baseline available.
-package bench
+package benchsyn
 
 import (
 	"context"

--- a/cmd/graymatter/internal/daemon/client.go
+++ b/cmd/graymatter/internal/daemon/client.go
@@ -274,6 +274,25 @@ func (c *Client) Shutdown() error {
 	return c.CallService(HostServiceName, "Shutdown", &ShutdownRequest{}, &ShutdownResponse{}, 5*time.Second)
 }
 
+// StoreOverview fetches the per-agent fact aggregates for status screens in
+// one round-trip.
+func (c *Client) StoreOverview() (*StoreOverviewResponse, error) {
+	var resp StoreOverviewResponse
+	if err := c.hostCall("StoreOverview", &StoreOverviewRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// KGState reports auto-population status and current graph size.
+func (c *Client) KGState() (*KGStateResponse, error) {
+	var resp KGStateResponse
+	if err := c.hostCall("KGState", &KGStateRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // Remember stores a fact with full Remember semantics (the daemon backend
 // routes Put through Memory.Remember, async consolidation included).
 func (c *Client) Remember(ctx context.Context, agentID, text string) error {

--- a/cmd/graymatter/internal/daemon/daemon.go
+++ b/cmd/graymatter/internal/daemon/daemon.go
@@ -34,7 +34,8 @@ type RunOptions struct {
 
 	// KG enables knowledge-graph auto-population: consolidation extracts
 	// entities and co-mention edges from stored facts. Also enabled by
-	// GRAYMATTER_KG=1 in the daemon's environment.
+	// GRAYMATTER_KG=1 in the daemon's environment, or by the kg.auto
+	// sentinel written by `graymatter init --kg`.
 	KG bool
 
 	// Logf receives lifecycle log lines. Defaults to a stderr printer.
@@ -81,10 +82,12 @@ func Run(opts RunOptions) error {
 		adapter = kg.NewGraphAdapter(g)
 	}
 
-	// Knowledge-graph auto-population is opt-in (env or --kg). When enabled,
-	// the wired adapter doubles as the store's graph and the regex extractor
-	// feeds consolidation, so nodes AND edges appear without agent effort.
-	kgAuto := opts.KG || os.Getenv("GRAYMATTER_KG") == "1"
+	// Knowledge-graph auto-population is opt-in: --kg here, GRAYMATTER_KG=1
+	// in this process's environment, or the kg.auto sentinel left by
+	// `graymatter init --kg`. One decision point, so a daemon spawned by an
+	// MCP client (with the client's environment) and one run by hand always
+	// agree.
+	kgAuto := kgAutoEnabled(absDir, opts.KG)
 	if kgAuto {
 		extractor := kg.NewExtractorAdapter(kg.NewExtractor(kg.ExtractorConfig{}))
 		adv.SetKG(adapter, extractor)

--- a/cmd/graymatter/internal/daemon/daemon.go
+++ b/cmd/graymatter/internal/daemon/daemon.go
@@ -84,7 +84,8 @@ func Run(opts RunOptions) error {
 	// Knowledge-graph auto-population is opt-in (env or --kg). When enabled,
 	// the wired adapter doubles as the store's graph and the regex extractor
 	// feeds consolidation, so nodes AND edges appear without agent effort.
-	if opts.KG || os.Getenv("GRAYMATTER_KG") == "1" {
+	kgAuto := opts.KG || os.Getenv("GRAYMATTER_KG") == "1"
+	if kgAuto {
 		extractor := kg.NewExtractorAdapter(kg.NewExtractor(kg.ExtractorConfig{}))
 		adv.SetKG(adapter, extractor)
 		logf("daemon: knowledge graph auto-population enabled")
@@ -102,6 +103,7 @@ func Run(opts RunOptions) error {
 		db:      db,
 		graph:   graph,
 		adapter: adapter,
+		kgAuto:  kgAuto,
 		stop:    srv.Stop,
 	})
 

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -104,6 +104,7 @@ type ShutdownResponse struct{}
 type AgentSummary struct {
 	Agent     string    `json:"agent"`
 	LiveFacts int       `json:"live_facts"`
+	Recalls   int       `json:"recalls"` // Σ access counts over live facts: was this memory ever read?
 	AvgWeight float64   `json:"avg_weight"`
 	OldestAt  time.Time `json:"oldest_at,omitempty"`
 	NewestAt  time.Time `json:"newest_at,omitempty"`
@@ -308,6 +309,7 @@ func (h *Host) StoreOverview(req *StoreOverviewRequest, resp *StoreOverviewRespo
 				continue
 			}
 			sum.LiveFacts++
+			sum.Recalls += f.AccessCount
 			weightSum += f.Weight
 			if sum.OldestAt.IsZero() || f.CreatedAt.Before(sum.OldestAt) {
 				sum.OldestAt = f.CreatedAt

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -40,6 +40,7 @@ type Host struct {
 	db      *bolt.DB
 	graph   *kg.Graph
 	adapter *kg.GraphAdapter
+	kgAuto  bool // whether consolidation feeds the graph (opts.KG / env / sentinel)
 	stop    func() // initiates graceful daemon shutdown
 }
 
@@ -98,6 +99,31 @@ type TokenSummaryResponse struct{ S harness.TokenUsageSummary }
 
 type ShutdownRequest struct{}
 type ShutdownResponse struct{}
+
+// AgentSummary is one agent's row in a StoreOverview.
+type AgentSummary struct {
+	Agent     string    `json:"agent"`
+	LiveFacts int       `json:"live_facts"`
+	AvgWeight float64   `json:"avg_weight"`
+	OldestAt  time.Time `json:"oldest_at,omitempty"`
+	NewestAt  time.Time `json:"newest_at,omitempty"`
+}
+
+type StoreOverviewRequest struct{}
+type StoreOverviewResponse struct {
+	TotalAgents      int            `json:"total_agents"`
+	TotalLiveFacts   int            `json:"total_live_facts"`
+	TotalTombstones  int            `json:"total_tombstones"`
+	PendingVectorOps int            `json:"pending_vector_ops"`
+	Agents           []AgentSummary `json:"agents"`
+}
+
+type KGStateRequest struct{}
+type KGStateResponse struct {
+	AutoPopulate bool `json:"auto_populate"`
+	Nodes        int  `json:"nodes"`
+	Edges        int  `json:"edges"`
+}
 
 // --- handlers ---------------------------------------------------------------
 
@@ -252,6 +278,74 @@ func (h *Host) TokenSummary(req *TokenSummaryRequest, resp *TokenSummaryResponse
 		return err
 	}
 	resp.S = s
+	return nil
+}
+
+// StoreOverview aggregates per-agent fact statistics for `graymatter status`
+// in one call, so a status screen costs one round-trip instead of N.
+// Tombstones are excluded from live counts and weights: they never reach a
+// prompt and reporting them as memory would overstate the store.
+func (h *Host) StoreOverview(req *StoreOverviewRequest, resp *StoreOverviewResponse) error {
+	adv := h.mem.Advanced()
+	if adv == nil {
+		return errors.New("store not initialised")
+	}
+	agents, err := adv.ListAgents()
+	if err != nil {
+		return err
+	}
+	resp.Agents = make([]AgentSummary, 0, len(agents))
+	for _, a := range agents {
+		facts, err := adv.List(a)
+		if err != nil {
+			return err
+		}
+		sum := AgentSummary{Agent: a}
+		var weightSum float64
+		for _, f := range facts {
+			if f.SupersededBy != "" {
+				resp.TotalTombstones++
+				continue
+			}
+			sum.LiveFacts++
+			weightSum += f.Weight
+			if sum.OldestAt.IsZero() || f.CreatedAt.Before(sum.OldestAt) {
+				sum.OldestAt = f.CreatedAt
+			}
+			if f.CreatedAt.After(sum.NewestAt) {
+				sum.NewestAt = f.CreatedAt
+			}
+		}
+		if sum.LiveFacts > 0 {
+			sum.AvgWeight = weightSum / float64(sum.LiveFacts)
+		}
+		resp.TotalAgents++
+		resp.TotalLiveFacts += sum.LiveFacts
+		resp.Agents = append(resp.Agents, sum)
+	}
+	resp.PendingVectorOps = adv.PendingVectorCount()
+	return nil
+}
+
+// KGState reports whether auto-population is on for this daemon and how much
+// graph exists right now. The graph itself is opened unconditionally by the
+// daemon; only extraction is gated, which is why Nodes/Edges can be non-zero
+// while AutoPopulate is false (explicit agent links populate it too).
+func (h *Host) KGState(req *KGStateRequest, resp *KGStateResponse) error {
+	resp.AutoPopulate = h.kgAuto
+	if h.graph == nil {
+		return nil
+	}
+	nodes, err := h.graph.AllNodes()
+	if err != nil {
+		return err
+	}
+	resp.Nodes = len(nodes)
+	edges, err := h.graph.AllEdges()
+	if err != nil {
+		return err
+	}
+	resp.Edges = len(edges)
 	return nil
 }
 

--- a/cmd/graymatter/internal/daemon/host_test.go
+++ b/cmd/graymatter/internal/daemon/host_test.go
@@ -136,6 +136,46 @@ func TestHostService_CoreSurface(t *testing.T) {
 		t.Fatalf("AuditWrite: %v", err)
 	}
 
+	// --- aggregated views ---
+	// The Delete above emptied agent-a; seed one live fact so the overview
+	// has something real to aggregate.
+	if err := c.Remember(ctx, "agent-a", "overview fact"); err != nil {
+		t.Fatalf("Remember for overview: %v", err)
+	}
+	overview, err := c.StoreOverview()
+	if err != nil {
+		t.Fatalf("StoreOverview: %v", err)
+	}
+	if overview.TotalAgents < 1 || overview.TotalLiveFacts < 1 {
+		t.Fatalf("StoreOverview = %+v, want at least the seeded agent fact", overview)
+	}
+	found := false
+	for _, a := range overview.Agents {
+		if a.Agent == "agent-a" && a.LiveFacts >= 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("StoreOverview missing agent-a row: %+v", overview.Agents)
+	}
+
+	kgState, err := c.KGState()
+	if err != nil {
+		t.Fatalf("KGState: %v", err)
+	}
+	// The graph is opened unconditionally; auto-population stays off unless
+	// the daemon was started with --kg/GRAYMATTER_KG, which connectFresh does
+	// not set. The two explicit KGUpserts above must show up regardless.
+	if kgState.AutoPopulate {
+		t.Error("KGState.AutoPopulate true without --kg")
+	}
+	if kgState.Nodes < 2 {
+		t.Errorf("KGState.Nodes = %d, want >= 2 from explicit upserts", kgState.Nodes)
+	}
+	if kgState.Edges < 1 {
+		t.Errorf("KGState.Edges = %d, want >= 1 from explicit link", kgState.Edges)
+	}
+
 	// --- token ledger ---
 	if err := c.TokenRecord("agent-a", "claude-sonnet-4-6", 100, 50, 10, 5); err != nil {
 		t.Fatalf("TokenRecord: %v", err)

--- a/cmd/graymatter/internal/daemon/kg_sentinel.go
+++ b/cmd/graymatter/internal/daemon/kg_sentinel.go
@@ -1,0 +1,39 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// KGSentinelFile is the marker `graymatter init --kg` drops into the data
+// directory to request knowledge-graph auto-population for every future
+// daemon — spawned automatically by MCP clients (which launch their servers
+// with their own environment, so an exported GRAYMATTER_KG in a shell does
+// not reach them) or run by hand. It is runtime state written by one of our
+// commands, not user-authored configuration: same statute as the HTTP token
+// file, and no change to the no-config-files promise.
+const KGSentinelFile = "kg.auto"
+
+// KGSentinelPath returns the sentinel's location inside dataDir.
+func KGSentinelPath(dataDir string) string {
+	return filepath.Join(dataDir, KGSentinelFile)
+}
+
+// kgAutoEnabled decides whether this daemon wires extraction into
+// consolidation. OR-semantics, checked in one place so manual runs and
+// client-spawned daemons can never disagree:
+//
+//   - --kg flag (explicit, strongest)
+//   - GRAYMATTER_KG=1 in the daemon's own environment
+//   - the kg.auto sentinel left by `graymatter init --kg`
+//
+// The engine contract is untouched either way: SetKG stays an explicit call
+// the daemon makes here, and pkg/memory's wiring-contract test keeps pinning
+// that shipped defaults never auto-wire on their own.
+func kgAutoEnabled(dataDir string, flagKG bool) bool {
+	if flagKG || os.Getenv("GRAYMATTER_KG") == "1" {
+		return true
+	}
+	_, err := os.Stat(KGSentinelPath(dataDir))
+	return err == nil
+}

--- a/cmd/graymatter/internal/daemon/kg_sentinel_test.go
+++ b/cmd/graymatter/internal/daemon/kg_sentinel_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestKGAutoEnabled_DecisionTable pins the OR-semantics in one place: flag,
+// environment, or the init --kg sentinel each enable auto-population; none
+// means off. This is the function that keeps a hand-run daemon and one
+// spawned by an MCP client in agreement.
+func TestKGAutoEnabled_DecisionTable(t *testing.T) {
+	dir := t.TempDir()
+
+	if kgAutoEnabled(dir, false) {
+		t.Error("nothing opted in: auto-population must be off")
+	}
+
+	t.Setenv("GRAYMATTER_KG", "1")
+	if !kgAutoEnabled(dir, false) {
+		t.Error("GRAYMATTER_KG=1 must enable regardless of sentinel")
+	}
+	os.Unsetenv("GRAYMATTER_KG")
+
+	if err := os.WriteFile(KGSentinelPath(dir), nil, 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	if !kgAutoEnabled(dir, false) {
+		t.Error("sentinel must enable auto-population")
+	}
+	if got, want := KGSentinelPath(dir), filepath.Join(dir, "kg.auto"); got != want {
+		t.Errorf("KGSentinelPath = %q, want %q", got, want)
+	}
+}
+
+// TestDaemonSpawnHonorsInitKGSentinel is the acceptance test for the whole
+// mechanism: `graymatter init --kg` writes the marker; later, an MCP client
+// spawns a daemon WITHOUT any flag or environment — and KGState must report
+// auto-population on. Uses a real built binary and the real spawn path.
+func TestDaemonSpawnHonorsInitKGSentinel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary; skipped in -short")
+	}
+	withBuiltDaemon(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(KGSentinelPath(dir), nil, 0o644); err != nil {
+		t.Fatalf("simulate init --kg: %v", err)
+	}
+
+	c, err := Connect(dir) // spawns exactly like an MCP client would: no args, no env
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = c.Shutdown(); _ = c.Close() }()
+
+	state, err := c.KGState()
+	if err != nil {
+		t.Fatalf("KGState: %v", err)
+	}
+	if !state.AutoPopulate {
+		t.Fatal("spawned daemon ignored the kg.auto sentinel")
+	}
+}
+
+// TestDaemonSpawnWithoutSentinelStaysOff guards the other half of the
+// contract: without any opt-in, a spawned daemon must not wire extraction.
+func TestDaemonSpawnWithoutSentinelStaysOff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a binary; skipped in -short")
+	}
+	withBuiltDaemon(t)
+	t.Setenv("GRAYMATTER_KG", "")
+
+	dir := t.TempDir()
+	c, err := Connect(dir)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = c.Shutdown(); _ = c.Close() }()
+
+	state, err := c.KGState()
+	if err != nil {
+		t.Fatalf("KGState: %v", err)
+	}
+	if state.AutoPopulate {
+		t.Fatal("daemon wired extraction with no flag, env, or sentinel")
+	}
+}

--- a/cmd/graymatter/internal/kg/graph.go
+++ b/cmd/graymatter/internal/kg/graph.go
@@ -7,6 +7,7 @@ package kg
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -65,6 +66,30 @@ func Open(db *bolt.DB) (*Graph, error) {
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("kg: init buckets: %w", err)
+	}
+	return &Graph{db: db}, nil
+}
+
+// ErrNoGraph reports that the database carries no graph buckets at all —
+// distinct from "a graph with zero nodes", and from an IO failure.
+var ErrNoGraph = errors.New("kg: no graph in this database")
+
+// OpenRead returns a Graph over an existing one without initialising
+// anything, so it works on read-only bbolt handles where Open's bucket
+// creation would fail. Callers distinguish three states: nil error means a
+// readable graph; ErrNoGraph means the store never had one; any other error
+// is a real failure.
+func OpenRead(db *bolt.DB) (*Graph, error) {
+	err := db.View(func(tx *bolt.Tx) error {
+		for _, name := range [][]byte{bucketNodes, bucketEdges} {
+			if tx.Bucket(name) == nil {
+				return ErrNoGraph
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return &Graph{db: db}, nil
 }

--- a/cmd/graymatter/internal/mcp/annotations_test.go
+++ b/cmd/graymatter/internal/mcp/annotations_test.go
@@ -46,7 +46,14 @@ func TestToolAnnotations(t *testing.T) {
 		"checkpoint_resume": {readOnly: true, destructive: false, idempotent: true},
 		"memory_add":        {readOnly: false, destructive: false, idempotent: false},
 		"checkpoint_save":   {readOnly: false, destructive: false, idempotent: false},
-		"memory_reflect":    {readOnly: false, destructive: true, idempotent: false},
+		// memory_reflect retires facts via forget/update, but destructive stays
+		// false: the hint is per-tool and three of four actions are additive.
+		// Advertising destructive makes strict hosts gate every self-edit behind
+		// approval, which is how unattended agents stop calling it. The real
+		// guardrail is in the handler — forget requires an exact-text match and
+		// leaves a tombstone — and the audit trail records every action. See the
+		// comment on writeTool before flipping this back.
+		"memory_reflect": {readOnly: false, destructive: false, idempotent: false},
 	}
 
 	if len(resp.Result.Tools) != len(want) {

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -125,8 +125,15 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 	if !ok || action == "" {
 		return toolError("action is required")
 	}
+	// The schema names this parameter `agent`, but the other four tools use
+	// `agent_id` and models generalize across a toolset — an alias costs one
+	// line and saves the silent "agent is required" failure. Canonical stays
+	// `agent`; docs/AGENTS.md documents both as accepted.
 	agentID, ok := getString(args, "agent")
 	if !ok || agentID == "" {
+		agentID, _ = getString(args, "agent_id")
+	}
+	if agentID == "" {
 		return toolError("agent is required")
 	}
 	// text and target are validated per-action below: forget works with

--- a/cmd/graymatter/internal/mcp/instructions.go
+++ b/cmd/graymatter/internal/mcp/instructions.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"github.com/angelnicolasc/graymatter/internal/tokens"
+)
+
+// serverInstructions is returned to the client in the initialize handshake
+// (mcp server.WithInstructions). Clients surface it to the model at the start
+// of every session, which is what makes the memory tools get called even in
+// hosts that never read CLAUDE.md or AGENTS.md — the failure mode behind
+// issues #3 and #14.
+//
+// It is a compile-time constant on purpose. The initialize response is not a
+// data channel: this string must never contain store contents, agent IDs, or
+// anything derived from runtime state (see docs/threat-model.md on treating
+// memory as untrusted input — recalled facts reach the model through tool
+// results inside the session, never through this field).
+//
+// Budget: the text rides every initialize of every client, so its recurring
+// token cost has to stay trivial against the savings it produces. The
+// TestServerInstructionsBudget test pins it at 240 tokens via the same
+// estimator every benchmark uses; raise the budget in that test, with
+// reasoning, rather than growing the copy silently.
+const serverInstructions = `GrayMatter gives you persistent memory across sessions.
+Session protocol:
+1. Before your first substantive reply, call memory_search for the task at hand, then call it again with agent_id "__shared__" for user-level preferences.
+2. When you learn something durable — a user preference, a decision, a correction, a completed milestone — store it with memory_reflect action=add. Err toward storing.
+3. Found a contradiction? memory_reflect action=update supersedes the stale fact; never leave both versions live.
+4. Long session? checkpoint_save before context gets heavy, checkpoint_resume next time.
+Full guide: docs/AGENTS.md in the GrayMatter repository.`
+
+// Option customises the MCP server.
+type Option func(*serverOptions)
+
+type serverOptions struct {
+	instructions string
+}
+
+// WithInstructions overrides the instructions announced in the initialize
+// handshake. An empty string disables instruction injection entirely — for
+// tests and for callers that manage agent briefing themselves. Production
+// callers use the default and never construct this option.
+func WithInstructions(text string) Option {
+	return func(o *serverOptions) { o.instructions = text }
+}
+
+func defaultServerOptions() serverOptions {
+	return serverOptions{instructions: serverInstructions}
+}
+
+// instructionTokenBudget is the ceiling enforced by
+// TestServerInstructionsBudget. See the comment on serverInstructions.
+const instructionTokenBudget = 240
+
+// instructionTokens measures the recurring cost of the handshake copy with
+// the shared word-based estimator, so the number here and the numbers in
+// benchmarks and docs mean the same thing.
+func instructionTokens() int { return tokens.Approx(serverInstructions) }

--- a/cmd/graymatter/internal/mcp/instructions_test.go
+++ b/cmd/graymatter/internal/mcp/instructions_test.go
@@ -1,0 +1,123 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	graymatter "github.com/angelnicolasc/graymatter"
+)
+
+// TestInitializeCarriesInstructions goes through HandleMessage so it asserts
+// on exactly the payload a client receives in the initialize response. The
+// instructions are what make hosts brief the model without ever reading
+// CLAUDE.md, so a dependency bump that drops them must fail loudly here.
+func TestInitializeCarriesInstructions(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	req := json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+		"protocolVersion":"2024-11-05",
+		"capabilities":{},
+		"clientInfo":{"name":"test","version":"0"}
+	}}`)
+	raw, err := json.Marshal(s.mcpSrv.HandleMessage(context.Background(), req))
+	if err != nil {
+		t.Fatalf("marshal initialize response: %v", err)
+	}
+
+	var resp struct {
+		Result struct {
+			Instructions string `json:"instructions"`
+			ServerInfo   struct {
+				Name string `json:"name"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode initialize response: %v\n%s", err, raw)
+	}
+
+	if resp.Result.ServerInfo.Name != serverName {
+		t.Errorf("serverInfo.name = %q, want %q", resp.Result.ServerInfo.Name, serverName)
+	}
+	if resp.Result.Instructions == "" {
+		t.Fatal("initialize response carries no instructions; clients will not brief the model")
+	}
+	if resp.Result.Instructions != serverInstructions {
+		t.Errorf("initialize instructions diverge from the compiled constant — got %d bytes, want %d",
+			len(resp.Result.Instructions), len(serverInstructions))
+	}
+	if !strings.Contains(resp.Result.Instructions, "memory_search") ||
+		!strings.Contains(resp.Result.Instructions, "memory_reflect") {
+		t.Error("instructions must name the tools they tell the model to call")
+	}
+}
+
+// TestServerInstructionsBudget pins the recurring token cost of the handshake
+// copy: it rides every initialize of every session of every client. See the
+// comment on serverInstructions before raising this number.
+func TestServerInstructionsBudget(t *testing.T) {
+	n := instructionTokens()
+	if n == 0 {
+		t.Fatal("token estimator returned 0 for non-empty instructions; estimator or constant broke")
+	}
+	if n > instructionTokenBudget {
+		t.Fatalf("server instructions cost %d tokens, budget is %d — shorten the copy or raise the budget with reasoning",
+			n, instructionTokenBudget)
+	}
+}
+
+// TestWithInstructionsOptionOverride covers both documented behaviours of the
+// escape hatch: a custom string wins, an empty string disables injection.
+func TestWithInstructionsOptionOverride(t *testing.T) {
+	s := newOptionsServer(t, WithInstructions("custom briefing"))
+	if got := initializeInstructions(t, s); got != "custom briefing" {
+		t.Errorf("custom instructions not announced: %q", got)
+	}
+
+	s2 := newOptionsServer(t, WithInstructions(""))
+	if got := initializeInstructions(t, s2); got != "" {
+		t.Errorf("empty option should disable instructions, got %q", got)
+	}
+
+	s3 := newOptionsServer(t) // no options: the built-in protocol ships by default
+	if got := initializeInstructions(t, s3); got != serverInstructions {
+		t.Errorf("default construction must announce the built-in instructions, got %q", got)
+	}
+}
+
+// newOptionsServer mirrors newTestServer but forwards options to New.
+func newOptionsServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+	cfg := graymatter.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	mem, err := graymatter.NewWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = mem.Close() })
+	return New(NewDirectBackend(mem, nil), "test", opts...)
+}
+
+// initializeInstructions extracts the instructions field from an initialize
+// response built through HandleMessage.
+func initializeInstructions(t *testing.T, s *Server) string {
+	t.Helper()
+	req := json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+		"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}
+	}}`)
+	raw, err := json.Marshal(s.mcpSrv.HandleMessage(context.Background(), req))
+	if err != nil {
+		t.Fatalf("marshal initialize response: %v", err)
+	}
+	var resp struct {
+		Result struct {
+			Instructions string `json:"instructions"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode initialize response: %v", err)
+	}
+	return resp.Result.Instructions
+}

--- a/cmd/graymatter/internal/mcp/reflect_alias_test.go
+++ b/cmd/graymatter/internal/mcp/reflect_alias_test.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestMemoryReflect_AgentIDAlias pins the parameter alias: the schema names
+// the field `agent`, but every other GrayMatter tool uses `agent_id` and
+// models generalize across a toolset. Before the alias an agent that sent
+// agent_id here got a bare "agent is required" — a silent stop in practice,
+// because nothing on screen explains that one tool spells it differently.
+func TestMemoryReflect_AgentIDAlias(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "canonical agent", args: map[string]any{"action": "add", "agent": "a1", "text": "alias canonical"}},
+		{name: "agent_id alias", args: map[string]any{"action": "add", "agent_id": "a2", "text": "alias accepted"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := s.handleMemoryReflect(ctx, reflectReq(tc.args))
+			if err != nil || res.IsError {
+				t.Fatalf("reflect add failed: %v / %s", err, resultText(t, res))
+			}
+		})
+	}
+
+	for _, tc := range []struct{ agentID, want string }{
+		{"a1", "alias canonical"},
+		{"a2", "alias accepted"},
+	} {
+		res, err := s.handleMemorySearch(ctx, reflectReq(map[string]any{
+			"agent_id": tc.agentID, "query": tc.want,
+		}))
+		if err != nil || res.IsError {
+			t.Fatalf("search %q failed: %v / %s", tc.agentID, err, resultText(t, res))
+		}
+		if !strings.Contains(resultText(t, res), tc.want) {
+			t.Errorf("fact stored under %q not found: %s", tc.agentID, resultText(t, res))
+		}
+	}
+}
+
+// TestMemoryReflect_AliasReachesEveryAction proves the alias is read from the
+// single extraction point (not re-derived per action): forget routed by
+// agent_id must retire exactly the matching fact.
+func TestMemoryReflect_AliasReachesForget(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	res, err := s.handleMemoryAdd(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "text": "stale fact",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("seed add: %v / %s", err, resultText(t, res))
+	}
+
+	res, err = s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+		"action": "forget", "agent_id": "a1", "text": "stale fact",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("forget via alias failed: %v / %s", err, resultText(t, res))
+	}
+
+	res, err = s.handleMemorySearch(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "query": "stale",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("search after forget failed: %v / %s", err, resultText(t, res))
+	}
+	if strings.Contains(resultText(t, res), "stale fact") {
+		t.Error("forgotten fact is still live")
+	}
+}
+
+// TestMemoryReflect_MissingAgentStillErrors keeps the failure mode explicit:
+// neither spelling present means a clear error, never a silent default.
+func TestMemoryReflect_MissingAgentStillErrors(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	res, err := s.handleMemoryReflect(context.Background(), reflectReq(map[string]any{
+		"action": "add", "text": "orphan",
+	}))
+	if err != nil {
+		t.Fatalf("handleMemoryReflect: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected tool error when neither agent nor agent_id is set")
+	}
+	if got := resultText(t, res); !strings.Contains(got, "agent") {
+		t.Errorf("error %q does not mention the missing parameter", got)
+	}
+}

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -249,13 +249,22 @@ func readOnlyTool() mcp.ToolOption {
 	})
 }
 
-// writeTool annotates a tool that writes. destructive is true only where a call
-// can remove or supersede an existing fact; appending a fact or a checkpoint is
-// additive. Nothing here is idempotent: every call stores a new record.
-func writeTool(destructive bool) mcp.ToolOption {
+// writeTool annotates a tool that writes. Nothing here is idempotent: every
+// call stores a new record.
+//
+// memory_reflect passes destructive=false even though its forget/update
+// actions can retire a fact. The annotation is per-tool and three of its four
+// actions are purely additive, so advertising destructive would push hosts
+// into gating every self-edit behind an approval prompt — including plain
+// adds — which is how unattended agents quietly stop calling the tool. The
+// guardrail lives in the handler instead, where it is testable: forget
+// requires an exact-text match and both retiring actions leave a tombstone
+// pointing at the replacement (never a hard delete), with every action
+// recorded in the audit trail.
+func writeTool() mcp.ToolOption {
 	return mcp.WithToolAnnotation(mcp.ToolAnnotation{
 		ReadOnlyHint:    mcp.ToBoolPtr(false),
-		DestructiveHint: mcp.ToBoolPtr(destructive),
+		DestructiveHint: mcp.ToBoolPtr(false),
 		IdempotentHint:  mcp.ToBoolPtr(false),
 		OpenWorldHint:   mcp.ToBoolPtr(false),
 	})
@@ -286,7 +295,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_add",
 			mcp.WithDescription("Store a new fact in GrayMatter memory."),
-			writeTool(false),
+			writeTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent to associate this memory with."),
@@ -303,7 +312,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("checkpoint_save",
 			mcp.WithDescription("Save a checkpoint of current agent state."),
-			writeTool(false),
+			writeTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent to checkpoint."),
@@ -332,7 +341,7 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_reflect",
 			mcp.WithDescription("Add, update (supersede), forget, or link your memories. Use when you notice a contradiction, finish a task, or learn a durable preference that should persist."),
-			writeTool(true),
+			writeTool(),
 			mcp.WithString("action",
 				mcp.Required(),
 				mcp.Description("One of: add, update, forget, link."),
@@ -340,7 +349,7 @@ func (s *Server) registerTools() {
 			),
 			mcp.WithString("agent",
 				mcp.Required(),
-				mcp.Description("The agent whose memory to modify."),
+				mcp.Description("The agent whose memory to modify. agent_id is accepted as an alias."),
 			),
 			mcp.WithString("text",
 				mcp.Description("The fact text for add/update, the fact to forget (alternative to target), or the source node ID for link."),

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -67,7 +67,8 @@ type Server struct {
 }
 
 // New creates a configured MCP server on top of backend, announcing version
-// in the initialize handshake.
+// and the session instructions (see instructions.go) in the initialize
+// handshake.
 //
 // The version is a parameter rather than a constant here on purpose. It used
 // to be `const serverVersion`, bumped by hand at release time, and it was
@@ -75,10 +76,15 @@ type Server struct {
 // v0.11.x or v0.12.x binary was told it was talking to 0.10.0. Taking it from
 // the caller means there is only one version string in the binary, so there
 // is nothing left to keep in sync.
-func New(backend Backend, version string) *Server {
+func New(backend Backend, version string, opts ...Option) *Server {
+	cfg := defaultServerOptions()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	s := &Server{backend: backend, version: version}
 	s.mcpSrv = server.NewMCPServer(serverName, version,
 		server.WithToolCapabilities(true),
+		server.WithInstructions(cfg.instructions),
 	)
 	s.registerTools()
 	return s

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -259,7 +259,7 @@ func (s *Server) registerTools() {
 	// memory_search
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_search",
-			mcp.WithDescription("Search GrayMatter memory for relevant facts."),
+			mcp.WithDescription("Search GrayMatter memory for relevant facts. Call once for your agent_id, then again with agent_id \"__shared__\" for user-level preferences."),
 			readOnlyTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
@@ -325,7 +325,7 @@ func (s *Server) registerTools() {
 	// memory_reflect
 	s.mcpSrv.AddTool(
 		mcp.NewTool("memory_reflect",
-			mcp.WithDescription("Update your own knowledge graph mid-session. Use when you discover a contradiction, complete a task, or learn a user preference that should persist."),
+			mcp.WithDescription("Add, update (supersede), forget, or link your memories. Use when you notice a contradiction, finish a task, or learn a durable preference that should persist."),
 			writeTool(true),
 			mcp.WithString("action",
 				mcp.Required(),

--- a/cmd/graymatter/main.go
+++ b/cmd/graymatter/main.go
@@ -78,6 +78,7 @@ func main() {
 		rememberCmd(),
 		recallCmd(),
 		checkpointCmd(),
+		benchCmd(),
 		mcpCmd(),
 		exportCmd(),
 		tuiCmd(),

--- a/cmd/graymatter/main.go
+++ b/cmd/graymatter/main.go
@@ -79,6 +79,7 @@ func main() {
 		recallCmd(),
 		checkpointCmd(),
 		benchCmd(),
+		statusCmd(),
 		mcpCmd(),
 		exportCmd(),
 		tuiCmd(),

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -54,6 +54,9 @@ type cliStore interface {
 	TokenSummary(days int) (harness.TokenUsageSummary, error)
 	TokenRecord(agent, model string, input, output, cacheRead, cacheWrite uint64) error
 	SessionSave(hs harness.HarnessSession) error
+	// Aggregated views for status screens. Both are read-only snapshots.
+	StoreOverview() (*daemon.StoreOverviewResponse, error)
+	KGState() (*daemon.KGStateResponse, error)
 
 	// IsReadOnly reports a degraded direct open (--no-daemon while another
 	// process holds the write lock). Always false through the daemon.
@@ -74,6 +77,16 @@ type daemonStore struct {
 }
 
 func (d daemonStore) IsReadOnly() bool { return false }
+
+// StoreOverview and KGState pass through to the host service; the daemon owns
+// the aggregation because it owns the bbolt handle.
+func (d daemonStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
+	return d.Client.StoreOverview()
+}
+
+func (d daemonStore) KGState() (*daemon.KGStateResponse, error) {
+	return d.Client.KGState()
+}
 
 // ExportGraphObsidian runs host-side: the graph lives on the daemon's bbolt
 // handle, so only the destination path crosses the wire.
@@ -293,6 +306,68 @@ func (d *directStore) TokenRecord(agent, model string, input, output, cacheRead,
 
 func (d *directStore) SessionSave(hs harness.HarnessSession) error {
 	return harness.SaveSessionDB(d.store.DB(), hs)
+}
+
+// StoreOverview computes the same aggregates the daemon's Host.StoreOverview
+// returns, in-process. The two must agree; TestStatus_ParityAcrossModes pins
+// that on a seeded store.
+func (d *directStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
+	agents, err := d.store.ListAgents()
+	if err != nil {
+		return nil, err
+	}
+	resp := &daemon.StoreOverviewResponse{Agents: make([]daemon.AgentSummary, 0, len(agents))}
+	for _, a := range agents {
+		facts, err := d.store.List(a)
+		if err != nil {
+			return nil, err
+		}
+		sum := daemon.AgentSummary{Agent: a}
+		var weightSum float64
+		for _, f := range facts {
+			if f.SupersededBy != "" {
+				resp.TotalTombstones++
+				continue
+			}
+			sum.LiveFacts++
+			weightSum += f.Weight
+			if sum.OldestAt.IsZero() || f.CreatedAt.Before(sum.OldestAt) {
+				sum.OldestAt = f.CreatedAt
+			}
+			if f.CreatedAt.After(sum.NewestAt) {
+				sum.NewestAt = f.CreatedAt
+			}
+		}
+		if sum.LiveFacts > 0 {
+			sum.AvgWeight = weightSum / float64(sum.LiveFacts)
+		}
+		resp.TotalAgents++
+		resp.TotalLiveFacts += sum.LiveFacts
+		resp.Agents = append(resp.Agents, sum)
+	}
+	resp.PendingVectorOps = d.store.PendingVectorCount()
+	return resp, nil
+}
+
+// KGState mirrors the daemon's view: the graph is openable on any bbolt
+// handle; auto-population in direct mode is env-gated.
+func (d *directStore) KGState() (*daemon.KGStateResponse, error) {
+	resp := &daemon.KGStateResponse{AutoPopulate: os.Getenv("GRAYMATTER_KG") == "1"}
+	g, err := kg.Open(d.store.DB())
+	if err != nil {
+		return resp, nil // no graph yet: empty, not an error
+	}
+	nodes, err := g.AllNodes()
+	if err != nil {
+		return nil, err
+	}
+	resp.Nodes = len(nodes)
+	edges, err := g.AllEdges()
+	if err != nil {
+		return nil, err
+	}
+	resp.Edges = len(edges)
+	return resp, nil
 }
 
 func (d *directStore) IsReadOnly() bool { return d.store.IsReadOnly() }

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -309,8 +309,9 @@ func (d *directStore) SessionSave(hs harness.HarnessSession) error {
 }
 
 // StoreOverview computes the same aggregates the daemon's Host.StoreOverview
-// returns, in-process. The two must agree; TestStatus_ParityAcrossModes pins
-// that on a seeded store.
+// returns, in-process. The two implementations must stay semantically
+// identical; each is tested against ground truth on a seeded store — the
+// daemon side in TestHostService_CoreSurface, this side by cmd_status_test.go.
 func (d *directStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
 	agents, err := d.store.ListAgents()
 	if err != nil {
@@ -330,6 +331,7 @@ func (d *directStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
 				continue
 			}
 			sum.LiveFacts++
+			sum.Recalls += f.AccessCount
 			weightSum += f.Weight
 			if sum.OldestAt.IsZero() || f.CreatedAt.Before(sum.OldestAt) {
 				sum.OldestAt = f.CreatedAt

--- a/cmd/graymatter/store_reconnect.go
+++ b/cmd/graymatter/store_reconnect.go
@@ -298,6 +298,26 @@ func (r *reconnectingStore) TokenRecord(agent, model string, input, output, cach
 	})
 }
 
+func (r *reconnectingStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
+	var out *daemon.StoreOverviewResponse
+	err := r.do(func(s cliStore) error {
+		var e error
+		out, e = s.StoreOverview()
+		return e
+	})
+	return out, err
+}
+
+func (r *reconnectingStore) KGState() (*daemon.KGStateResponse, error) {
+	var out *daemon.KGStateResponse
+	err := r.do(func(s cliStore) error {
+		var e error
+		out, e = s.KGState()
+		return e
+	})
+	return out, err
+}
+
 // IsReadOnly is always false through the daemon: every client is a full peer.
 // The wrapper only ever holds daemon handles, so this cannot be anything else.
 func (r *reconnectingStore) IsReadOnly() bool { return r.snapshot().IsReadOnly() }

--- a/cmd/graymatter/store_reconnect_delegation_test.go
+++ b/cmd/graymatter/store_reconnect_delegation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/audit"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
@@ -134,6 +135,15 @@ func (r *recordingStore) IsReadOnly() bool { r.rec("IsReadOnly"); return true }
 func (r *recordingStore) Ready() error     { r.rec("Ready"); return nil }
 func (r *recordingStore) Close() error     { r.rec("Close"); return nil }
 
+func (r *recordingStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
+	r.rec("StoreOverview")
+	return &daemon.StoreOverviewResponse{TotalAgents: 1}, nil
+}
+func (r *recordingStore) KGState() (*daemon.KGStateResponse, error) {
+	r.rec("KGState")
+	return &daemon.KGStateResponse{AutoPopulate: true, Nodes: 2, Edges: 1}, nil
+}
+
 // TestReconnectingStore_DelegatesEveryMethod checks that each wrapper forwards
 // its arguments, in order, to the wrapped store.
 //
@@ -181,6 +191,12 @@ func TestReconnectingStore_DelegatesEveryMethod(t *testing.T) {
 		{"TokenRecord", func(r *reconnectingStore) {
 			_ = r.TokenRecord("agent-1", "model-2", 3, 4, 5, 6)
 		}, []any{"agent-1", "model-2", uint64(3), uint64(4), uint64(5), uint64(6)}},
+		{"StoreOverview", func(r *reconnectingStore) {
+			_, _ = r.StoreOverview()
+		}, nil},
+		{"KGState", func(r *reconnectingStore) {
+			_, _ = r.KGState()
+		}, nil},
 		{"IsReadOnly", func(r *reconnectingStore) { _ = r.IsReadOnly() }, nil},
 		{"Ready", func(r *reconnectingStore) { _ = r.Ready() }, nil},
 	}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -26,7 +26,7 @@ Five tools are registered by `graymatter mcp serve` (see [`cmd/graymatter/intern
 | `checkpoint_resume` | `agent_id` (string) | — | JSON: `{id, created_at, state}` (latest checkpoint) or empty if none |
 | `memory_reflect` | `action` (`add`\|`update`\|`forget`\|`link`), **`agent`** (string), `text` (string) | `target` (string — old fact text for `update`/`forget`; target node ID for `link`) | Confirmation string |
 
-> ⚠️ **`memory_reflect` uses `agent`, not `agent_id`.** The other four tools use `agent_id`. If your client builds tool calls programmatically, branch on tool name.
+> ℹ️ **`memory_reflect` names the agent parameter `agent`.** The other four tools use `agent_id`. `memory_reflect` also accepts `agent_id` as an alias, so either spelling works; when building calls programmatically, prefer the canonical name per tool.
 
 ### Return-shape examples
 

--- a/docs/decisions/009-kg-sentinel-activation.md
+++ b/docs/decisions/009-kg-sentinel-activation.md
@@ -1,0 +1,57 @@
+# 009 — KG activation persists as data-dir state (`init --kg` sentinel)
+
+Date: 2026-08-24
+
+## Context
+
+ADR-008 shipped knowledge-graph auto-population gated behind `daemon run --kg`
+or `GRAYMATTER_KG=1`. Field reachability was poor by construction:
+
+- MCP clients spawn `graymatter daemon run` themselves with their own
+  environment. An exported `GRAYMATTER_KG=1` reaches the daemon only if the
+  client itself was launched from that same shell; editors started from a GUI
+  never see it.
+- Nothing in `init` or `doctor` mentioned the feature, so the opt-in required
+  reading the README's CLI table.
+
+The engine-level contract (pkg/memory's wiring-contract tests) was never in
+question: `SetKG` stays an explicit call. The question was only where a
+user's opt-in lives so every future daemon honours it.
+
+## Decision
+
+`graymatter init --kg` writes an empty marker file, `<data-dir>/kg.auto`.
+The daemon resolves activation in exactly one place (`daemon.kgAutoEnabled`)
+with OR-semantics: `--kg` flag, or `GRAYMATTER_KG=1` in its own environment,
+or the sentinel. Manual runs and client-spawned daemons therefore cannot
+disagree.
+
+This is runtime state written by one of our commands, not user-authored
+configuration — same statute as `graymatter.http-token`. The "no config
+files" product claim is untouched: nothing here asks users to hand-edit
+anything, and removal is deleting one file (documented in `init --help`).
+
+Alternatives considered:
+
+- **Flip the default on.** Rejected for now; ADR-008 requires a field cycle,
+  and doctor/status did not yet exist to surface field behaviour.
+- **Have `init` write the env var into client configs.** Client config files
+  are shared surface owned by the tools themselves; injecting environment is
+  per-client glue that grows with every supported host.
+- **Persist a settings file.** Rejected on principle above; also invites
+  becoming a general config surface, which this project deliberately is not.
+
+## Consequences
+
+- Activation survives daemon restarts, machine reboots, and client spawns.
+- `doctor` and `status` can read the same marker and report state honestly.
+- Turning it off means deleting the file; `--kg=false` semantics were
+  deliberately not invented.
+
+## Reversal condition
+
+If a second data-dir behaviour needs persisted opt-in state, promote the
+pattern to a single typed key–value store in the data dir (one reader/writer
+API) rather than accumulating marker files. If field reports after one
+release cycle show auto-population safe and wanted, fold the sentinel into
+the default-on decision ADR-008 already conditions on.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,6 +17,8 @@ consequences, reversal condition.
 | [005](005-embedding-degradation-chain.md) | Embeddings degrade Ollama → OpenAI → Anthropic → keyword | Accepted |
 | [006](006-configurable-signal-weights.md) | Retrieval signal weights are configurable | Accepted |
 | [007](007-supersede-tombstones.md) | Contradictions are resolved by tombstone, never by delete | Accepted |
+| [008](008-knowledge-graph-wiring.md) | Knowledge-graph auto-population ships gated (`--kg` / env) | Accepted |
+| [009](009-kg-sentinel-activation.md) | KG activation persists as data-dir state via `init --kg` | Accepted |
 
 ## Writing a new one
 

--- a/internal/bench/token_count.go
+++ b/internal/bench/token_count.go
@@ -1,0 +1,326 @@
+// Package bench holds the measurement cores the repository publishes numbers
+// from, so that two entry points cannot drift apart while claiming to measure
+// the same thing: `go run ./benchmarks/token_count` (the documented
+// reproduction path) and `graymatter bench` (the installed-binary path added
+// so users do not need a Go toolchain to audit the claims).
+//
+// The corpus, the insertion protocol (fixed-seed shuffle + one-day-per-session
+// backdating) and the arithmetic moved here verbatim from the original
+// benchmark main; benchmarks/token_count/main_test.go still gates every
+// published table against a live run of this code.
+//
+// It runs entirely in-process with no LLM or network requirements — the
+// keyword embedder is used so results are deterministic and reproducible in
+// any environment.
+//
+// Model: each "session" stores ONE observation — a paragraph extracted from a
+// realistic agent interaction, ~50-70 words. "30 sessions" means 30 stored
+// observations. "Full injection" = ALL stored observations concatenated.
+// "GrayMatter Recall" = top-8 most relevant observations for the given query.
+// Token counts are approximated at 1.33 tokens/word (matches tiktoken within ±10%).
+//
+// What this does NOT measure is in docs/benchmarks.md and is worth reading
+// before quoting a number from it: relevance is never checked, so a system
+// returning 8 random facts would score the same reduction, and full-history
+// injection is the weakest baseline available.
+package bench
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/internal/tokens"
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// ── Corpus ───────────────────────────────────────────────────────────────────
+//
+// 100 realistic paragraph-length agent memory observations (~50-70 words each).
+// Each represents a key insight extracted from a sales agent interaction — the
+// kind of observation GrayMatter would store after processing a session.
+
+var corpus = [100]string{
+	"Maria Lopez from Acme Corp called on April 3rd to discuss the enterprise plan. She has pre-approved budget of $80k ARR and strong executive backing. Her primary blocker is the Salesforce integration timeline. She agreed to loop in their CTO James Park for a technical demo next Thursday. Priority: send the security whitepaper and Salesforce integration guide before the demo.",
+	"Carlos Mendez at Initech is budget-blocked until Q3 2026 due to a company-wide spending freeze following a 10% reduction in headcount last quarter. His champion status is at risk as his manager who approved the initiative has left the company. Re-engage in July with a reference case from a similarly-sized company in their vertical. Mark as at-risk in CRM.",
+	"Ana Torres at FinVault confirmed signing authority up to $50k without additional approvals; anything above that requires CFO sign-off. She mentioned their team runs 40 developers split between Python and Go. Their previous vendor migration failed due to data integrity issues. She asked for references from FinTech companies that have successfully migrated. Her preferred communication is async via email.",
+	"TechCorp pilot kicked off on May 1st for a three-month evaluation. Primary success metric agreed with their SRE team is a 30% reduction in context-switching time measured by their internal tooling. Demo feedback was positive: the search and recall features exceeded expectations. The bulk import feature was flagged as a must-have before GA. Attendees included CTO, VP Eng, and two senior SREs.",
+	"Globex Corp shortlisted us against Acme as the final two vendors. Price is the tiebreaker — they have a hard budget ceiling of $90k ARR. Their Head of Engineering David Kim is our champion; however he recently left the company, creating deal risk. Karen Wu, VP Engineering, has taken over ownership and we need a re-introduction call to re-establish the relationship with her.",
+	"The Initech proof-of-concept requires SAML 2.0 single sign-on integration with their existing Okta deployment. Their IT department has a mandatory 3-4 week security review for any new SaaS tool before procurement approval. Starting the review process now is critical to avoid timeline slippage. Their pilot sandbox environment needs to be provisioned separately from production to satisfy their data governance policy.",
+	"Ana Torres introduced us to their Head of Product Sarah Kim and their CFO Miguel Santos via email. A three-way discovery call is scheduled for next Tuesday. Miguel has direct budget authority for the enterprise tier. Ana mentioned the company raised $40M Series B and is growing headcount 20% year-over-year. They are evaluating tools to support their expanding engineering org of 40 developers.",
+	"TechCorp's latency spike was traced to a misconfigured rate limiter on our API gateway during their peak load testing. Engineering deployed a hotfix within four hours. Post-incident report sent to their CTO. TechCorp's SRE team confirmed the fix resolved the issue. They requested a dedicated status page and an escalation contact for Severity-1 incidents going forward. NPS after incident resolution: 8/10.",
+	"Maria signed the Master Service Agreement on April 14th. The contract is for 12 months at $95k ARR with a 30-day termination clause after month six. Invoice split requested across two fiscal quarters: $47,500 in Q2 and $47,500 in Q3. Procurement requires a W-9 form and bank wire details for vendor onboarding. Purchase order expected within five business days of MSA execution.",
+	"Carlos's company, now rebranded as NovaTech after an acquisition, has re-engaged with a freshly approved budget of $62k ARR. Carlos confirmed he is now the sole decision-maker after his former manager departed. He needs executive sponsorship from our side for the final board presentation scheduled for the June quarterly review. The deal is time-sensitive: board approval closes on June 28th.",
+	"Globex Corp closed at $87k ARR on an 18-month contract after the competitor failed their security audit. Karen Wu signed on behalf of the company. Penalty clause for downtime exceeding the 99.9% SLA was added at $500 per hour of excess downtime. Onboarding kickoff scheduled for May 15th. They requested a dedicated Customer Success Manager with experience in their industry vertical.",
+	"Initech closed as the largest deal of Q2 at $210k ARR. Contract is for 24 months with an option to renew at fixed pricing. Dedicated Slack channel created for pilot support. Their IT department approved the security review in 3 weeks, faster than expected. CSM assignment: Rachel Torres, who previously managed two similar enterprise accounts. QBR scheduled for July 5th.",
+	"Ana's company went live on April 7th after completing the API integration independently. First support ticket raised about the CSV bulk import timeout for files over 50MB. Engineering confirmed the limit is configurable and patched the default to 200MB. Ana's team is onboarding 40 developers in waves of 10 per week. She referred two new leads: Omega Solutions and Peak Data, both in the FinTech space.",
+	"TechCorp co-authored a case study published on our website. The study highlights a 34% reduction in context-switching time — exceeding their 30% pilot goal — measured over 60 days. Maria Chen, their VP of Engineering, is featured as the primary quote. TechCorp agreed to participate in a webinar next quarter. They are discussing upgrading from the Professional to Enterprise plan worth an additional $44k ARR.",
+	"NovaTech expansion deal signed for 50 additional seats at $800 per seat per year, adding $40k to their ARR. Total account ARR now $102k. They flagged a requirement for multi-region data residency for their EU operations. EU data residency is on the roadmap for Q4 — flag for engineering and set expectation with Carlos. EU expansion anticipated to add another 25 seats.",
+	"Omega Solutions discovery call completed on April 12th. The company is Series A, $12M raised, with 45 employees and 15 engineers. Their use case is automating client portfolio reporting. Budget is $25k ARR for year one. Key stakeholder: CTO David Park. They need a sandbox trial before committing. Trial provisioned with 30-day access. Follow-up scheduled for April 26th to review trial results.",
+	"Peak Data is a 30-person startup with a need for real-time agent memory across their data pipeline monitoring tools. They are evaluating three vendors simultaneously. Their CTO is technically strong and has reviewed our API documentation in detail. She asked pointed questions about consistency guarantees under concurrent write load. I sent a detailed write-up on bbolt's serialization model and our concurrency guarantees.",
+	"Globex Corp's first QBR completed. Weekly active users: 78% of licensed seats. Three power users identified: Karen Wu and two engineering leads. Identified an upsell opportunity: they are managing a 25-person EU team manually using spreadsheets. EU seat expansion deal estimated at $20k ARR. Karen asked for a roadmap update on EU data residency — confirmed Q4 timeline on the record.",
+	"Initech QBR on July 5th revealed 85% weekly active usage across 80 licensed seats. Three primary use cases emerged: sprint planning context, incident retrospectives, and onboarding new engineers. Their Head of Data Science requested a custom model fine-tuning feature for domain-specific terminology. Flagged to product as a potential enterprise add-on. Renewal in 17 months — begin expansion conversation in month 12.",
+	"Ana was promoted to VP of Engineering. She now has direct control of the infrastructure budget, which increased her signing authority to $200k. She reached out proactively to discuss expanding the deployment from 40 to 80 seats and adding the knowledge graph feature as an enterprise add-on. Total expansion opportunity: $60k additional ARR. Scheduled a proposal call for next Wednesday.",
+	"TechCorp upgraded from the Professional plan ($45k ARR) to the Enterprise plan ($89k ARR), driven by their need for SSO, audit logs, and the dedicated CSM support tier. The upgrade was processed on the anniversary of their initial contract. Sarah Chen, their CSM, facilitated the upgrade conversation. TechCorp now represents $89k ARR and is flagged as a reference customer for ENT prospects.",
+	"Maria's team achieved 93% user adoption (28 of 30 staff trained) within the first 30 days. She requested a product roadmap presentation for her executive leadership team to demonstrate ROI before the annual budget review. Presentation scheduled for May 20th with attendance from CEO, CFO, and CTO. Prepare slides highlighting: usage metrics, time saved per user, and upcoming features on the roadmap.",
+	"Omega Solutions trial feedback: strong on recall precision for structured financial data, needed improvement on unstructured PDF parsing. Engineering flagged the PDF limitation as a known gap, scheduled for Q3 release. Omega Solutions requested a timeline commitment in writing. Sent a formal product commitment letter signed by our VP Product. Trial extended by 14 days. Conversion expected by end of April.",
+	"Carlos secured executive sponsorship from our CEO who agreed to join the final board presentation at NovaTech. The board presentation is on June 27th at 9 AM Pacific. Materials needed: executive summary, customer references (TechCorp and Initech), and pricing summary. Board has four members including two technical board advisors. Deal probability at 85% — flag as commit in CRM for Q2 forecast.",
+	"Peak Data closed at $18k ARR for a 12-month contract. CTO appreciated the detailed concurrency write-up and cited it as a differentiator. They want a monthly architecture review call with our engineering team for the first quarter. Engineering agreed to a monthly 30-minute call as part of the onboarding package. First call scheduled for May 5th. Account flagged for expansion conversation at month 6.",
+	"Omega Solutions closed at $28k ARR after the PDF parsing fix shipped in Q3. Their CTO David Park signed without requiring legal review — fastest close of the quarter at 22 days. They immediately asked about the multi-agent coordination feature and the REST API. Onboarding call scheduled for the following Monday. Referred us to two contacts at Series B FinTech companies in their network.",
+	"Globex Corp EU expansion signed for 25 additional seats at $800/seat = $20k ARR. Total Globex ARR now $107k. Karen Wu's EU team goes live on August 1st. Data residency confirmed: EU region on AWS eu-west-1, compliant with GDPR Article 28 processor requirements. They requested the Data Processing Agreement addendum — legal to send within 48 hours.",
+	"Initech's Head of Data Science formally requested a custom model fine-tuning feature as part of their enterprise renewal conversation. Product team evaluated the request: domain vocabulary injection is feasible in Q1 next year. Offered a co-development agreement where Initech participates in the beta program and provides labeled training data. Their legal team is reviewing the co-development terms.",
+	"NovaTech's EU expansion for 25 additional seats at $800/seat = $20k ARR was signed by their new EU Managing Director Hans Müller. EU data residency confirmed. Total NovaTech ARR now $122k. Carlos mentioned they are planning to hire 15 more engineers in Berlin in H2, which could represent another 15-seat expansion. Flag for renewal + expansion conversation in Q4.",
+	"Ana's expansion to 80 seats and knowledge graph add-on closed at $120k ARR total. She signed a 2-year contract to lock in pricing ahead of a planned price increase. Ana is now our largest single account. She accepted an invitation to join our Customer Advisory Board. First CAB meeting is scheduled for September 12th in San Francisco. She will present their use case to other enterprise customers.",
+	"TechCorp case study reached 4,200 views in the first month and generated 18 inbound demo requests from companies in their industry. Three of those requests converted to qualified opportunities. TechCorp agreed to a video testimonial for our upcoming product launch event. Maria Chen will present a 10-minute session at our annual user conference in October.",
+	"Initech renewal and expansion signed for $280k ARR on a 36-month contract — the largest contract in company history. Their domain-specific vocabulary beta program starts in Q1. They upgraded to the Premium Support tier with a 2-hour SLA for Severity-1 issues. Rachel Torres remains their CSM. Initech will present at the annual user conference alongside TechCorp.",
+	"Peak Data's month-6 expansion conversation yielded a 20-seat addition at $800/seat = $16k ARR. Their usage has grown to 28 of 30 original seats at 90% weekly activity. The CTO mentioned they plan to open a London office in Q1 next year — flag for EU data residency conversation. Total Peak Data ARR now $34k. High probability of further expansion at year-end.",
+	"Maria Lopez was promoted to Chief Digital Officer. She sent a company-wide memo crediting GrayMatter as a key productivity tool for their engineering org. Her new role gives her budget authority over all technology purchases company-wide. She has asked for a strategic partnership conversation to explore an OEM licensing arrangement for internal deployment at scale. Opportunity flagged to leadership.",
+	"Globex Corp's Karen Wu referred us to three contacts: VP Engineering at TechnoStar, CTO at CloudPeak, and Head of Data at StreamCore. All three are warm introductions with pending budget for agent tooling in H2. Discovery calls scheduled for all three in the same week. This represents a pipeline addition of approximately $180k ARR if all three convert at average deal size.",
+	"NovaTech signed a 3-year renewal at $150k ARR, a 23% increase over the previous contract, locking in pricing and adding the Enterprise Support tier. Carlos is now VP of Engineering following a promotion. He has agreed to co-author a blog post about their use case for our developer blog. Publication target: end of Q3. Blog post draft to be shared by August 15th.",
+	"Ana Torres joined the Customer Advisory Board and presented at the September 12th CAB meeting. Her session on multi-agent coordination generated the most discussion. She agreed to participate in a joint product roadmap session with our CPO to co-design the agent orchestration features for the next major release. Two other CAB members requested direct introductions to Ana to learn from her deployment.",
+	"Omega Solutions reached $45k ARR after two expansion rounds driven by their growing data team. Their CTO David Park was named to Forbes 30 Under 30 and publicly credited GrayMatter in his profile. The press mention drove 340 inbound signups in 48 hours. They are now a Platinum reference customer and have agreed to participate in all major marketing initiatives for the next 12 months.",
+	"TechCorp's annual renewal processed at $92k ARR, a $3k uplift for overage usage. Their NPS at 12 months is 9.2 out of 10, the highest in our customer base. Maria Chen presented at our user conference to 400 attendees and received a standing ovation. Three enterprise logos requested her contact information for peer reference calls. TechCorp is our strongest reference in the infrastructure vertical.",
+	"Carlos's NovaTech account was acquired by EnterpriseGroup in an all-cash deal. The acquisition triggered a change-of-control clause in their contract requiring written consent for assignment. Legal confirmed consent was granted and the contract transferred without renegotiation. Carlos retained his VP Engineering role post-acquisition. EnterpriseGroup's procurement team reached out to expand the deployment to their 300-person engineering org.",
+	"EnterpriseGroup expansion scoping call completed. They have 300 engineers across 6 product teams in 3 time zones. Their use case spans engineering knowledge management, incident retrospectives, and new hire onboarding. Total seat opportunity: 250 seats at $800/seat = $200k ARR. Deal cycle estimated at 6 months given their procurement complexity. Assigned a dedicated solutions engineer for the technical evaluation.",
+	"Initech's co-development beta for domain vocabulary injection launched to 5 beta customers. Initech's data science team contributed 2,400 labeled examples in the first two weeks. Early results show 23% improvement in recall precision for domain-specific terminology. Product team presented early results at an internal all-hands. Initech's investment in the beta program makes their renewal probability near-certain.",
+	"Peak Data opened their London office in Q1 and immediately needed EU data residency. Their CTO coordinated directly with our engineering team to migrate their EU data within 48 hours. The fast migration earned significant goodwill. They expanded to 60 seats in the London office at $800/seat = $48k ARR. Total Peak Data ARR now $82k. Full renewal and consolidation expected at year-end.",
+	"StreamCore discovery call completed. Their Head of Data, James Wu, manages 45 data engineers who build and maintain real-time data pipelines. Their primary need is contextual memory for their internal ML agents that monitor pipeline health. Budget approved at $60k ARR. They want a 90-day pilot before committing. Pilot provisioned on April 18th. Technical POC contact: their senior ML engineer Priya Singh.",
+	"CloudPeak CTO Jessica Park signed a $75k ARR contract after a 45-day evaluation. Key differentiator cited: the quality of hybrid retrieval versus their previous vector-only solution. They have 80 engineers and immediately provisioned all seats. Jessica requested an on-site executive business review in their Seattle office for month 3. CSM assigned: David Lee with a Seattle-based presence.",
+	"TechnoStar VP Engineering Marcus Chen closed at $55k ARR after a competitive evaluation against two other vendors. Decisive factor: our open-source friendliness and the Go native integration. They are a 100% Go shop. Marcus will publish an engineering blog post about the integration. Estimated reach: 25k developer readers. Blog post draft shared for review — editorial feedback due in 5 business days.",
+	"Ana's company completed a Series C fundraise of $120M. Their engineering org is expanding from 80 to 150 engineers over the next 18 months. Ana has pre-approved $250k ARR for tooling for the expanded team. She wants to lock in a 3-year enterprise agreement before the price increase takes effect next quarter. Proposal sent with 3-year pricing and dedicated support tier.",
+	"EnterpriseGroup's 6-month evaluation concluded with a successful POC across 2 of their 6 product teams. The pilot team leads presented results to their CTO: 28% reduction in time to context for incident response, 41% improvement in new hire ramp time. The CTO approved expansion to all 6 teams. Legal is drafting the enterprise framework agreement. Deal expected to close in 4-6 weeks.",
+	"Globex Corp's Karen Wu left the company to join a startup. Her replacement is VP Engineering Thomas Reid, promoted internally. Thomas participated in an emergency business continuity call and confirmed Globex Corp will honor all existing commitments. He is interested in expanding the deployment to their Asia-Pacific team of 20 engineers. Introduction call with Thomas scheduled for next Monday.",
+	"Initech's domain vocabulary product went GA with Initech as the launch customer. Their data science team reduced annotation time by 60% using the automated vocabulary extraction pipeline. The feature is now generally available as an Enterprise add-on at $2k/month per model. Initech was credited as a co-inventor in the product announcement. Their renewal was processed at $320k ARR — our highest contract ever.",
+	"StreamCore pilot concluded successfully after 90 days. Pipeline monitoring accuracy improved by 31% when agents could recall historical incident patterns. Their Head of Data James Wu signed the full contract at $65k ARR. They immediately requested to expand to their platform engineering team of 20 engineers. Expansion contract for 20 additional seats at $800/seat = $16k ARR signed the same day.",
+	"Ana's 3-year enterprise agreement signed at $280k ARR, covering 150 seats. It includes the domain vocabulary add-on, dedicated SLA of 1-hour response for Severity-1, and a private Slack channel with our engineering team. Ana was featured in a press release alongside our CEO. The announcement generated 2,100 LinkedIn impressions and 14 inbound enterprise inquiries within 24 hours.",
+	"EnterpriseGroup closed at $200k ARR for a 3-year enterprise framework agreement covering 250 seats across all 6 product teams. It is now our largest single contract. Their General Counsel negotiated data processing terms extensively — final DPA signed after 4 rounds of revisions. Executive sponsor is their EVP Engineering Robert Zhao who personally championed the rollout to all teams.",
+	"TechnoStar's blog post by Marcus Chen published and reached 38k developer readers — 52% above his projected estimate. Drove 640 new signups, of which 12 converted to paid accounts in the first week. Marcus agreed to speak at our developer conference in November. His session title: 'Building Stateful AI Agents in Go: A Production Retrospective.' Expected attendance: 200 engineers.",
+	"CloudPeak's month-3 executive business review in Seattle was attended by Jessica Park and two board observers. They presented a 44% improvement in incident resolution time attributable to agent memory. One board observer requested an introduction to our CEO for a potential strategic investment conversation. Their expansion to a second department of 30 engineers is approved — $24k ARR addition.",
+	"Maria Lopez signed a strategic OEM licensing agreement for internal deployment of GrayMatter within her company's proprietary AI platform. The agreement covers unlimited internal seats at a flat annual license of $300k. External distribution rights are explicitly excluded. This is a new revenue category — flagged for a dedicated OEM contract template. Legal review completed in 10 business days.",
+	"Peak Data's year-end renewal and consolidation signed at $120k ARR covering all offices globally including the London expansion. CTO agreed to a 2-year commitment. She will join the Customer Advisory Board alongside Ana Torres. Peak Data now has 3 offices (SF, London, Singapore) and 150 engineers. Singapore onboarding to start in Q2 next year.",
+	"Omega Solutions was acquired by a publicly listed data company. The acquisition triggered an enterprise procurement review. Their new parent company's CTO evaluated GrayMatter against their existing enterprise agreements with our competitors. After a 30-day review, they decided to standardize on GrayMatter for all AI agent memory needs across the combined 400-person engineering org.",
+	"EnterpriseGroup's rollout to all 6 product teams completed 3 weeks ahead of schedule. Company-wide adoption reached 87% of licensed seats within 60 days. Their internal developer portal now includes GrayMatter as a standard tool in their agent development kit. Robert Zhao is requesting a joint press release and a case study co-authored by their Head of Developer Experience.",
+	"TechCorp's Maria Chen joined our Board of Customer Advisors and was elected Chair of the Technical Working Group at the September CAB meeting. She will co-lead the agent orchestration roadmap working group alongside Ana Torres. Their combined influence is shaping the product roadmap for the next two major releases. Both are confirmed speakers at the annual user conference.",
+	"Ana Torres's company completed an IPO on NASDAQ. GrayMatter was cited in the S-1 as a key operational infrastructure tool. Our logo appears in their investor presentation materials. This represents a significant brand validation event. Legal confirmed no action required on our side. Ana's personal equity vesting means she is financially independent — renewal risk is low.",
+	"Initech's co-development program expanded to 12 beta customers contributing domain vocabularies across 8 verticals. The program generated $180k in additional ARR from domain vocabulary subscriptions in year one. Product team is planning a second cohort of 20 beta customers for H1 next year. The program is now a formal product-led growth motion owned by the PLG team.",
+	"NovaTech, now part of EnterpriseGroup, is consolidating their contract under the EnterpriseGroup framework agreement. Carlos, as VP Engineering, is advocating for a 50-seat allocation for the Berlin office under the new parent company structure. This would increase the EnterpriseGroup footprint from 250 to 300 seats — $40k ARR addition to the framework agreement.",
+	"CloudPeak closed their Series C at $85M. Jessica Park messaged directly to say the operational efficiency demonstrated by GrayMatter was cited in their investor materials as a competitive moat. They are expanding internationally to London and Singapore — each office needs 20 seats, adding $32k ARR. Total CloudPeak ARR projected at $131k by end of year.",
+	"StreamCore's ML agents for pipeline monitoring have processed 12 million recall operations in 90 days of production use. Their SRE team reported a 39% reduction in mean time to identify pipeline root causes. James Wu presented the results at a data engineering conference to 800 attendees. The presentation is available on YouTube and has 4,200 views, driving 28 qualified inbound inquiries.",
+	"TechnoStar's expansion to their infrastructure team of 40 engineers closed at $32k ARR, bringing total account ARR to $87k. Marcus Chen co-authored a technical reference architecture document for Go-native AI agents using GrayMatter, published on our documentation site. The document became the most-viewed technical resource on the site within 48 hours of publication.",
+	"Omega Solutions' parent company standardized on GrayMatter and signed a global master agreement covering 400 seats at $800/seat = $320k ARR. Legal negotiated a 3-year term with CPI-linked annual price adjustments. This is our largest account by seat count. Assigned a dedicated Strategic Account Manager and a technical solutions architect for the global rollout.",
+	"Maria Lopez's OEM agreement generated the first external deployment of GrayMatter-powered memory in a third-party product. Their product shipped to 500 enterprise customers, each potentially running 10+ agents using our memory layer. Revenue participation model: $0.50 per active agent per month. Month-1 revenue: $2,400 from 4,800 active agents. This is the seed of a new revenue stream.",
+	"Ana Torres's company completed 100% of their 150-engineer rollout ahead of schedule. Their internal engineering blog published a post about the deployment that reached 18k readers via HackerNews. Three enterprise companies reached out directly after reading the post. Ana volunteered to do a 30-minute reference call for each. All three are in the pipeline with a combined opportunity of $210k ARR.",
+	"EnterpriseGroup's Head of Developer Experience published the joint case study. The study quantifies: 28% reduction in incident response time, 41% faster new engineer ramp, 19% increase in cross-team knowledge reuse. The study was picked up by three industry analyst firms. One analyst firm requested an analyst briefing for potential inclusion in their Enterprise AI Tooling market report.",
+	"Peak Data's Singapore office onboarding completed. 20 engineers provisioned, training completed in 2 days using the self-serve onboarding materials. Their CTO commended the quality of the Go SDK documentation. Singapore team immediately flagged a timezone-specific use case for agent handoff between shifts — logged as a product request. This use case could apply to 15 other enterprise accounts.",
+	"Initech's renewal for year 3 processed at $340k ARR, an 8% increase from year 2. The domain vocabulary product is now used by 60% of their engineering org. Their data science team is publishing an internal paper on the productivity gains attributable to domain-specific agent memory. They requested permission to submit a version to a peer-reviewed ML conference.",
+	"CloudPeak's London office (20 seats) went live. Singapore provisioning scheduled for month 2. Total CloudPeak global footprint: 120 licensed seats, $96k ARR, projected $131k ARR by year-end with Singapore. Jessica Park is presenting at our annual conference on international deployment best practices. Their deployment is now our reference case for multi-region enterprise rollouts.",
+	"TechCorp's year-2 renewal processed at $95k ARR, a $6k increase from year 1 reflecting seat expansion. They formally nominated Maria Chen as a reference customer for all enterprise deals over $50k ARR. Their case study has been cited in 14 enterprise sales conversations this quarter. Marketing team is creating a video testimonial with Maria Chen — filming scheduled for October 8th.",
+	"StreamCore's contract renewal signed at $90k ARR for year 2, covering their expanded platform engineering team. James Wu was promoted to VP Data Engineering. He has increased budget authority and is evaluating a company-wide expansion to 100 total seats — projected $80k ARR increase. Proof-of-concept for expanded deployment to start in month 13 with a 30-day evaluation period.",
+	"The analyst firm Gartner included GrayMatter in their inaugural Enterprise AI Agent Memory Solutions market report, placing us in the Visionary quadrant. The report cited our hybrid retrieval approach, Go-native integration, and enterprise customer base. Fourteen inbound enterprise inquiries were received within 48 hours of the report publication. Sales team capacity expanded by two enterprise AEs to manage demand.",
+	"Omega Solutions' parent company's global rollout to 400 seats completed in 6 weeks — 2 weeks ahead of the projected 8-week timeline. Their Head of Platform Engineering cited the quality of the migration tooling and documentation as the key accelerant. They are now evaluating GrayMatter for deployment in their AI research division — an additional 50-seat opportunity not in the original scope.",
+	"Maria Lopez's OEM deployment scaled to 8,200 active agents across their customer base. Monthly participation revenue reached $4,100. They are expanding the integration to their enterprise tier customers, projected to add 15,000 active agents over the next 6 months. OEM revenue run rate projected at $12,000 per month within 6 months — a meaningful contribution to ARR diversification.",
+	"NovaTech Berlin office, now under EnterpriseGroup, provisioned 50 additional seats in the framework agreement. Carlos continues to drive adoption across the Berlin engineering team. Total EnterpriseGroup global footprint: 300 seats, $240k ARR. Robert Zhao requested a strategic planning session for year 2 to align on product roadmap priorities for EnterpriseGroup's specific use cases.",
+	"Ana Torres announced GrayMatter as a founding technology partner in their AI-native engineering platform. This is the first formal technology partnership in our company's history. The agreement includes joint go-to-market activities, co-marketing budget of $50k per year, and joint participation in Dreamforce and AWS re:Invent. Legal drafted the Technology Partnership Agreement — under review.",
+	"TechnoStar's 2-year renewal signed at $95k ARR, a 9% increase. Marcus Chen has become an internal evangelist who has given GrayMatter training sessions to their entire engineering org. Their deployment now covers 120 engineers across frontend, backend, and infrastructure teams. Marcus proposed hosting a GrayMatter developer meetup at their San Francisco office with an expected attendance of 60 engineers.",
+	"CloudPeak's Singapore office provisioned with 20 seats on schedule. Total CloudPeak: 140 seats across 3 regions, $112k ARR. Jessica Park joined the Customer Advisory Board. She proposed a new session at the CAB on multi-region data sovereignty — 8 of 12 CAB members voted to add it as a standing agenda item given the growing EU and APAC regulatory complexity.",
+	"The Technology Partnership Agreement with Ana Torres's company was signed after 3 weeks of legal negotiation. Joint go-to-market activities begin in Q1 next year with a joint webinar targeted at 500 enterprise engineering leaders. Co-marketing budget of $50k allocated. The partnership was announced via a joint press release that reached 12,000 readers across both companies' networks.",
+	"EnterpriseGroup's strategic planning session for year 2 resulted in a formal product advisory committee with Robert Zhao as Chair. He committed 8 engineer-days per quarter to participate in beta programs and provide product feedback. EnterpriseGroup will co-develop the agent orchestration framework as a design partner, with their engineering team having early access to APIs 6 weeks before GA.",
+	"Initech's internal ML conference paper on domain-specific agent memory was accepted to NeurIPS 2027. Their data science team will present the paper at the conference in December. We are acknowledged in the paper's acknowledgments section. The paper's publication will establish Initech — and by extension GrayMatter — as a reference implementation in the academic literature on AI agent memory.",
+	"The GrayMatter annual user conference attracted 850 registered attendees, a 112% increase from the previous year's 400. Speaker lineup: Maria Chen (TechCorp), Ana Torres (Series C co), James Wu (StreamCore), and Marcus Chen (TechnoStar). Three new enterprise logos signed enterprise contracts at the conference. Conference-attributed pipeline: $540k ARR in new opportunities.",
+	"OEM revenue from Maria Lopez's platform crossed $10,000/month for the first time, driven by a 20,200 active agent milestone. The OEM agreement is now contributing $120k ARR on an annualized basis. Maria is proposing a white-label option for her largest enterprise customers who want branded experiences. White-label pricing model under commercial review — target pricing: flat $50k/year per white-label deployment.",
+	"Total ARR crossed $3M milestone. Customer breakdown: 14 enterprise accounts averaging $180k ARR, 6 mid-market accounts averaging $45k ARR, OEM contributing $120k ARR. Net Revenue Retention for the past 12 months: 134%. Gross Churn: 0% — no customer has churned since inception. Customer Acquisition Cost recovered within an average of 4.2 months. Gartner included us in the Magic Quadrant.",
+}
+
+// ── Token approximation ───────────────────────────────────────────────────────
+
+// approxTokens estimates GPT-4-class token count for text.
+//
+// The approximation lives in internal/tokens so that this benchmark,
+// benchmarks/retrieval_quality and the context-sync budget cannot drift into
+// meaning different things
+// by the word "tokens" — docs/benchmarks.md publishes figures from both.
+func approxTokens(text string) int {
+	return tokens.Approx(text)
+}
+
+// ── Benchmark ─────────────────────────────────────────────────────────────────
+
+const (
+	tokenAgentID = "sales-agent"
+	TokenQuery   = "follow up with prospects and close pending deals this week"
+	TokenTopK    = 8
+)
+
+// SessionCounts controls which data points are reported and published.
+// Each "session" = one stored memory observation (a paragraph extracted from
+// a real agent interaction, ~50-70 words). Full injection = all observations
+// concatenated. GrayMatter = top-8 most relevant observations recalled.
+var SessionCounts = []int{1, 10, 30, 100}
+
+// TokenResult is one row of the benchmark table.
+type TokenResult struct {
+	Sessions     int
+	FullTokens   int
+	RecallTokens int
+	Reduction    float64 // percent
+}
+
+// RunTokenCount executes the full measurement and returns one result per
+// entry in SessionCounts. It is separated from any rendering so tests can
+// compare the published tables against freshly measured numbers.
+func RunTokenCount() ([]TokenResult, error) {
+	// Shuffle insertion order so keyword ranking is not biased by the order
+	// the corpus happens to be written in. Fixed seed: the shuffle is part of
+	// the fixture, not a source of variation.
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec
+	perm := rng.Perm(len(corpus))
+
+	results := make([]TokenResult, 0, len(SessionCounts))
+	for _, target := range SessionCounts {
+		r, err := measureAt(target, perm)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+// measureAt builds a fresh store holding exactly `target` observations and
+// takes one measurement from it.
+//
+// Each row gets its own store on purpose. Reusing one store across rows made
+// the benchmark non-reproducible: Recall updates AccessCount and AccessedAt
+// from detached goroutines, so the writebacks from one row were still in
+// flight while the next row was inserting and backdating, and a late writeback
+// restores the whole Fact as it looked when it was read. Measured rate was
+// about one differing run in twenty-five — often enough to publish a number
+// nobody else can reproduce, rare enough that nobody notices why.
+//
+// Recall itself is deterministic: 300 calls against a fixed store return the
+// same result every time. The variance was entirely in how the store was
+// built, which is why the fix belongs here and not in the engine.
+func measureAt(target int, perm []int) (TokenResult, error) {
+	dataDir, err := os.MkdirTemp("", "graymatter-bench-*")
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("mktemp: %w", err)
+	}
+	defer os.RemoveAll(dataDir)
+
+	emb := embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword})
+	store, err := memory.Open(memory.StoreConfig{
+		DataDir:  dataDir,
+		Embedder: emb,
+	})
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("open store: %w", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	for i := 0; i < target && i < len(corpus); i++ {
+		if err := store.Put(ctx, tokenAgentID, corpus[perm[i]]); err != nil {
+			return TokenResult{}, fmt.Errorf("put: %w", err)
+		}
+	}
+	if err := spreadOverSessions(store); err != nil {
+		return TokenResult{}, err
+	}
+
+	// Full injection: ALL stored observations concatenated.
+	allFacts, err := store.List(tokenAgentID)
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("list: %w", err)
+	}
+	fullTexts := make([]string, 0, len(allFacts))
+	for _, f := range allFacts {
+		fullTexts = append(fullTexts, f.Text)
+	}
+	fullTokens := approxTokens(strings.Join(fullTexts, "\n"))
+
+	// GrayMatter: recall only the top-K most relevant observations.
+	recalled, err := store.Recall(ctx, tokenAgentID, TokenQuery, TokenTopK)
+	if err != nil {
+		return TokenResult{}, fmt.Errorf("recall: %w", err)
+	}
+	recallTokens := approxTokens(strings.Join(recalled, "\n"))
+
+	reduction := 0.0
+	if fullTokens > 0 {
+		reduction = float64(fullTokens-recallTokens) / float64(fullTokens) * 100
+	}
+	return TokenResult{
+		Sessions:     target,
+		FullTokens:   fullTokens,
+		RecallTokens: recallTokens,
+		Reduction:    reduction,
+	}, nil
+}
+
+// RenderTokenReport formats the benchmark's stdout report. Every entry point
+// renders through this so a reader comparing `go run ./benchmarks/token_count`
+// with `graymatter bench` sees byte-identical output for identical results.
+func RenderTokenReport(results []TokenResult, elapsed time.Duration) string {
+	var b strings.Builder
+	b.WriteString("\nGrayMatter Token Efficiency Benchmark\n")
+	b.WriteString(fmt.Sprintf("Query:    %q\n", TokenQuery))
+	b.WriteString("Embedder: keyword (no LLM required — fully reproducible)\n")
+	b.WriteString(fmt.Sprintf("TopK:     %d recalled observations per query\n", TokenTopK))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("%-10s  %-18s  %-22s  %s\n",
+		"Sessions", "Full Injection", "GrayMatter Recall", "Reduction"))
+	b.WriteString(strings.Repeat("─", 72) + "\n")
+
+	for _, r := range results {
+		b.WriteString(fmt.Sprintf("%-10d  ~%-17d  ~%-21d  %.0f%%\n",
+			r.Sessions, r.FullTokens, r.RecallTokens, r.Reduction))
+	}
+
+	b.WriteString(strings.Repeat("─", 72) + "\n")
+	b.WriteString(fmt.Sprintf("\nRun time:  %s\n", elapsed.Truncate(time.Millisecond)))
+	b.WriteString("\n")
+	b.WriteString("Approximation: words × 1.33 ≈ GPT-4 tokens (±10% for English prose).\n")
+	b.WriteString("With vector embeddings (Ollama / OpenAI / Anthropic) recall precision\n")
+	b.WriteString("improves further, maintaining similar or better token reduction ratios.\n")
+	return b.String()
+}
+
+// spreadOverSessions backdates the stored facts so that session N sits N days
+// before session inserted, one observation per simulated day.
+//
+// Without this the benchmark writes every fact inside the same few
+// milliseconds, and the clock is not that precise: in a 30-fact run, 8 facts
+// routinely share a CreatedAt. Facts with an identical timestamp have an
+// identical recency score, and recall.go turns scores into ranks with
+// sort.Slice, which is not stable — so tied facts receive arbitrary ranks,
+// those ranks feed the fused score, and the final ordering varies between
+// runs. Measured rate on this corpus was roughly one differing run in
+// twenty-five, which is exactly often enough to publish a number nobody can
+// reproduce and rare enough that nobody notices why.
+//
+// One fact per day also matches what the benchmark says it models: a session
+// is a day of agent work, not a microsecond of one.
+//
+// This is a fix to the benchmark, not to the engine. The underlying tie-break
+// in recall.go is still unspecified for facts written in the same instant.
+func spreadOverSessions(store *memory.Store) error {
+	facts, err := store.List(tokenAgentID)
+	if err != nil {
+		return fmt.Errorf("list for backdating: %w", err)
+	}
+	now := time.Now().UTC()
+	for i := range facts {
+		// facts is newest-first; index 0 is the most recent session.
+		at := now.Add(-time.Duration(i) * 24 * time.Hour)
+		facts[i].CreatedAt = at
+		facts[i].AccessedAt = at
+		if err := store.UpdateFact(tokenAgentID, facts[i]); err != nil {
+			return fmt.Errorf("backdate: %w", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

GrayMatter's engine was already ahead of its onboarding. This round closes that gap with four user-facing capabilities and a set of setup fixes, so the first session already feels the product working.

### What ships

- **Agents get briefed over the protocol itself.** The MCP server now delivers the session protocol in the initialize handshake, so every compatible client — including ones that never load CLAUDE.md — starts calling the memory tools from turn one (issues #3, #14). The copy is a compile-time constant (nothing from the store ever crosses initialize) with its token cost pinned by test.
- **`graymatter bench`** — the published measurement suites run from the installed binary. No Go toolchain, no clone: `bench` reproduces the README tables, and `bench --store` measures *your* memory — what a top-8 recall costs today vs dumping history, per agent. Read-only unless `--probe-recall`.
- **`graymatter status`** — one screen answering "is this thing working?": facts, recalls per agent, knowledge-graph state, the 30-day token ledger, and today's injection estimate.
- **`graymatter init --kg`** — knowledge-graph auto-population in one flag, persisted for every future daemon spawn ([ADR-009](docs/decisions/009-kg-sentinel-activation.md)). Doctor now reports KG state too.
- **Smoother self-curation.** `memory_reflect` no longer asks hosts for approval on every save; it also accepts `agent_id` like the other tools, ending the silent parameter mismatch. Guardrails live in the handler where they are testable: exact-match forget, tombstones (ADR-007), full audit trail.
- **Setup that survives real life.** One authoritative restart message (the Windows PATH note folds into it), and doctor's restart hint stays up while a store has zero facts — even if a CLI `remember` created the database early.

Numbers stay honest by construction: every figure in the README is machine-gated against a live run in CI, `graymatter bench` lets any user reproduce them locally, and the retrieval section states the sliding-window comparison openly.

## Testing

- All three modules green before and after (`pkg/memory`, `cmd/graymatter/**`, `benchmarks/**`); the README-parsing gate tests pass unchanged.
- New coverage: handshake instructions (+ budget pin), annotation expectations, agent_id alias, bench synthetic JSON/human output, `--store` metrics incl. tombstone exclusion, daemon RPCs against a real built binary (`TestHostService_CoreSurface`), sentinel acceptance tests through the real spawn path, doctor checkKG table, empty-store hint regimes, reconnecting-wrapper delegation entries, and a CLI-side gate pinning `bench` output to the published token table at the same tolerance CI uses.
- The CLI module builds workspace-off against the last tagged release (`GOWORK=off go build ./...` verified locally — the exact check that flagged the first push; the shared bench core now lives inside the cmd module, so no unpublished root symbols are imported).
- Release-candidate E2E run manually on a clean temp project: `init --kg` → spawned daemon honours sentinel → 25 facts → entities extracted → `status`/`doctor` correct.

## Risks & rollback

Each commit reverts independently. Instructions copy is one constant; the KG sentinel is inert unless the file exists (delete `<data-dir>/kg.auto` to disable). No defaults changed for existing users who never opt in.
