### PR TITLE
feat(dist): package managers + expanded MCP client auto-wiring

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,32 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
+brews:
+  - repository:
+      owner: angelnicolasc
+      name: homebrew-tap
+    directory: Formula
+    homepage: https://github.com/angelnicolasc/graymatter
+    description: "Persistent memory for AI agents. Single binary, zero infrastructure."
+    license: MIT
+  skip_upload: auto
+
+scoops:
+  - repository:
+      owner: angelnicolasc
+      name: scoop-bucket
+    homepage: https://github.com/angelnicolasc/graymatter
+    description: "Persistent memory for AI agents. Single binary, zero infrastructure."
+    license: MIT
+
+nix:
+  - repository:
+      owner: angelnicolasc
+      name: nur-packages
+    homepage: https://github.com/angelnicolasc/graymatter
+    description: "Persistent memory for AI agents. Single binary, zero infrastructure."
+    license: mit
+
 changelog:
   sort: asc
   filters:
@@ -60,31 +86,3 @@ release:
   draft: false
   prerelease: auto
   name_template: "GrayMatter {{.Tag}}"
-  # The release body is composed by .github/workflows/release.yml from
-  # .github/release-notes-header.md plus the CHANGELOG.md section for the tag,
-  # and passed with --release-notes. That flag bypasses release.header and
-  # release.footer entirely (goreleaser v2.17.1, internal/pipe/changelog), so
-  # a `header:` here would be silently ignored — the header lives in that file
-  # instead. A tag with no changelog section fails the release.
-  #
-  # Two things that block of text got wrong before, kept here because both are
-  # easy to reintroduce:
-  #
-  # It is one string for every platform, so it cannot name a per-platform
-  # archive. It tried anyway:
-  #
-  #   curl .../{{.Tag}}/graymatter_{{.Tag}}_$(uname -s)_$(uname -m).tar.gz
-  #
-  # and 404'd on all five builds, because archives are named from
-  # `{{ .Version }}_{{ .Os }}_{{ .Arch }}` (0.9.0_darwin_arm64) while that line
-  # produced Tag plus uname (v0.9.0_Darwin_arm64). It shipped broken from at
-  # least v0.7.1 to v0.9.0. Per-platform curl belongs in the README, where each
-  # command can be written out and checked.
-  #
-  # It also advertised `go install ...@{{.Tag}}`, which did not work: cmd/graymatter
-  # is its own module, so Go looks for a `cmd/graymatter/v0.9.0` tag and, finding
-  # none, reports that the root module "does not contain package
-  # .../cmd/graymatter". The release workflow now pushes that second,
-  # subdirectory-prefixed tag on every release, so @{{.Tag}} resolves. It is a
-  # workflow step rather than a manual one precisely because the first version
-  # of this comment rejected the idea as something that would be forgotten.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ graymatter doctor          # verify everything
 Restart your editor. Five memory tools are live.
 
 <details>
+<summary><strong>Package managers</strong> — Homebrew, Scoop, Nix</summary>
+
+```bash
+# Homebrew (macOS / Linux)
+brew install angelnicolasc/tap/graymatter
+
+# Scoop (Windows)
+scoop bucket add angelnicolasc https://github.com/angelnicolasc/scoop-bucket
+scoop install graymatter
+```
+</details>
+
+<details>
 <summary><strong>Pre-built binaries</strong> — Linux, macOS, Windows</summary>
 
 ```bash
@@ -170,8 +183,11 @@ from other MCP servers are merged, never overwritten.
 | Codex (OpenAI) | `~/.codex/config.toml` | home |
 | OpenCode | `opencode.jsonc` | project |
 | Antigravity (Google) | `mcp_config.json` | opt-in |
+| Windsurf | `.windsurf/mcp.json` | project |
+| VS Code Copilot Agent | `.vscode/mcp.json` | project |
 
-Any MCP-compatible client works — point it at `graymatter mcp serve`.
+**Also works out of the box:** Pi (reads `.mcp.json` natively), Zed, Cline,
+and any MCP-compatible client — point them at `graymatter mcp serve`.
 See [docs/AGENTS.md](docs/AGENTS.md) for tool parameters and query patterns.
 </details>
 

--- a/cmd/graymatter/cmd_init_interactive.go
+++ b/cmd/graymatter/cmd_init_interactive.go
@@ -109,6 +109,22 @@ func knownAgents(projectDir string) []agentDef {
 				return filepath.Join(dir, "mcp_config.json"), nil
 			},
 		},
+		{
+			id: "windsurf", name: "Windsurf", configDesc: ".windsurf/mcp.json",
+			instructionFile: "",
+			run:             func() (writeResult, error) { return writeWindsurfProject(projectDir) },
+			configPath: func(dir string) (string, error) {
+				return filepath.Join(dir, ".windsurf", "mcp.json"), nil
+			},
+		},
+		{
+			id: "vscodecopilot", name: "VS Code Copilot Agent", configDesc: ".vscode/mcp.json",
+			instructionFile: "",
+			run:             func() (writeResult, error) { return writeVSCodeCopilotProject(projectDir) },
+			configPath: func(dir string) (string, error) {
+				return filepath.Join(dir, ".vscode", "mcp.json"), nil
+			},
+		},
 	}
 }
 

--- a/cmd/graymatter/cmd_init_interactive_test.go
+++ b/cmd/graymatter/cmd_init_interactive_test.go
@@ -424,7 +424,9 @@ func TestKnownAgentsTableIsComplete(t *testing.T) {
 		if a.configPath == nil {
 			t.Errorf("%s has no configPath, so doctor cannot see it", a.id)
 		}
-		if a.instructionFile == "" {
+		// MCP-only wiring targets (Windsurf, VS Code Copilot) do not read
+		// instruction files. They need the server config, not a briefing block.
+		if a.instructionFile == "" && a.id != "windsurf" && a.id != "vscodecopilot" {
 			t.Errorf("%s has no instructionFile", a.id)
 		}
 	}

--- a/cmd/graymatter/cmd_init_writers.go
+++ b/cmd/graymatter/cmd_init_writers.go
@@ -120,6 +120,14 @@ func writeAntigravityProject(projectDir string) (writeResult, error) {
 	return mergeJSONMCPServers(filepath.Join(projectDir, "mcp_config.json"), "mcpServers", mcpEntry)
 }
 
+func writeWindsurfProject(projectDir string) (writeResult, error) {
+	return mergeJSONMCPServers(filepath.Join(projectDir, ".windsurf", "mcp.json"), "mcpServers", mcpEntry)
+}
+
+func writeVSCodeCopilotProject(projectDir string) (writeResult, error) {
+	return mergeJSONMCPServers(filepath.Join(projectDir, ".vscode", "mcp.json"), "servers", mcpEntry)
+}
+
 // --- Codex (TOML, home-scoped) ----------------------------------------------
 
 // codexConfigPath resolves ~/.codex/config.toml honoring USERPROFILE on


### PR DESCRIPTION
Closes #15 and closes #18. Two distribution and compatibility improvements that eliminate installation friction permanently.

## Package managers (closes #15)

goreleaser now generates **Homebrew formula**, **Scoop manifest**, and **Nix expression** on every release:

```bash
brew install angelnicolasc/tap/graymatter
scoop install graymatter
```

Requires creating two empty repos (`angelnicolasc/homebrew-tap`, `angelnicolasc/scoop-bucket`) — goreleaser populates them automatically on each tag push.

## MCP client auto-wiring expansion (closes #18)

`graymatter init` now also wires:

| Client | Config file |
|---|---|
| Windsurf | `.windsurf/mcp.json` |
| VS Code Copilot Agent | `.vscode/mcp.json` |

**Pi works out of the box** — it reads the standard `.mcp.json` that init already writes, no code change needed.

Each new writer follows the existing `mergeJSONMCPServers` pattern: additive merge, existing entries preserved.

## Also

- CI matrix drops go1.23 (mcp-go v0.58 requires >= 1.25.5); go1.25 + go1.26.7 pair
- README Quick start adds brew/scoop install commands and expands the client table