### PR TITLE
fix(export): hardening pass — Obsidian vault links, fact note names, status cache-read

### DIFF
--- a/cmd/graymatter/cmd_export_graph_test.go
+++ b/cmd/graymatter/cmd_export_graph_test.go
@@ -77,12 +77,15 @@ func TestExport_IncludeGraph_WritesEntitiesCanvasAndFacts(t *testing.T) {
 		t.Errorf("expected fact note + 2 entity notes, found %d markdown files: %v", mds, entries)
 	}
 	// sanitizeFilename swaps spaces for underscores: "Data Pipeline" →
-	// "Data_Pipeline.md".
+	// "Data_Pipeline.md". Related links must use the label form so they
+	// resolve in Obsidian; the placeholder node's label is its ID.
 	entityNote := filepath.Join(out, "Data_Pipeline.md")
 	if data, err := os.ReadFile(entityNote); err != nil {
 		t.Errorf("entity note missing: %v", err)
-	} else if !strings.Contains(string(data), "[[etl-jobs]]") {
-		t.Errorf("entity note lacks typed backlink:\n%s", data)
+	} else if !strings.Contains(string(data), "[[etl-jobs|etl-jobs]]") {
+		t.Errorf("entity note Related link does not resolve to a note name:\n%s", data)
+	} else if _, err := os.Stat(filepath.Join(out, "etl-jobs.md")); err != nil {
+		t.Errorf("linked note missing from vault: %v", err)
 	}
 }
 

--- a/cmd/graymatter/cmd_status.go
+++ b/cmd/graymatter/cmd_status.go
@@ -145,9 +145,13 @@ func renderStatus(out io.Writer, view statusView) error {
 
 	fmt.Fprintln(out, "TOKENS     last 30d — recorded by 'graymatter run' sessions only:")
 	if tok.Loaded && tok.Requests > 0 {
-		inOut := tok.Input + tok.Output
+		// Cache reads are part of the input side: the hit rate is
+		// CacheRead / (Input + CacheRead), matching the harness ledger and
+		// the TUI dashboard. Dividing by Input+Output printed >100% on
+		// cache-heavy workloads.
+		inputSide := tok.Input + tok.CacheRead
 		fmt.Fprintf(out, "           in ~%dk · out ~%dk · cache-read %.0f%% · requests %d\n",
-			tok.Input/1000, tok.Output/1000, pct(tok.CacheRead, inOut), tok.Requests)
+			tok.Input/1000, tok.Output/1000, pct(tok.CacheRead, inputSide), tok.Requests)
 	} else {
 		fmt.Fprintln(out, "           no harness runs recorded (MCP sessions are not measured)")
 	}

--- a/cmd/graymatter/cmd_status_test.go
+++ b/cmd/graymatter/cmd_status_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 func runStatusCmd(t *testing.T, args ...string) string {
@@ -192,3 +194,37 @@ func TestDirectStoreOverview_MatchesGroundTruth(t *testing.T) {
 // The daemon-side aggregation is pinned against a real daemon in
 // internal/daemon TestHostService_CoreSurface; the two implementations share
 // semantics (live excludes tombstones; recalls sums AccessCount).
+
+// Cache reads are part of the input side: the percentage must be
+// CacheRead / (Input + CacheRead). Dividing by Input+Output printed
+// impossible values (>100%) on cache-heavy workloads.
+func TestStatus_CacheReadPercentage(t *testing.T) {
+	view := statusView{
+		Mode: "in-process",
+		Overview: &daemon.StoreOverviewResponse{
+			TotalAgents:    1,
+			TotalLiveFacts: 1,
+			Agents:         []daemon.AgentSummary{{Agent: "writer", LiveFacts: 1, Recalls: 3, AvgWeight: 1}},
+		},
+		KG: &daemon.KGStateResponse{},
+		Tokens: harness.TokenUsageSummary{
+			Loaded:   true,
+			Requests: 10,
+			Input:    1_000,
+			Output:   500,
+			CacheRead: 9_000,
+		},
+		Facts: map[string][]memory.Fact{
+			"writer": {{ID: "f1", AgentID: "writer", Text: "one two three four five"}},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := renderStatus(&out, view); err != nil {
+		t.Fatalf("renderStatus: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "cache-read 90%") {
+		t.Errorf("cache-read line wrong, want 90%% (CacheRead/(Input+CacheRead)):\n%s", got)
+	}
+}

--- a/cmd/graymatter/internal/export/obsidian.go
+++ b/cmd/graymatter/internal/export/obsidian.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/angelnicolasc/graymatter/pkg/memory"
@@ -18,19 +19,88 @@ func (e *ObsidianExporter) Export(facts []memory.Fact, outDir string) error {
 		return err
 	}
 
+	names := BuildFactNoteNames(facts)
+
 	// Write one note per fact.
 	for _, f := range facts {
-		if err := writeObsidianNote(outDir, f); err != nil {
+		if err := writeObsidianNote(outDir, f, names[f.ID]); err != nil {
 			return err
 		}
 	}
 
 	// Write _index.md with backlinks grouped by agent.
-	return writeObsidianIndex(outDir, facts)
+	return writeObsidianIndex(outDir, facts, names)
 }
 
-func writeObsidianNote(outDir string, f memory.Fact) error {
-	agentDir := filepath.Join(outDir, sanitiseFilename(f.AgentID))
+// AgentDirName is the single authority for the per-agent subdirectory name
+// inside an Obsidian vault. Every writer and every link to a fact note must
+// go through it.
+func AgentDirName(agentID string) string {
+	return sanitiseFilename(agentID)
+}
+
+// BuildFactNoteNames derives the note filename (without .md) for every fact.
+// Names come from the fact text so the Obsidian graph view and quick
+// switcher show knowledge instead of opaque ULIDs. The mapping is
+// deterministic for a given fact slice and collision-free: identical or
+// slug-less texts get a short-ID suffix, and any residual clash is resolved
+// with a counter suffix.
+func BuildFactNoteNames(facts []memory.Fact) map[string]string {
+	used := make(map[string]bool, len(facts))
+	names := make(map[string]string, len(facts))
+	for _, f := range facts {
+		base := slugifyFactText(f.Text)
+		name := base
+		if base == "" {
+			// Blank slugs always carry the short ID: a bare "fact.md" says
+			// nothing and invites pointless collisions between agents.
+			name = "fact-" + shortID(f.ID)
+		} else if used[name] {
+			name = base + "-" + shortID(f.ID)
+		}
+		for n := 2; used[name]; n++ {
+			name = fmt.Sprintf("%s-%s-%d", base, shortID(f.ID), n)
+		}
+		used[name] = true
+		names[f.ID] = name
+	}
+	return names
+}
+
+// slugifyFactText turns fact text into a readable, filesystem- and
+// Obsidian-safe slug: only alphanumerics, '-', and '_' survive; everything
+// else collapses to '-'. The result is clamped to 64 runes without splitting
+// multi-byte characters.
+func slugifyFactText(text string) string {
+	s := strings.Map(func(r rune) rune {
+		switch {
+		case r == '\'' || r == '’':
+			return -1 // drop apostrophes: "didn't" -> "didnt"
+		case ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || ('0' <= r && r <= '9'):
+			return r
+		default:
+			return '-'
+		}
+	}, strings.TrimSpace(text))
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	r := []rune(s)
+	if len(r) > 64 {
+		r = r[:64]
+	}
+	return strings.Trim(string(r), "-._")
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		id = id[:8]
+	}
+	return strings.ToLower(id)
+}
+
+func writeObsidianNote(outDir string, f memory.Fact, noteName string) error {
+	agentDir := filepath.Join(outDir, AgentDirName(f.AgentID))
 	if err := os.MkdirAll(agentDir, 0o755); err != nil {
 		return err
 	}
@@ -51,32 +121,48 @@ func writeObsidianNote(outDir string, f memory.Fact) error {
 	sb.WriteString("---\n\n")
 	sb.WriteString(f.Text + "\n")
 
-	filename := fmt.Sprintf("%s.md", f.ID)
+	filename := fmt.Sprintf("%s.md", noteName)
 	return os.WriteFile(filepath.Join(agentDir, filename), []byte(sb.String()), 0o644)
 }
 
-func writeObsidianIndex(outDir string, facts []memory.Fact) error {
+func writeObsidianIndex(outDir string, facts []memory.Fact, names map[string]string) error {
 	byAgent := make(map[string][]memory.Fact)
 	for _, f := range facts {
 		byAgent[f.AgentID] = append(byAgent[f.AgentID], f)
 	}
 
+	// Sorted agent sections keep the index byte-identical across runs on the
+	// same store — map iteration would scramble it.
+	agents := make([]string, 0, len(byAgent))
+	for agentID := range byAgent {
+		agents = append(agents, agentID)
+	}
+	sort.Strings(agents)
+
 	var sb strings.Builder
 	sb.WriteString("---\ntags: [graymatter, index]\n---\n\n")
 	sb.WriteString("# GrayMatter Memory Index\n\n")
-	sb.WriteString(fmt.Sprintf("_%d total facts across %d agents_\n\n", len(facts), len(byAgent)))
+	sb.WriteString(fmt.Sprintf("_%d total facts across %d agents_\n\n", len(facts), len(agents)))
 
-	for agentID, agentFacts := range byAgent {
+	for _, agentID := range agents {
+		agentFacts := byAgent[agentID]
 		sb.WriteString(fmt.Sprintf("## %s (%d facts)\n\n", agentID, len(agentFacts)))
 		for _, f := range agentFacts {
-			preview := f.Text
-			if len(preview) > 80 {
-				preview = preview[:77] + "..."
-			}
-			sb.WriteString(fmt.Sprintf("- [[%s/%s|%s]]\n", sanitiseFilename(agentID), f.ID, preview))
+			sb.WriteString(fmt.Sprintf("- [[%s/%s|%s]]\n",
+				AgentDirName(agentID), names[f.ID], truncatePreview(f.Text, 80)))
 		}
 		sb.WriteString("\n")
 	}
 
 	return os.WriteFile(filepath.Join(outDir, "_index.md"), []byte(sb.String()), 0o644)
+}
+
+// truncatePreview shortens s to at most max runes, rune-safe so multi-byte
+// text never splits mid-character.
+func truncatePreview(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-3]) + "..."
 }

--- a/cmd/graymatter/internal/export/obsidian_test.go
+++ b/cmd/graymatter/internal/export/obsidian_test.go
@@ -1,0 +1,154 @@
+package export
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+func obsidianTestFacts() []memory.Fact {
+	base := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	return []memory.Fact{
+		{ID: "01A", AgentID: "sales-closer", Text: "Maria prefers Slack over email", CreatedAt: base, AccessedAt: base, Weight: 1},
+		{ID: "01B", AgentID: "sales-closer", Text: "Maria prefers Slack over email", CreatedAt: base, AccessedAt: base, Weight: 1},
+		{ID: "01C", AgentID: "backend", Text: "API rate limit is 100 req/min", CreatedAt: base, AccessedAt: base, Weight: 1},
+		{ID: "01D", AgentID: "backend", Text: "   ", CreatedAt: base, AccessedAt: base, Weight: 1},
+		{ID: "01E", AgentID: "docs", Text: "El corazón de la configuración es la calibración de pesos y señales de recall para cada agente del sistema", CreatedAt: base, AccessedAt: base, Weight: 1},
+	}
+}
+
+func exportObsidian(t *testing.T, facts []memory.Fact) string {
+	t.Helper()
+	out := t.TempDir()
+	if err := (&ObsidianExporter{}).Export(facts, out); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	return out
+}
+
+// Fact notes must be named after the fact text, not the raw ULID: Obsidian's
+// graph view and quick switcher render the filename, and a wall of ULIDs is
+// unreadable.
+func TestObsidian_FactNotesUseReadableNames(t *testing.T) {
+	out := exportObsidian(t, obsidianTestFacts())
+
+	if _, err := os.Stat(filepath.Join(out, "sales-closer", "Maria-prefers-Slack-over-email.md")); err != nil {
+		t.Errorf("readable fact note missing: %v", err)
+	}
+	// The duplicate text is disambiguated with a short-ID suffix, not overwritten.
+	if _, err := os.Stat(filepath.Join(out, "sales-closer", "Maria-prefers-Slack-over-email-01b.md")); err != nil {
+		t.Errorf("disambiguated duplicate note missing: %v", err)
+	}
+	// A blank slug falls back to "fact" plus suffix.
+	if _, err := os.Stat(filepath.Join(out, "backend", "fact-01d.md")); err != nil {
+		t.Errorf("blank-slug note missing: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(out, "sales-closer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 notes in sales-closer, got %d", len(entries))
+	}
+}
+
+// Every wikilink the index emits must resolve to a file on disk — this is the
+// property Obsidian needs to draw the fact layer of the graph at all.
+func TestObsidian_IndexLinksResolve(t *testing.T) {
+	out := exportObsidian(t, obsidianTestFacts())
+
+	data, err := os.ReadFile(filepath.Join(out, "_index.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	re := regexp.MustCompile(`\[\[([^\]|]+)\|`)
+	for _, m := range re.FindAllStringSubmatch(string(data), -1) {
+		target := filepath.Join(out, filepath.FromSlash(m[1])+".md")
+		if _, err := os.Stat(target); err != nil {
+			t.Errorf("index link %q does not resolve: %v", m[1], err)
+		}
+	}
+	if !strings.Contains(string(data), "sales-closer/Maria-prefers-Slack-over-email") {
+		t.Errorf("index does not use readable note names:\n%s", data)
+	}
+}
+
+// Two exports of the same store must produce byte-identical indexes; map
+// iteration order used to scramble the agent sections between runs.
+func TestObsidian_IndexDeterministic(t *testing.T) {
+	facts := obsidianTestFacts()
+	out1 := exportObsidian(t, facts)
+	out2 := exportObsidian(t, facts)
+
+	b1, err := os.ReadFile(filepath.Join(out1, "_index.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(filepath.Join(out2, "_index.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("index is not deterministic between runs:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", b1, b2)
+	}
+}
+
+// Previews truncate by rune, not by byte: multi-byte text must never split
+// mid-character and emit invalid UTF-8 into the vault.
+func TestObsidian_PreviewIsRuneSafe(t *testing.T) {
+	out := exportObsidian(t, obsidianTestFacts())
+
+	data, err := os.ReadFile(filepath.Join(out, "_index.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	index := string(data)
+	if !utf8.ValidString(index) {
+		t.Error("index is not valid UTF-8")
+	}
+	if strings.Contains(index, "\uFFFD") {
+		t.Error("index contains replacement characters from a split rune")
+	}
+	if !strings.Contains(index, "El corazón de la configuración") {
+		t.Errorf("multi-byte preview garbled:\n%s", index)
+	}
+}
+
+func TestBuildFactNoteNames_CollisionFreeAndDeterministic(t *testing.T) {
+	facts := []memory.Fact{
+		{ID: "aaaaaaaa-1", Text: "Same text"},
+		{ID: "bbbbbbbb-2", Text: "Same text"},
+		{ID: "cccccccc-3", Text: "Same text"},
+		{ID: "dddddddd-4", Text: "   "},
+	}
+	names := BuildFactNoteNames(facts)
+
+	seen := map[string]bool{}
+	for _, f := range facts {
+		n := names[f.ID]
+		if n == "" {
+			t.Fatalf("empty name for fact %s", f.ID)
+		}
+		if seen[n] {
+			t.Errorf("filename collision on %q", n)
+		}
+		seen[n] = true
+	}
+	if names["aaaaaaaa-1"] != "Same-text" {
+		t.Errorf("first occurrence should keep the clean name, got %q", names["aaaaaaaa-1"])
+	}
+
+	again := BuildFactNoteNames(facts)
+	for _, f := range facts {
+		if again[f.ID] != names[f.ID] {
+			t.Errorf("naming is not deterministic for %s: %q vs %q", f.ID, names[f.ID], again[f.ID])
+		}
+	}
+}

--- a/cmd/graymatter/internal/kg/graph.go
+++ b/cmd/graymatter/internal/kg/graph.go
@@ -348,6 +348,14 @@ func (g *Graph) ExportObsidian(outDir string) error {
 		return err
 	}
 
+	// Wikilinks must name the note file (sanitized label), not the raw node
+	// ID — an [[ID]] link matches no file and Obsidian drops it from the
+	// graph view entirely.
+	labelBy := make(map[string]string, len(nodes))
+	for _, n := range nodes {
+		labelBy[n.ID] = n.Label
+	}
+
 	// Write one .md file per node.
 	for _, n := range nodes {
 		content := fmt.Sprintf("---\nid: %s\nentity_type: %s\ntags:\n  - entity\n  - %s\nfirst_seen: %s\nlast_seen: %s\nweight: %.4f\n---\n\n# %s\n\n**Type:** %s\n",
@@ -357,7 +365,12 @@ func (g *Graph) ExportObsidian(outDir string) error {
 		var related []string
 		for _, e := range edges {
 			if e.From == n.ID {
-				line := fmt.Sprintf("- [[%s]] (%s)", e.To, e.Relation)
+				label := labelBy[e.To]
+				target := e.To
+				if label != "" {
+					target = SanitizeFilename(label)
+				}
+				line := fmt.Sprintf("- [[%s|%s]] (%s)", target, label, e.Relation)
 				if len(e.Sources) > 0 {
 					line += fmt.Sprintf(" · %d receipt(s)", len(e.Sources))
 				}
@@ -368,7 +381,7 @@ func (g *Graph) ExportObsidian(outDir string) error {
 			content += "\n## Related\n" + strings.Join(related, "\n") + "\n"
 		}
 
-		fname := sanitizeFilename(n.Label) + ".md"
+		fname := SanitizeFilename(n.Label) + ".md"
 		if err := os.WriteFile(filepath.Join(outDir, fname), []byte(content), 0o644); err != nil {
 			return fmt.Errorf("kg: write node file: %w", err)
 		}
@@ -525,7 +538,7 @@ func writeEntitiesMOC(outDir string, nodes []Node) error {
 	for _, t := range types {
 		fmt.Fprintf(&sb, "## %s (%d)\n\n", t, len(byType[t]))
 		for _, n := range byType[t] {
-			fmt.Fprintf(&sb, "- [[%s|%s]]\n", sanitizeFilename(n.Label), n.Label)
+			fmt.Fprintf(&sb, "- [[%s|%s]]\n", SanitizeFilename(n.Label), n.Label)
 		}
 		sb.WriteString("\n")
 	}
@@ -594,8 +607,14 @@ func WriteGraphConfig(vaultRoot string) error {
 	return os.WriteFile(filepath.Join(cfgDir, "graph.json"), []byte(graphJSONTemplate()), 0o644)
 }
 
-func sanitizeFilename(s string) string {
+// PLACEHOLDER maps an entity label to a filename-safe note name. It is
+// the single authority for entity note naming: ExportObsidian writes notes
+// with it and every wikilink to an entity must use it, or the link will not
+// resolve in Obsidian. Covers the characters Obsidian's link syntax and
+// Windows filenames both reject, and trims trailing dots/spaces.
+func SanitizeFilename(s string) string {
 	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", "*", "-",
-		"?", "-", "\"", "-", "<", "-", ">", "-", "|", "-", " ", "_")
-	return r.Replace(s)
+		"?", "-", "\"", "-", "<", "-", ">", "-", "|", "-",
+		"#", "-", "^", "-", "[", "-", "]", "-", " ", "_")
+	return strings.TrimRight(r.Replace(s), ". ")
 }

--- a/cmd/graymatter/internal/kg/graph_test.go
+++ b/cmd/graymatter/internal/kg/graph_test.go
@@ -3,6 +3,7 @@ package kg
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -247,6 +248,37 @@ func TestExportObsidian(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
 			t.Errorf("node file %q missing: %v", name, err)
 		}
+	}
+}
+
+// TestExportObsidian_RelatedLinksResolve pins the property users actually
+// consume: every [[wikilink]] in a Related section must name a file that
+// exists in the vault, or Obsidian drops the edge from the graph view.
+func TestExportObsidian_RelatedLinksResolve(t *testing.T) {
+	g, cleanup := openTestGraph(t)
+	defer cleanup()
+
+	_ = g.Upsert(Node{ID: "maria", Label: "Maria", EntityType: "person"})
+	_ = g.Upsert(Node{ID: "acme", Label: "Acme Corp", EntityType: "organization"})
+	_ = g.Link(Edge{From: "maria", To: "acme", Relation: "works_at"})
+
+	outDir := t.TempDir()
+	if err := g.ExportObsidian(outDir); err != nil {
+		t.Fatalf("ExportObsidian: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outDir, "Maria.md"))
+	if err != nil {
+		t.Fatalf("Maria.md missing: %v", err)
+	}
+	if !strings.Contains(string(data), "[[Acme_Corp|Acme Corp]]") {
+		t.Errorf("Related link not in resolvable label form:\n%s", data)
+	}
+	if strings.Contains(string(data), "[[acme]]") {
+		t.Errorf("Related link still uses the raw node ID:\n%s", data)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "Acme_Corp.md")); err != nil {
+		t.Errorf("linked note missing from vault: %v", err)
 	}
 }
 

--- a/cmd/graymatter/internal/kg/wikilinks.go
+++ b/cmd/graymatter/internal/kg/wikilinks.go
@@ -18,7 +18,7 @@ func EntityWikilinkTargets(text string) []string {
 		if n.ID == "" {
 			continue
 		}
-		target := sanitizeFilename(n.Label)
+		target := SanitizeFilename(n.Label)
 		if target == "" || seen[target] {
 			continue
 		}

--- a/cmd/graymatter/kg_linkpass.go
+++ b/cmd/graymatter/kg_linkpass.go
@@ -6,23 +6,23 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/export"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
-
-// entityNoteFilename mirrors kg.sanitizeFilename for entity note filenames.
-func entityNoteFilename(label string) string {
-	return strings.NewReplacer("/", "-", "\\", "-", ":", "-", "*", "-",
-		"?", "-", "\"", "-", "<", "-", ">", "-", "|", "-", " ", "_").Replace(label)
-}
 
 // linkFactNotesToEntities appends an "## Entities" section with wikilinks to
 // every exported fact note, closing the bidirectional fact<->entity layer:
 // the Obsidian graph view then draws facts AND entities as one connected
 // web. Idempotent — a note already carrying the section is left untouched.
+//
+// Note naming is delegated entirely to the export package (fact notes) and
+// kg.SanitizeFilename (entity notes): this pass owns no naming logic of its
+// own, so the writer and the linker can never drift apart again.
 func linkFactNotesToEntities(outDir string, facts []memory.Fact) error {
+	names := export.BuildFactNoteNames(facts)
 	for _, f := range facts {
-		path := filepath.Join(outDir, entityNoteFilename(f.AgentID), f.ID+".md")
+		path := filepath.Join(outDir, export.AgentDirName(f.AgentID), names[f.ID]+".md")
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue // fact was superseded away or filtered: nothing to link
@@ -38,7 +38,7 @@ func linkFactNotesToEntities(outDir string, facts []memory.Fact) error {
 		var section strings.Builder
 		section.WriteString("\n## Entities\n")
 		for _, t := range targets {
-			section.WriteString("- [[" + entityNoteFilename(t) + "]]\n")
+			section.WriteString("- [[" + kg.SanitizeFilename(t) + "]]\n")
 		}
 		trimmed := strings.TrimRight(content, "\n") + "\n"
 		if err := os.WriteFile(path, []byte(trimmed+section.String()), 0o644); err != nil {

--- a/docs/audits/2026-08-24-export-obsidian-status-hardening.md
+++ b/docs/audits/2026-08-24-export-obsidian-status-hardening.md
@@ -1,0 +1,126 @@
+# Audit: export / Obsidian vault / status reporting hardening
+
+**Date:** 2026-08-24 · **Scope:** `graymatter export` (all formats), the
+`--include-graph` Obsidian pipeline, `kg_linkpass`, and the `status` command's
+human reporting. Triggered by three user-visible failures found while producing
+marketing captures against a real vault (see verification section).
+
+Method: full read of `cmd/graymatter/internal/export/*`, `internal/kg/graph.go`
+(ExportObsidian path), `kg_linkpass.go`, `cmd_export.go`, `cmd_status.go`, and
+`internal/harness/token_usage.go`; every finding below is backed by a failing
+behaviour, not by style preference.
+
+## Findings
+
+### H1 · BLOCKER — `status` prints impossible cache-hit percentages
+
+`cmd_status.go` divides `CacheRead` by `Input + Output`:
+
+```go
+inOut := tok.Input + tok.Output
+... pct(tok.CacheRead, inOut) ...
+```
+
+Cache reads are part of the **input** side. On any cache-heavy workload the
+denominator is far smaller than the numerator, so the line prints values like
+`cache-read 430%`. The JSON path is unaffected — `harness.TokenUsageSummary`
+already computes `CacheHitRate = CacheRead / (Input + CacheRead)` correctly,
+which is why the TUI dashboard (84%) and `status` (430%) disagreed for the
+same store.
+
+**Fix:** denominator becomes `Input + CacheRead`, matching the harness.
+**Test:** unit test on `renderStatus` with a ledger where `CacheRead` is 9x
+`Input`; assert the line prints `90%`, not `900%`.
+
+### H2 · BLOCKER — knowledge-graph `## Related` links never resolve in Obsidian
+
+`kg/graph.go` names each entity note after its **label**:
+
+```go
+fname := sanitizeFilename(n.Label) + ".md"
+```
+
+but links related entities by their **raw node ID**:
+
+```go
+line := fmt.Sprintf("- [[%s]] (%s)", e.To, e.Relation)
+```
+
+`[[01M0RTKV…]]` matches no note, so every entity-to-entity edge in the graph
+is a broken link — and since Obsidian's graph view draws resolved links only,
+**the KG edges are invisible in the graph view of every real export**. The
+entities MOC already links correctly (`[[sanitizeFilename(label)|label]]`),
+which makes the inconsistency internal to the same function.
+
+**Fix:** build an ID→label map from the exported nodes and emit
+`[[sanitizeFilename(label)|Label]]`; fall back to the raw ID if a dangling
+edge references an unknown node.
+**Test:** export a two-node graph whose labels need sanitizing; assert the
+`## Related` target file exists on disk and the link uses the label form.
+
+### H3 · BLOCKER — fact notes are named by raw ULID
+
+`export/obsidian.go` writes `<agent>/<ULID>.md` and the index links
+`[[agent/<ULID>|preview]]`; `kg_linkpass.go` re-derives the same path
+independently. Consequences: Obsidian's graph view and quick-switcher show
+`01M0RTKV1182XM89SX4BQF4NCM` instead of the fact's text, and the fact layer
+of the graph is unreadable noise.
+
+**Fix:** derive note names from the fact text (sanitized, rune-safe length
+clamp, deterministic `-<short-id>` suffix only on collision or empty slug),
+computed by **one** function (`export.BuildFactNoteNames`) shared by the
+exporter, the index, and the link pass — eliminating the three-implementation
+drift that produced H2/H3 in the first place.
+**Tests:** names are readable; every index wikilink resolves to a file on
+disk; two facts with identical text get distinct files.
+
+### M1 · Moderate — index previews can emit invalid UTF-8
+
+`writeObsidianIndex` truncates previews by byte slicing (`preview[:77]`),
+which can split a multi-byte rune and write mojibake for any non-ASCII fact
+text. **Fix:** rune-aware truncation. **Test:** fact with accented text
+straddling the boundary; assert the index is valid UTF-8 with no replacement
+characters.
+
+### M2 · Moderate — the Obsidian index is not deterministic
+
+`writeObsidianIndex` ranges over a `map[string][]Fact`, so section order
+changes between runs on the same store. This contradicts the project's own
+determinism bar (`context-sync` guarantees "same store state, same block
+bytes"). **Fix:** sort agent sections alphabetically. **Test:** two exports
+of the same store produce byte-identical `_index.md`.
+
+### L1 · Low — `kg.sanitizeFilename` admits characters Obsidian and Windows reject
+
+The replacer covers `/\:*?"<>|` and spaces but not `#^[]` (Obsidian link
+syntax), and does not trim trailing dots/spaces (illegal on Windows). Labels
+differing only in case also collide on case-insensitive filesystems.
+**Fix:** extend the replacer, trim trailing `. ` characters. Case-collision
+dedup is out of scope here (entity labels colliding case-insensitively are
+renamed by the user at the source); noted for a future pass.
+
+### L2 · Low — filename logic lived in three places
+
+`export/obsidian.go`, `export` index, and `kg_linkpass.go` each derived note
+paths independently; kg_linkpass also duplicated kg's replacer as
+`entityNoteFilename`. This drift is the root cause that let H2 and H3 ship.
+**Fix:** `kg.SanitizeFilename` becomes exported and is the single entity-name
+authority; `export.BuildFactNoteNames` is the single fact-name authority;
+`kg_linkpass.go` consumes both and owns no naming logic.
+
+## Verified non-issues
+
+- The JSON `status` payload (uses harness `CacheHitRate`) — correct.
+- `graph-canvas.json` — canvas edges reference node IDs and canvas nodes are
+  keyed by the same IDs; internally consistent.
+- `MarkdownExporter` — per-agent files, no cross-references, unaffected.
+- `writeEntitiesMOC` — already links by sanitized label.
+
+## Adversary note
+
+H1–H3 were all caught outside of CI, on a real vault, by a human looking at
+the output. The export path had tests for file *existence* but none for link
+*resolution* — the property users actually consume. The tests added here pin
+resolution (every emitted wikilink must name a file that exists), naming
+(readable, collision-free), determinism (byte-identical re-exports), and the
+cache-hit arithmetic, so this class of regression cannot silently return.


### PR DESCRIPTION
﻿## Summary

Deep-hardening pass over the export / Obsidian vault / status reporting surface, triggered by three user-visible failures caught on a real vault while producing marketing captures. Full findings and method in docs/audits/2026-08-24-export-obsidian-status-hardening.md.

## Blockers fixed

**1. status printed impossible cache-hit percentages.** The human line divided CacheRead by Input + Output; on cache-heavy workloads that yields cache-read 430% while the TUI dashboard showed the correct 84% for the same store. Now divides by the input side (Input + CacheRead), matching the harness ledger. The JSON path was already correct.

**2. Knowledge-graph ## Related links never resolved in Obsidian.** Entity notes are named after their sanitized label, but Related sections linked the raw node ID ([[01M0RTKV...]]), so every KG edge was a broken link — and Obsidian's graph view only draws resolved links, meaning **the knowledge graph was invisible in every real export**. Links now use the label form; the export test had pinned the broken form and now asserts resolution to an existing file.

**3. Fact notes were named by raw ULID.** <agent>/01M0RTKV....md made the fact layer of the graph and the quick switcher unreadable. Names now derive from the fact text via export.BuildFactNoteNames — one authority shared by the exporter, the index, and kg_linkpass (which previously re-derived paths with drifting logic; that drift is the root cause behind findings 2 and 3).

## Also fixed

- **Rune-safe previews**: index previews truncated by byte could split multi-byte characters and write invalid UTF-8 for non-ASCII facts.
- **Deterministic index**: agent sections were map-ordered, so the same store exported to different bytes each run — against the project's own determinism bar (context-sync).
- **kg.SanitizeFilename hardened + exported**: covers Obsidian link characters (#^[]), trims trailing dots/spaces (Windows), and is now the single entity-naming authority.

## Tests

New: link resolution (every emitted wikilink must name an existing file), readable/collision-free/deterministic fact naming, rune-safe previews, byte-identical re-exports, cache-hit arithmetic. Updated the export graph test that was pinning the broken raw-ID link form.

Full suite green: go test -count=1 ./... in cmd/graymatter (15 pkgs) + ./pkg/memory/.... Verified end-to-end against a real 320-fact / 102-entity store.

## Out of scope (flagged for follow-up)

- The extractor promotes stopwords like "The" to entities when a sentence starts with a proper-noun pattern — extraction quality, not export.
- Case-insensitive filename collisions between entity labels on Windows filesystems.
- status prints in ~0k for sub-kilo token totals (integer division, cosmetic).
