### PR TITLE
ci(docs): path-scoped Actions deploy, previews only for doc-touching PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -66,4 +66,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: www
-          command: versions upload --message "docs preview for PR #${{ github.event.number }}"
+          command: versions upload --message docs-preview-pr-${{ github.event.number }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,69 @@
+name: docs
+
+# Deploys the documentation site only when something it renders changes.
+# Code-only PRs never trigger this workflow: the docs are a render of
+# www/ (site) + docs/ (canonical content), so those are the only paths
+# that can change the output.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'www/**'
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  pull_request:
+    paths:
+      - 'www/**'
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: www/package-lock.json
+
+      - name: Install
+        working-directory: www
+        run: npm ci
+
+      - name: Build
+        working-directory: www
+        run: npm run build
+
+      # main: promote straight to the active deployment.
+      - name: Publish (main)
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: www
+          command: deploy
+
+      # PRs: upload a version and get a preview URL without touching
+      # production traffic. The URL lands in this step's log and in the
+      # Worker's Version History.
+      - name: Preview (PR)
+        if: github.event_name == 'pull_request'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: www
+          command: versions upload --message "docs preview for PR #${{ github.event.number }}"

--- a/www/README.md
+++ b/www/README.md
@@ -21,12 +21,18 @@ npm run deploy     # build + wrangler deploy (manual deploys)
 
 ## Deployment
 
-CI deploys via Cloudflare Workers Builds (Git integration): every push to
-`main` runs the build command and `npx wrangler deploy`. Non-production
-branches get preview builds.
+Deploys run through GitHub Actions (`.github/workflows/deploy-docs.yml`) and
+only trigger when `www/`, `docs/`, or the workflow itself changes:
+
+- push to `main` → `wrangler deploy` (promotes to the active deployment)
+- PRs touching those paths → `wrangler versions upload` (preview URL in the
+  step log, production untouched)
+
+Requires the repo secrets `CLOUDFLARE_API_TOKEN` (template "Edit Cloudflare
+Workers") and `CLOUDFLARE_ACCOUNT_ID`.
 
 Config lives in `wrangler.jsonc` — assets-only, no Worker code. The Worker
-`name` must match the Worker created in the Cloudflare dashboard.
+`name` must match the Worker registered in the Cloudflare dashboard.
 
 The canonical `site` URL in `astro.config.mjs` feeds the sitemap and
 `llms.txt`; update it after the first deploy or when attaching a custom


### PR DESCRIPTION
﻿## Summary

Replaces the Workers Builds Git integration with a path-scoped GitHub Actions workflow (.github/workflows/deploy-docs.yml). This is the fix for the preview-build failures and the guard against every future one.

## Why not just fix the Workers Builds command

Two reasons, both structural:

1. **Workers Builds has no path filters.** Every PR — including pure-Go ones that cannot change the docs output — would build and upload a docs version. Path-scoped CI is the standard: build only what changed.
2. **The deploy config lived in dashboard defaults, not in the repo.** The failure we hit (ersions upload running from the repo root, away from wrangler.jsonc) was invisible config drift between dashboard and repository. Deploy config belongs in review like everything else.

## Behaviour

| Event | Trigger | Action |
|---|---|---|
| Push to main touching www/ or docs/ | paths filter | wrangler deploy → active deployment |
| PR touching www/ or docs/ | paths filter | wrangler versions upload → preview URL in step log, production untouched |
| Code-only PR | — | workflow never runs, no checks, no noise |

## Setup (one-time, before merge)

1. Cloudflare dash → My Profile → API Tokens → Create Token → template **Edit Cloudflare Workers**
2. Repo → Settings → Secrets and variables → Actions → add CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID (dash → Workers & Pages → right sidebar)
3. Merge this PR and verify the first run goes green
4. Then disconnect Workers Builds: Worker graymatter → Settings → Builds → Disconnect (otherwise both pipelines deploy)

## Verification

- Local: cd www && npm ci && npm run build green (same commands the workflow runs).
- First production run after merge should show wrangler deploy uploading www/dist (22 pages) and promoting to graymatter.nickcerutti.workers.dev.
