### PR TITLE
fix(tui): graph viewport overflow, done-session styling, dead detail pane

### DIFF
--- a/cmd/graymatter/cmd_tui.go
+++ b/cmd/graymatter/cmd_tui.go
@@ -325,6 +325,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.nodeList.SetItems(items)
 		m.kgEdgeCount = msg.edges
 		m.kgOrphans = msg.orphans
+		if sel, ok := m.nodeList.SelectedItem().(nodeItem); ok {
+			m.nodeDetail.SetContent(formatNodeDetail(sel.n))
+		}
 
 	case dashboardLoadedMsg:
 		m.dashboard = msg.data
@@ -364,6 +367,12 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd1, cmd2 tea.Cmd
 		m.nodeList, cmd1 = m.nodeList.Update(msg)
 		m.nodeDetail, cmd2 = m.nodeDetail.Update(msg)
+		// Keep the detail pane in sync with the highlighted node.
+		if _, isKey := msg.(tea.KeyMsg); isKey {
+			if sel, ok := m.nodeList.SelectedItem().(nodeItem); ok {
+				m.nodeDetail.SetContent(formatNodeDetail(sel.n))
+			}
+		}
 		cmds = append(cmds, cmd1, cmd2)
 	}
 
@@ -663,8 +672,18 @@ func (m *tuiModel) updateSizes() {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-func formatFactDetail(f memory.Fact) string {
+func formatNodeDetail(n kg.Node) string {
 	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Entity:  %s\n", n.Label))
+	sb.WriteString(fmt.Sprintf("Type:    %s\n", n.EntityType))
+	sb.WriteString(fmt.Sprintf("ID:      %s\n", n.ID))
+	sb.WriteString(fmt.Sprintf("Weight:  %.4f\n", n.Weight))
+	sb.WriteString(fmt.Sprintf("First:   %s\n", n.FirstSeen.Format("2006-01-02 15:04")))
+	sb.WriteString(fmt.Sprintf("Last:    %s\n", n.LastSeen.Format("2006-01-02 15:04")))
+	return sb.String()
+}
+
+func formatFactDetail(f memory.Fact) string {	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("ID:      %s\n", f.ID))
 	sb.WriteString(fmt.Sprintf("Agent:   %s\n", f.AgentID))
 	sb.WriteString(fmt.Sprintf("Created: %s\n", f.CreatedAt.Format("2006-01-02 15:04:05")))

--- a/cmd/graymatter/cmd_tui.go
+++ b/cmd/graymatter/cmd_tui.go
@@ -80,8 +80,8 @@ func statusStyle(status string) string {
 	switch status {
 	case "running":
 		return styleStatusOK.Render("● running")
-	case "success":
-		return styleStatusOK.Render("✓ success")
+	case "success", "done": // the runner writes "done" for completed runs
+		return styleStatusOK.Render("✓ " + status)
 	case "failed", "killed":
 		return styleStatusFail.Render("✗ " + status)
 	default:
@@ -622,10 +622,13 @@ func (m tuiModel) renderGraph(h int) string {
 	stats := styleDimText.Render(fmt.Sprintf(
 		"  entities: %d · edges: %d · orphans: %d",
 		len(m.nodeList.Items()), m.kgEdgeCount, m.kgOrphans))
+	// The stats block costs 5 screen rows (3 content + 2 border). The panes
+	// must discount them or the tab overflows the viewport and pushes the
+	// header off screen — h-7 content + 2 border + 5 = h, an exact fit.
 	header := styleBorderInactive.Width(m.width - 4).Height(3).Render(stats)
 	body := lipgloss.JoinHorizontal(lipgloss.Top,
-		styleBorderInactive.Width(leftW-2).Height(h-5).Render(m.nodeList.View()),
-		styleBorderInactive.Width(m.width-leftW-4).Height(h-5).Render(m.nodeDetail.View()))
+		styleBorderInactive.Width(leftW-2).Height(h-7).Render(m.nodeList.View()),
+		styleBorderInactive.Width(m.width-leftW-4).Height(h-7).Render(m.nodeDetail.View()))
 	return lipgloss.JoinVertical(lipgloss.Left, header, body)
 }
 
@@ -650,9 +653,12 @@ func (m *tuiModel) updateSizes() {
 	m.sessionList.SetSize(m.width-6, listH)
 
 	leftW := m.width * 2 / 5
-	m.nodeList.SetSize(leftW-4, listH)
+	// Graph-tab panes sit under a 5-row stats header the other tabs don't
+	// have, so their lists get 3 rows less than the shared listH (see
+	// renderGraph for the arithmetic).
+	m.nodeList.SetSize(leftW-4, listH-3)
 	m.nodeDetail.Width = m.width - leftW - 6
-	m.nodeDetail.Height = listH
+	m.nodeDetail.Height = listH - 3
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/cmd/graymatter/cmd_tui_test.go
+++ b/cmd/graymatter/cmd_tui_test.go
@@ -34,7 +34,7 @@ func TestTUI_DeleteAllowedInWriteMode(t *testing.T) {
 		readOnly: false,
 		memPane:  memPaneFacts,
 		// factList and agentList are zero-value: SelectedItem() returns nil,
-		// so the inner delete block is skipped — but no status is set either.
+		// so the inner delete block is skipped â€” but no status is set either.
 	}
 
 	_ = m.updateMemoryKey(keyMsg('d'))
@@ -65,5 +65,21 @@ func TestTUI_KillAllowedInWriteMode(t *testing.T) {
 
 	if strings.Contains(m.status, "read-only") {
 		t.Errorf("write-mode 'k' should not set read-only status, got %q", m.status)
+	}
+}
+
+// The runner writes "done" for completed sessions; statusStyle used to have
+// a case only for "success", so finished runs rendered as pending (?).
+func TestStatusStyle_RunnerDoneIsGreen(t *testing.T) {
+	got := statusStyle("done")
+	check, pending := string(rune(0x2713)), string(rune(0x25CB))
+	if strings.Contains(got, pending) {
+		t.Errorf("done rendered as pending: %q", got)
+	}
+	if !strings.Contains(got, check) || !strings.Contains(got, "done") {
+		t.Errorf("done should render with a check mark: %q", got)
+	}
+	if got := statusStyle("running"); !strings.Contains(got, "running") {
+		t.Errorf("running mangled: %q", got)
 	}
 }

--- a/cmd/graymatter/tui_capture_test.go
+++ b/cmd/graymatter/tui_capture_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -11,6 +12,7 @@ import (
 	"github.com/muesli/termenv"
 
 	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
 )
 
 // captureDir is where the ANSI dumps land. Unset, the test only logs, so it is
@@ -184,3 +186,43 @@ var errCaptureDead = errCapture{}
 type errCapture struct{}
 
 func (errCapture) Error() string { return "connection is shut down" }
+
+// TestTUI_GraphTabFitsViewport pins the whole-screen invariant: whatever the
+// tab, View() must never render more lines than the terminal height, and the
+// header (logo + tab bar) must stay visible. The Graph tab used to overflow
+// because its stats header (3 rows) was never discounted from the pane
+// heights, pushing the header off the top of the screen.
+func TestTUI_GraphTabFitsViewport(t *testing.T) {
+	st := seedForCapture(t)
+	ds, ok := st.(*directStore)
+	if !ok {
+		t.Fatalf("expected *directStore")
+	}
+	g, err := kg.Open(ds.store.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, label := range []string{"bbolt", "chromem-go", "RRF", "daemon", "Obsidian", "MCP", "decay", "tombstone"} {
+		if err := g.Upsert(kg.Node{ID: label, Label: label, EntityType: "concept", Weight: 1 - float64(i)*0.05}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, size := range [][2]int{{124, 36}, {190, 44}, {100, 30}, {80, 24}} {
+		m := newCaptureTUI(t, st)
+		m.width, m.height = size[0], size[1]
+		m.activeTab = tabGraph
+		m.updateSizes()
+		m = loadAll(t, m, "")
+		out := m.View()
+		lines := strings.Count(out, "\n") + 1
+		if lines > m.height {
+			t.Errorf("graph tab at %dx%d renders %d lines (viewport %d)", m.width, m.height, lines, m.height)
+		}
+		if !strings.Contains(out, "GRAYMATTER") {
+			t.Errorf("graph tab at %dx%d lost the header", m.width, m.height)
+		}
+		if !strings.Contains(out, "1-4") {
+			t.Errorf("graph tab at %dx%d lost the footer", m.width, m.height)
+		}
+	}
+}

--- a/cmd/graymatter/tui_capture_test.go
+++ b/cmd/graymatter/tui_capture_test.go
@@ -224,5 +224,9 @@ func TestTUI_GraphTabFitsViewport(t *testing.T) {
 		if !strings.Contains(out, "1-4") {
 			t.Errorf("graph tab at %dx%d lost the footer", m.width, m.height)
 		}
+		// The detail pane must show the highlighted node, never dead space.
+		if !strings.Contains(out, "Entity:") {
+			t.Errorf("graph tab at %dx%d has an empty detail pane", m.width, m.height)
+		}
 	}
 }


### PR DESCRIPTION
﻿## Summary

Three TUI fixes found while producing a GIF, each with a regression test:

**1. Graph tab overflowed the viewport (constant, every size).** 
enderGraph adds a 5-row stats header the other tabs don't have, but updateSizes gave its lists the shared height — the tab rendered 2 lines past the viewport and pushed the header and tab bar off screen. The panes now discount the stats block and the graph lists get their own size. Pinned by TestTUI_GraphTabFitsViewport: renders the tab with a populated graph across four viewport sizes and asserts the screen fits with header and footer intact.

**2. statusStyle colored a state that never exists.** It had a case for success, but the runner writes done — completed sessions fell through to the pending style and looked identical to in-progress ones. done now renders green with a check mark.

**3. Graph detail pane was permanently dead space.** 
odeDetail.SetContent was never called anywhere: the right half of the Graph tab rendered empty on entry and no keypress ever filled it. The pane now shows the highlighted entity on load and tracks j/k navigation.

## Verification

- go test ./... green (cmd/graymatter, 15 pkgs)
- New tests: viewport fit across 4 sizes with populated graph, header/footer presence, detail-pane population, done-vs-pending styling
- End-to-end: re-rendered the TUI tour against the fixed binary — the Graph tab segment now shows the full chrome and the Sessions segment shows done sessions in green

## Out of scope (noted)

- Extractor noise: bare URLs promoted to entities; John_Maynard_Keynes typed as act. Extraction-quality work, separate pass.
