### PR TITLE
feat(memory): consolidation propose/apply with tombstone receipts + local Ollama summariser

### DIFF
--- a/benchmarks/retrieval_quality/consolidation_test.go
+++ b/benchmarks/retrieval_quality/consolidation_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// The consolidation quality gate (hardening playbook W3, test plan item 5):
+// consolidation must not degrade retrieval of canonical facts on a
+// 500-fact store. The summariser under test is a *lossless* local merge —
+// every consumed fact's text enters the summary verbatim — so this measures
+// the mechanism itself (tombstone receipts + summary replacement), not the
+// eloquence of any model. A regression here means the pipeline loses what it
+// was given, which no amount of model quality can excuse.
+//
+// Deterministic: frozen store clock, keyword embedder, scripted HTTP
+// summariser. No network, no key, no Ollama install required.
+
+const (
+	gateAgent      = "gate-agent"
+	canonicalCount = 50
+	fillerCount    = 450
+	consolidations = 6
+)
+
+var promptRowRe = regexp.MustCompile(`^- ([0-9A-Za-z]+): (.*)$`)
+
+type gateRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+func TestConsolidationGate_CanonicalRecallDoesNotRegress(t *testing.T) {
+	// Scripted lossless summariser: consume everything shown, echo every
+	// shown text into one paragraph.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req gateRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		var texts []string
+		var ids []string
+		for _, line := range strings.Split(req.Prompt, "\n") {
+			if m := promptRowRe.FindStringSubmatch(line); m != nil {
+				ids = append(ids, m[1])
+				texts = append(texts, m[2])
+			}
+		}
+		if len(ids) == 0 {
+			t.Errorf("summariser received no parsable rows:\n%s", req.Prompt)
+		}
+		summary := "consolidated digest: " + strings.Join(texts, " | ")
+		prop, _ := json.Marshal(map[string]any{"summary": summary, "consumes": ids})
+		env, _ := json.Marshal(map[string]any{"response": string(prop)})
+		_, _ = w.Write(env)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	s, err := memory.Open(memory.StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+	type canon struct{ text, marker string }
+	canonicals := make([]canon, 0, canonicalCount)
+	for i := 0; i < fillerCount; i++ {
+		txt := fmt.Sprintf("session note %d: reviewed dashboard metrics and filed routine follow-ups", i)
+		if err := s.Put(ctx, gateAgent, txt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < canonicalCount; i++ {
+		marker := fmt.Sprintf("QEDX-%04d", i)
+		txt := fmt.Sprintf("binding decision %s: deploy %s only through the signed release channel", marker, marker)
+		canonicals = append(canonicals, canon{text: txt, marker: marker})
+		if err := s.Put(ctx, gateAgent, txt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	recallHits := func() float64 {
+		hits := 0
+		for _, c := range canonicals {
+			res, err := s.Recall(ctx, gateAgent, c.marker, 8)
+			if err != nil {
+				t.Fatalf("recall %s: %v", c.marker, err)
+			}
+			for _, got := range res {
+				if strings.Contains(got, c.marker) {
+					hits++
+					break
+				}
+			}
+		}
+		return float64(hits) / float64(len(canonicals))
+	}
+
+	before := recallHits()
+
+	cfg := &gateConsolidateCfg{
+		llm:       "ollama",
+		ollamaURL: srv.URL,
+		threshold: 40,
+	}
+	for cycle := 0; cycle < consolidations; cycle++ {
+		if err := s.Consolidate(ctx, gateAgent, cfg); err != nil {
+			t.Fatalf("cycle %d: %v", cycle, err)
+		}
+	}
+
+	after := recallHits()
+
+	cycles, _ := s.ConsolidationCounters()
+	if cycles == 0 {
+		t.Fatal("gate ran no consolidations; nothing was measured")
+	}
+	t.Logf("canonical recall@8 before=%.3f after=%.3f across %d applied cycles (%d facts seeded)",
+		before, after, cycles, canonicalCount+fillerCount)
+
+	if after < before {
+		t.Errorf("consolidation regressed canonical recall@8: %.3f -> %.3f", before, after)
+	}
+}
+
+// gateConsolidateCfg satisfies memory.ConsolidateConfig for the gate.
+type gateConsolidateCfg struct {
+	llm       string
+	ollamaURL string
+	threshold int
+}
+
+func (c *gateConsolidateCfg) GetAnthropicAPIKey() string        { return "" }
+func (c *gateConsolidateCfg) GetConsolidateLLM() string         { return c.llm }
+func (c *gateConsolidateCfg) GetConsolidateModel() string       { return "" }
+func (c *gateConsolidateCfg) GetConsolidateThreshold() int      { return c.threshold }
+func (c *gateConsolidateCfg) GetDecayHalfLife() time.Duration   { return 720 * time.Hour }
+func (c *gateConsolidateCfg) GetOllamaURL() string              { return c.ollamaURL }
+func (c *gateConsolidateCfg) GetOllamaConsolidateModel() string { return "gate-mock" }

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -326,6 +326,9 @@ func checkStore(dir string) checkResult {
 		pending, _ := dc.PendingVectorCount()
 		c.Status = "ok"
 		c.Detail = fmt.Sprintf("served by daemon — %d fact(s) across %d agent(s)", facts, len(agents))
+		if ov, err := dc.StoreOverview(); err == nil {
+			c.Detail += fmt.Sprintf(" · consolidations %d (facts consolidated %d)", ov.Consolidations, ov.FactsConsumed)
+		}
 		if pending > 0 {
 			c.Status = "warn"
 			c.Detail += fmt.Sprintf(", %d pending vector write(s)", pending)
@@ -362,8 +365,9 @@ func checkStore(dir string) checkResult {
 		}
 	}
 	pending := store.PendingVectorCount()
+	cycles, consumed := store.ConsolidationCounters()
 	c.Status = "ok"
-	c.Detail = fmt.Sprintf("no daemon running — %d fact(s) across %d agent(s) (direct read)", facts, len(agents))
+	c.Detail = fmt.Sprintf("no daemon running — %d fact(s) across %d agent(s) (direct read) · consolidations %d (facts consolidated %d)", facts, len(agents), cycles, consumed)
 	if pending > 0 {
 		c.Status = "warn"
 		c.Detail += fmt.Sprintf(", %d pending vector write(s)", pending)

--- a/cmd/graymatter/cmd_status.go
+++ b/cmd/graymatter/cmd_status.go
@@ -137,6 +137,8 @@ func renderStatus(out io.Writer, view statusView) error {
 		ov.TotalAgents, ov.TotalLiveFacts, ov.TotalTombstones, pinnedTotal, avgWeight)
 	fmt.Fprintf(out, "           oldest fact %s · newest %s · pending vector ops: %d\n",
 		relTime(oldest), relTime(newest), ov.PendingVectorOps)
+	fmt.Fprintf(out, "           consolidations %d · facts consolidated %d\n",
+		ov.Consolidations, ov.FactsConsumed)
 
 	totalRecalls := 0
 	for _, a := range ov.Agents {
@@ -228,12 +230,15 @@ func pct(part, whole uint64) float64 {
 
 func encodeStatusJSON(out io.Writer, mode string, ov *daemon.StoreOverviewResponse, kg *daemon.KGStateResponse, tok harness.TokenUsageSummary, pinned int) error {
 	payload := struct {
-		Mode     string                        `json:"mode"`
-		Store    *daemon.StoreOverviewResponse `json:"store"`
-		KG       *daemon.KGStateResponse       `json:"kg"`
-		Tokens30 *harness.TokenUsageSummary    `json:"tokens_30d"`
-		Pinned   int                           `json:"pinned"`
-	}{Mode: mode, Store: ov, KG: kg, Tokens30: &tok, Pinned: pinned}
+		Mode           string                        `json:"mode"`
+		Store          *daemon.StoreOverviewResponse `json:"store"`
+		KG             *daemon.KGStateResponse       `json:"kg"`
+		Tokens30       *harness.TokenUsageSummary    `json:"tokens_30d"`
+		Pinned         int                           `json:"pinned"`
+		Consolidations int                           `json:"consolidations"`
+		FactsConsumed  int                           `json:"facts_consumed"`
+	}{Mode: mode, Store: ov, KG: kg, Tokens30: &tok, Pinned: pinned,
+		Consolidations: ov.Consolidations, FactsConsumed: ov.FactsConsumed}
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
 	return enc.Encode(payload)

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -28,6 +28,7 @@ import (
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/kg"
 	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 // HostServiceName is the net/rpc service name for the host-level service,
@@ -116,6 +117,8 @@ type StoreOverviewResponse struct {
 	TotalLiveFacts   int            `json:"total_live_facts"`
 	TotalTombstones  int            `json:"total_tombstones"`
 	PendingVectorOps int            `json:"pending_vector_ops"`
+	Consolidations   int            `json:"consolidations"`    // cycles that applied at least one proposal
+	FactsConsumed    int            `json:"facts_consumed"`    // batch facts tombstoned by those proposals
 	Agents           []AgentSummary `json:"agents"`
 }
 
@@ -326,6 +329,7 @@ func (h *Host) StoreOverview(req *StoreOverviewRequest, resp *StoreOverviewRespo
 		resp.Agents = append(resp.Agents, sum)
 	}
 	resp.PendingVectorOps = adv.PendingVectorCount()
+	resp.Consolidations, resp.FactsConsumed = memory.ReadConsolidationCounters(h.db)
 	return nil
 }
 

--- a/cmd/graymatter/internal/server/server_test.go
+++ b/cmd/graymatter/internal/server/server_test.go
@@ -49,11 +49,13 @@ func (u unreadyStore) Ready() error { return u.err }
 
 type testConsolidateCfg struct{}
 
-func (testConsolidateCfg) GetAnthropicAPIKey() string      { return os.Getenv("ANTHROPIC_API_KEY") }
-func (testConsolidateCfg) GetConsolidateLLM() string       { return "anthropic" }
-func (testConsolidateCfg) GetConsolidateModel() string     { return "claude-haiku-4-5-20251001" }
-func (testConsolidateCfg) GetConsolidateThreshold() int    { return 20 }
-func (testConsolidateCfg) GetDecayHalfLife() time.Duration { return 168 * time.Hour }
+func (testConsolidateCfg) GetAnthropicAPIKey() string        { return os.Getenv("ANTHROPIC_API_KEY") }
+func (testConsolidateCfg) GetConsolidateLLM() string         { return "anthropic" }
+func (testConsolidateCfg) GetConsolidateModel() string       { return "claude-haiku-4-5-20251001" }
+func (testConsolidateCfg) GetConsolidateThreshold() int      { return 20 }
+func (testConsolidateCfg) GetDecayHalfLife() time.Duration   { return 168 * time.Hour }
+func (testConsolidateCfg) GetOllamaURL() string              { return "" }
+func (testConsolidateCfg) GetOllamaConsolidateModel() string { return "" }
 
 // startTestServer starts the REST server on a random free port and returns
 // the base URL + a cleanup function that shuts it down.

--- a/cmd/graymatter/kg_e2e_direct_test.go
+++ b/cmd/graymatter/kg_e2e_direct_test.go
@@ -14,11 +14,13 @@ import (
 // kgTestConfig satisfies memory.ConsolidateConfig with deterministic values.
 type kgTestConfig struct{}
 
-func (c *kgTestConfig) GetAnthropicAPIKey() string      { return "" }
-func (c *kgTestConfig) GetConsolidateLLM() string       { return "" }
-func (c *kgTestConfig) GetConsolidateModel() string     { return "" }
-func (c *kgTestConfig) GetConsolidateThreshold() int    { return 100 }
-func (c *kgTestConfig) GetDecayHalfLife() time.Duration { return 720 * time.Hour }
+func (c *kgTestConfig) GetAnthropicAPIKey() string        { return "" }
+func (c *kgTestConfig) GetConsolidateLLM() string         { return "" }
+func (c *kgTestConfig) GetConsolidateModel() string       { return "" }
+func (c *kgTestConfig) GetConsolidateThreshold() int      { return 100 }
+func (c *kgTestConfig) GetDecayHalfLife() time.Duration   { return 720 * time.Hour }
+func (c *kgTestConfig) GetOllamaURL() string              { return "" }
+func (c *kgTestConfig) GetOllamaConsolidateModel() string { return "" }
 
 // TestKGEndToEnd_DirectMode is the acceptance run for knowledge-graph
 // auto-population, exercised through the real shipped stack in direct mode:

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -348,6 +348,7 @@ func (d *directStore) StoreOverview() (*daemon.StoreOverviewResponse, error) {
 		resp.Agents = append(resp.Agents, sum)
 	}
 	resp.PendingVectorOps = d.store.PendingVectorCount()
+	resp.Consolidations, resp.FactsConsumed = memory.ReadConsolidationCounters(d.store.DB())
 	return resp, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -47,6 +47,11 @@ type Config struct {
 	// Default: value of GRAYMATTER_OLLAMA_MODEL env var, or "nomic-embed-text"
 	OllamaModel string
 
+	// OllamaConsolidateModel is the local model used for consolidation
+	// summarisation when ConsolidateLLM is "ollama".
+	// Default: value of GRAYMATTER_OLLAMA_CONSOLIDATE_MODEL env var, or "llama3.2"
+	OllamaConsolidateModel string
+
 	// AnthropicAPIKey for the Anthropic embeddings and consolidation endpoints.
 	// Default: value of ANTHROPIC_API_KEY env var.
 	AnthropicAPIKey string
@@ -135,21 +140,22 @@ type Config struct {
 // variables and runtime probes. Safe to call multiple times.
 func DefaultConfig() Config {
 	return Config{
-		DataDir:              ".graymatter",
-		TopK:                 8,
-		EmbeddingMode:        EmbeddingAuto,
-		OllamaURL:            envOrDefault("GRAYMATTER_OLLAMA_URL", "http://localhost:11434"),
-		OllamaModel:          envOrDefault("GRAYMATTER_OLLAMA_MODEL", "nomic-embed-text"),
-		AnthropicAPIKey:      os.Getenv("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:         os.Getenv("OPENAI_API_KEY"),
-		OpenAIModel:          envOrDefault("GRAYMATTER_OPENAI_MODEL", "text-embedding-3-small"),
-		ConsolidateLLM:       resolveConsolidateLLM(),
-		ConsolidateModel:     "claude-haiku-4-5-20251001",
-		ConsolidateThreshold: 20,
+		DataDir:                 ".graymatter",
+		TopK:                    8,
+		EmbeddingMode:           EmbeddingAuto,
+		OllamaURL:               envOrDefault("GRAYMATTER_OLLAMA_URL", "http://localhost:11434"),
+		OllamaModel:             envOrDefault("GRAYMATTER_OLLAMA_MODEL", "nomic-embed-text"),
+		OllamaConsolidateModel:  envOrDefault("GRAYMATTER_OLLAMA_CONSOLIDATE_MODEL", "llama3.2"),
+		AnthropicAPIKey:         os.Getenv("ANTHROPIC_API_KEY"),
+		OpenAIAPIKey:            os.Getenv("OPENAI_API_KEY"),
+		OpenAIModel:             envOrDefault("GRAYMATTER_OPENAI_MODEL", "text-embedding-3-small"),
+		ConsolidateLLM:          resolveConsolidateLLM(),
+		ConsolidateModel:        "claude-haiku-4-5-20251001",
+		ConsolidateThreshold:    20,
 		VectorReconcileInterval: 30 * time.Second,
-		DecayHalfLife:        720 * time.Hour,
-		AsyncConsolidate:       true,
-		MaxAsyncConsolidations: 2,
+		DecayHalfLife:           720 * time.Hour,
+		AsyncConsolidate:        true,
+		MaxAsyncConsolidations:  2,
 	}
 }
 
@@ -182,8 +188,10 @@ func envOrDefault(key, def string) string {
 // Config implements memory.ConsolidateConfig so it can be passed directly
 // to Store.Consolidate / Store.MaybeConsolidate without an adapter.
 
-func (c Config) GetAnthropicAPIKey() string      { return c.AnthropicAPIKey }
-func (c Config) GetConsolidateLLM() string       { return c.ConsolidateLLM }
-func (c Config) GetConsolidateModel() string     { return c.ConsolidateModel }
-func (c Config) GetConsolidateThreshold() int    { return c.ConsolidateThreshold }
-func (c Config) GetDecayHalfLife() time.Duration { return c.DecayHalfLife }
+func (c Config) GetAnthropicAPIKey() string        { return c.AnthropicAPIKey }
+func (c Config) GetConsolidateLLM() string         { return c.ConsolidateLLM }
+func (c Config) GetConsolidateModel() string       { return c.ConsolidateModel }
+func (c Config) GetOllamaURL() string              { return c.OllamaURL }
+func (c Config) GetOllamaConsolidateModel() string { return c.OllamaConsolidateModel }
+func (c Config) GetConsolidateThreshold() int      { return c.ConsolidateThreshold }
+func (c Config) GetDecayHalfLife() time.Duration   { return c.DecayHalfLife }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -614,8 +614,15 @@ export ANTHROPIC_API_KEY=sk-ant-...    # Anthropic embeddings + consolidation LL
 ollama pull nomic-embed-text
 export GRAYMATTER_OLLAMA_URL=http://localhost:11434     # optional override
 export GRAYMATTER_OLLAMA_MODEL=nomic-embed-text         # optional override
+export GRAYMATTER_OLLAMA_CONSOLIDATE_MODEL=llama3.2     # local consolidation summariser (ADR-011)
 export GRAYMATTER_OPENAI_MODEL=text-embedding-3-small   # optional override
 ```
+
+Consolidation (`ConsolidateLLM`) accepts `"anthropic"` (needs
+`ANTHROPIC_API_KEY`) or `"ollama"` — fully local, no key. With Ollama, each
+applied cycle replaces the weakest half of an agent's facts with one summary;
+the consumed facts stay auditable as tombstones pointing at the summary, and
+`status` reports the running totals (`consolidations`, `facts_consumed`).
 
 ### Key config fields ([`config.go`](../config.go))
 

--- a/docs/decisions/011-consolidation-propose-apply.md
+++ b/docs/decisions/011-consolidation-propose-apply.md
@@ -1,0 +1,91 @@
+# 011 — Consolidation is propose/apply with tombstone receipts; Ollama is the offline summariser
+
+**Status:** Accepted — **Date:** 2026-08-25
+
+## Context
+
+Three audit findings converged on one subsystem:
+
+- **A5** — the summarisation step replaced its batch with a **hard delete**
+  (`s.Delete`), making consolidation the single code path that violated
+  ADR-007's "tombstones, never delete". A summary that dropped a detail the
+  user considered key destroyed the evidence of what had been there.
+- **A6** — `ConsolidateLLM="ollama"` was accepted by config and rejected by
+  runtime (`ErrConsolidateLLMUnsupported`): a store could be configured for
+  fully-local intelligence and silently never get any.
+- **A7** — every cycle re-extracted every surviving fact into the knowledge
+  graph. Idempotent, but O(facts) per cycle forever, and a real cost once the
+  extractor is an LLM.
+
+The playbook's constraint that shaped everything else: an LLM proposes,
+never applies. And W1's invariant I-1 already keeps pinned facts out of the
+batch, so no proposal can ever consume them.
+
+## Decision
+
+**Propose/apply.** The summariser returns a structured proposal:
+
+```json
+{"summary": "<paragraph>", "consumes": ["<fact-id>", ...], "contradictions": [...]}
+```
+
+Application is deterministic code, not model judgement:
+
+1. The summary enters with `Put`. If that fails, nothing else happens.
+2. `consumes` is **clamped to the batch** — the model may only consume what
+   it was shown. Hallucinated IDs are ignored; duplicate IDs consume once.
+3. Consumed facts become tombstones (`SupersededBy` → the *real* summary
+   fact's ID) and keep their post-decay weight. Zeroing their weight instead
+   would let the same cycle's prune step delete each receipt milliseconds
+   after writing it — receipts must outlive the cycle so `List`, export and
+   the TUI stay auditable. Ordinary decay collects them on schedule.
+4. A response that is not a valid proposal (malformed JSON after fence
+   stripping, empty summary, empty consumes) is **discarded**: hook fires,
+   store untouched, counters unmoved. A broken summariser degrades to the
+   exact behaviour of `ConsolidateLLM=""`.
+
+The Anthropic path predates structured proposals; whatever it returns is
+treated as consuming the whole batch — same semantics as before, now with
+receipts.
+
+**Ollama is implemented** as the local summariser: `/api/generate` with
+`"format":"json"` (sampler-level JSON constraint, not prompt hope), model
+from `GRAYMATTER_OLLAMA_CONSOLIDATE_MODEL` (default `llama3.2`). One retry,
+and only for transient failures — transport errors, 5xx, 408, 429. A 4xx is
+a deterministic rejection; retrying reproduces it. An unreachable Ollama
+surfaces through `OnConsolidateError`; the sentinel
+`ErrConsolidateLLMUnsupported` is retired (kept only so callers matching it
+still compile). Offline-first holds both ways: users without Ollama see no
+difference, users with Ollama need no account and no key.
+
+**Extraction watermark (A7).** The meta bucket records a SHA-256 text
+signature per extracted fact. A fact is re-extracted only when its text
+changed or its ID is new. Superseded facts are skipped entirely: since they
+stopped being deleted, the pass would otherwise feed retired content back
+into the graph — the graph mirrors recallable memory. Deleting a fact drops
+its signature with it.
+
+**Counters.** Each applied proposal bumps `consolidations` and
+`facts_consolidated` in the meta bucket; `status` (human and JSON),
+`StoreOverview`, and `doctor`'s store check surface them. What the product
+measures it can publish honestly.
+
+## Consequences
+
+- No consolidation path deletes anymore; ADR-007's append-only promise is
+  uniform across supersede and consolidate.
+- Summarisation quality is now bounded below by "no worse than disabled":
+  every failure mode lands on decay+prune-only behaviour.
+- Tombstones linger until decay collects them, so `List` overstates live
+  memory briefly; every consumer already filters by `IsSuperseded`.
+- Local-model output quality varies; the structured contract plus clamping
+  means the worst a bad model can do is nothing.
+
+## Reversal condition
+
+If real stores show summaries routinely dropping information users expected
+to survive (measurable via the recall-quality gate in
+`benchmarks/retrieval_quality/consolidation_test.go` against lossy mock
+summarisers), the next step is requiring the proposal to quote consumed fact
+IDs *verbatim inside the summary* before apply accepts it — turning the
+summary itself into a receipt-checkable artifact.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,6 +19,8 @@ consequences, reversal condition.
 | [007](007-supersede-tombstones.md) | Contradictions are resolved by tombstone, never by delete | Accepted |
 | [008](008-knowledge-graph-wiring.md) | Knowledge-graph auto-population ships gated (`--kg` / env) | Accepted |
 | [009](009-kg-sentinel-activation.md) | KG activation persists as data-dir state via `init --kg` | Accepted |
+| [010](010-pinned-facts.md) | Pinned facts are exempt from decay, pruning and summarisation | Accepted |
+| [011](011-consolidation-propose-apply.md) | Consolidation is propose/apply with tombstone receipts; Ollama summarises locally | Accepted |
 
 ## Writing a new one
 

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -1,30 +1,40 @@
 package memory
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	bolt "go.etcd.io/bbolt"
 )
 
-// ErrConsolidateLLMUnsupported is returned when ConsolidateLLM names a
-// provider that can embed but cannot yet summarise. Today that is "ollama":
-// it is a supported embedding backend, and configuring it as the consolidation
-// LLM is accepted by config but does nothing.
-//
-// It used to do nothing quietly. A store configured this way would run decay
-// and pruning forever and never summarise, with no error and no log line to
-// explain why memory kept growing. It now reaches OnConsolidateError like any
-// other consolidation failure.
+// Deprecated: ErrConsolidateLLMUnsupported is no longer returned. Ollama is
+// implemented as a consolidation summariser since v0.14.0; the sentinel is
+// kept for API compatibility with callers that matched on it. A configured
+// but unreachable Ollama now surfaces as the underlying network error via
+// OnConsolidateError.
 var ErrConsolidateLLMUnsupported = errors.New(
-	"consolidation LLM \"ollama\" is not implemented: Ollama works as an embedding " +
-		"backend but cannot summarise yet; set ConsolidateLLM to \"anthropic\" or \"\"")
+	"consolidation LLM \"ollama\" is implemented since v0.14.0; this sentinel " +
+		"is retained only for API compatibility and is never returned")
+
+// ErrInvalidProposal marks an LLM response that arrived intact but is not a
+// usable consolidation proposal — malformed JSON, missing summary, or an
+// empty consumes list. The proposal is discarded and the store is untouched;
+// OnConsolidateError carries this sentinel so callers can tell a bad model
+// output apart from a transport failure.
+var ErrInvalidProposal = errors.New("invalid consolidation proposal")
 
 // ConsolidateConfig is the subset of configuration used by consolidation.
 // Defined as an interface to avoid a circular import with the root package.
@@ -34,6 +44,11 @@ type ConsolidateConfig interface {
 	GetConsolidateModel() string
 	GetConsolidateThreshold() int
 	GetDecayHalfLife() time.Duration
+	// Ollama settings for the local consolidation summariser (W3). The
+	// embedder already carries GRAYMATTER_OLLAMA_URL; consolidation reuses it
+	// and adds its own model knob.
+	GetOllamaURL() string
+	GetOllamaConsolidateModel() string
 }
 
 // LaunchAsyncConsolidate starts MaybeConsolidate in a tracked, bounded goroutine.
@@ -133,28 +148,39 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 
 	// Step 2: LLM summarisation when enabled and threshold exceeded.
 	// Strictly greater, unlike MaybeConsolidate's >= — see the note there.
+	//
+	// Propose/apply discipline (ADR-011): the LLM only ever proposes; the
+	// application is deterministic. A proposal that fails to arrive or fails
+	// validation is discarded with a hook and the store is untouched — decay
+	// and pruning already ran, so a broken summariser degrades to the exact
+	// behaviour of ConsolidateLLM="".
 	if len(facts) > cfg.GetConsolidateThreshold() && cfg.GetConsolidateLLM() != "" {
 		batch := summarisationBatch(facts)
 
-		summary, err := summariseFacts(ctx, batch, cfg)
-		if err != nil && s.cfg.OnConsolidateError != nil {
+		prop, err := summariseFacts(ctx, batch, cfg)
+		switch {
+		case err != nil:
 			// Report rather than swallow. Summarisation failing is not fatal —
-			// the facts are still there and decay still runs — but a caller
-			// who configured an LLM and is getting no summaries has no other
-			// way to find out. ErrConsolidateLLMUnsupported arrives here too,
-			// which is how a store configured for Ollama summarisation learns
-			// that it is not implemented instead of quietly doing nothing.
-			s.cfg.OnConsolidateError(agentID, err)
-		}
-		if err == nil && summary != "" {
-			// Only delete the batch if Put of the summary succeeds — never lose data.
-			if putErr := s.Put(ctx, agentID, summary); putErr == nil {
-				for _, f := range batch {
-					// Best-effort deletes; facts will be pruned by weight decay if delete fails.
-					_ = s.Delete(agentID, f.ID)
+			// the facts are still there — but a caller who configured an LLM
+			// and gets nothing back has no other way to find out. Unreachable
+			// Ollama and discarded proposals both arrive here; neither may
+			// touch the store.
+			if s.cfg.OnConsolidateError != nil {
+				s.cfg.OnConsolidateError(agentID, err)
+			}
+		case prop != nil:
+			applied, applyErr := s.applyProposal(ctx, agentID, batch, prop)
+			if applied > 0 {
+				if cErr := recordConsolidation(s.db, applied); cErr != nil && s.cfg.OnConsolidateError != nil {
+					s.cfg.OnConsolidateError(agentID, fmt.Errorf("record consolidation counters: %w", cErr))
 				}
 			}
+			if applyErr != nil && s.cfg.OnConsolidateError != nil {
+				s.cfg.OnConsolidateError(agentID, applyErr)
+			}
 		}
+		// prop == nil && err == nil: summariser produced nothing to apply by
+		// configuration (unknown provider name) — silence stays correct.
 	}
 
 	// Step 3: prune dead facts. Pinned facts are exempt (invariant I-1):
@@ -174,7 +200,12 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 		}
 	}
 
-	// Step 4: run entity extraction on all surviving facts and upsert into graph.
+	// Step 4: run entity extraction on surviving facts and upsert into graph.
+	//
+	// A text-signature watermark (A7) makes the pass incremental: a fact is
+	// extracted only when its text changed since the last successful pass.
+	// Extraction is idempotent, so the old re-extract-everything behaviour was
+	// correct but O(facts) per cycle for no information.
 	//
 	// Two paths, chosen by capability:
 	//   - TypedEntityExtractor + EdgeWriter: nodes keep the extractor's label
@@ -192,6 +223,19 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 
 		facts, _ = s.List(agentID)
 		for _, f := range facts {
+			// Superseded facts are retired: their content lives on in the
+			// fact (or summary) that replaced them. Extracting a tombstone
+			// would re-grow graph nodes for information that is no longer
+			// retrievable — the graph must mirror recallable memory, and
+			// since tombstones stopped being deleted this pass sees them.
+			if f.IsSuperseded() {
+				continue
+			}
+			sig := textSignature(f.Text)
+			if prev, ok := s.extractedSignature(agentID, f.ID); ok && prev == sig {
+				continue
+			}
+			clean := true
 			if typedOK && writeOK {
 				refs, links, extractErr := typed.ExtractTyped(f.Text)
 				if extractErr != nil {
@@ -199,6 +243,7 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 				}
 				for _, ref := range refs {
 					if upsertErr := graph.UpsertNode(ref.ID, ref.Label, ref.EntityType); upsertErr != nil {
+						clean = false
 						if s.cfg.OnConsolidateError != nil {
 							s.cfg.OnConsolidateError(agentID, fmt.Errorf("upsert node %s: %w", ref.ID, upsertErr))
 						}
@@ -206,10 +251,14 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 				}
 				for i := 0; i < len(links); i++ {
 					if linkErr := writer.LinkEdges([]EntityLink{links[i]}, f.ID); linkErr != nil {
+						clean = false
 						if s.cfg.OnConsolidateError != nil {
 							s.cfg.OnConsolidateError(agentID, fmt.Errorf("link edge: %w", linkErr))
 						}
 					}
+				}
+				if clean {
+					_ = s.markExtracted(agentID, f.ID, sig)
 				}
 				continue
 			}
@@ -220,15 +269,25 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 			}
 			for _, id := range ids {
 				if upsertErr := graph.UpsertNode(id, id, "concept"); upsertErr != nil {
+					clean = false
 					if s.cfg.OnConsolidateError != nil {
 						s.cfg.OnConsolidateError(agentID, fmt.Errorf("upsert node %s: %w", id, upsertErr))
 					}
 				}
 			}
+			if clean {
+				_ = s.markExtracted(agentID, f.ID, sig)
+			}
 		}
 	}
 
 	return nil
+}
+
+// textSignature fingerprints a fact's text for the extraction watermark.
+func textSignature(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return fmt.Sprintf("%x", sum)
 }
 
 // summarisationBatch selects the facts the LLM summariser may consume: the
@@ -250,30 +309,279 @@ func summarisationBatch(facts []Fact) []Fact {
 	return live[:len(live)/2]
 }
 
-func summariseFacts(ctx context.Context, facts []Fact, cfg ConsolidateConfig) (string, error) {
+// consolidationProposal is the structured output a consolidation summariser
+// must produce (ADR-011): the summary paragraph, the batch fact IDs the
+// summary fully accounts for, and any contradictions noticed along the way.
+// The LLM proposes this; applyProposal applies it deterministically.
+type consolidationProposal struct {
+	Summary        string   `json:"summary"`
+	Consumes       []string `json:"consumes"`
+	Contradictions []string `json:"contradictions,omitempty"`
+}
+
+// parseProposal validates a raw model response into a proposal. Fenced code
+// blocks are stripped because models emit them even when told not to; after
+// that the payload must be a strict JSON object with a non-empty summary and
+// at least one consumed ID — a proposal consuming nothing would grow memory
+// without retiring anything, which is not a consolidation.
+func parseProposal(raw string) (*consolidationProposal, error) {
+	var p consolidationProposal
+	if err := json.Unmarshal([]byte(stripCodeFence(raw)), &p); err != nil {
+		return nil, fmt.Errorf("%w: response is not a JSON object: %v", ErrInvalidProposal, err)
+	}
+	if strings.TrimSpace(p.Summary) == "" || len(p.Consumes) == 0 {
+		return nil, fmt.Errorf("%w: empty summary or empty consumes", ErrInvalidProposal)
+	}
+	p.Summary = strings.TrimSpace(p.Summary)
+	return &p, nil
+}
+
+// stripCodeFence removes one surrounding markdown code fence, if present.
+func stripCodeFence(s string) string {
+	t := strings.TrimSpace(s)
+	for {
+		switch {
+		case strings.HasPrefix(t, "```"):
+			t = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(t, "```"), "json"))
+		case strings.HasSuffix(t, "```"):
+			t = strings.TrimSpace(strings.TrimSuffix(t, "```"))
+		default:
+			return t
+		}
+	}
+}
+
+// applyProposal puts the proposed summary and tombstones exactly the consumed
+// batch facts toward it — ADR-007 receipts with propose/apply discipline:
+//
+//   - The summary enters first. If its Put fails, nothing else changes and
+//     the batch stays live; data is never lost ahead of its replacement.
+//   - Consumed IDs are clamped to the batch: the model may only consume what
+//     it was shown. Hallucinated or duplicate IDs are ignored deterministically.
+//   - Tombstones keep their post-decay weight and decay on like any other
+//     fact. They leave Recall immediately (IsSuperseded), remain listed,
+//     exportable and auditable, and pruning collects them on the ordinary
+//     schedule. Zeroing their weight instead would let step 3 of this very
+//     cycle delete each receipt milliseconds after writing it.
+//   - The receipt points at the real summary fact's ID. Falling back to the
+//     generic SupersededByAgent marker on lookup failure would falsify the
+//     audit trail ("an agent retired this"), so failure aborts instead.
+//
+// It returns how many facts were actually tombstoned; per-fact write failures
+// are joined into the returned error without stopping the remaining ones.
+func (s *Store) applyProposal(ctx context.Context, agentID string, batch []Fact, prop *consolidationProposal) (int, error) {
+	byID := make(map[string]Fact, len(batch))
+	for _, f := range batch {
+		byID[f.ID] = f
+	}
+	consumed := make([]Fact, 0, len(prop.Consumes))
+	for _, id := range prop.Consumes {
+		f, ok := byID[id]
+		if !ok {
+			continue // not shown to the model: it cannot be consumed
+		}
+		delete(byID, id) // duplicate IDs consume once
+		consumed = append(consumed, f)
+	}
+
+	if err := s.Put(ctx, agentID, prop.Summary); err != nil {
+		return 0, fmt.Errorf("put consolidation summary: %w", err)
+	}
+	summaryID := s.factIDByText(agentID, prop.Summary)
+	if summaryID == "" {
+		// Unreachable in practice — Put just stored exactly this text — but
+		// refusing here is what keeps every receipt resolvable.
+		return 0, fmt.Errorf("consolidation summary vanished after put; batch left untouched")
+	}
+
+	var errs []error
+	applied := 0
+	for _, f := range consumed {
+		tomb := f
+		tomb.SupersededBy = summaryID
+		if err := s.UpdateFact(agentID, tomb); err != nil {
+			errs = append(errs, fmt.Errorf("tombstone consolidated fact %s: %w", f.ID, err))
+			continue
+		}
+		applied++
+	}
+	return applied, errors.Join(errs...)
+}
+
+// factIDByText returns the ID of the most recent fact with exactly this text,
+// or "" when absent. List returns facts newest first, so the first match is
+// the newest — scanning from the back would return the oldest duplicate,
+// pointing consolidation receipts at a stale record.
+func (s *Store) factIDByText(agentID, text string) string {
+	facts, err := s.List(agentID)
+	if err != nil {
+		return ""
+	}
+	for _, f := range facts {
+		if f.Text == text {
+			return f.ID
+		}
+	}
+	return ""
+}
+
+// extractedSignature returns the text signature recorded the last time this
+// fact was successfully extracted into the knowledge graph.
+func (s *Store) extractedSignature(agentID, factID string) (string, bool) {
+	var sig string
+	found := false
+	_ = s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketKGExtracted)
+		if b == nil {
+			return nil // read-only store against an old DB: treat as unextracted
+		}
+		if v := b.Get([]byte(agentID + "\x00" + factID)); v != nil {
+			sig, found = string(v), true
+		}
+		return nil
+	})
+	return sig, found
+}
+
+// markExtracted records the text signature of a fact whose extraction fully
+// succeeded. No-op on read-only stores (consolidation cannot run there
+// anyway, and a failed write must not fail the pass).
+func (s *Store) markExtracted(agentID, factID, sig string) error {
+	if s.readOnly {
+		return nil
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketKGExtracted)
+		if b == nil {
+			return fmt.Errorf("kg_extracted bucket missing")
+		}
+		return b.Put([]byte(agentID+"\x00"+factID), []byte(sig))
+	})
+}
+
+func summariseFacts(ctx context.Context, facts []Fact, cfg ConsolidateConfig) (*consolidationProposal, error) {
 	if len(facts) == 0 {
-		return "", nil
+		return nil, nil
 	}
 	texts := make([]string, 0, len(facts))
+	rows := make([]string, 0, len(facts))
 	for _, f := range facts {
 		texts = append(texts, "- "+f.Text)
+		rows = append(rows, fmt.Sprintf("- %s: %s", f.ID, f.Text))
 	}
-	prompt := fmt.Sprintf(
-		"The following are memory facts for an AI agent. "+
-			"Produce a single concise paragraph (≤5 sentences) that preserves all key information:\n\n%s",
-		strings.Join(texts, "\n"),
-	)
 	switch cfg.GetConsolidateLLM() {
 	case "anthropic":
-		return consolidateViaAnthropic(ctx, prompt, cfg)
+		prompt := fmt.Sprintf(
+			"The following are memory facts for an AI agent. "+
+				"Produce a single concise paragraph (≤5 sentences) that preserves all key information:\n\n%s",
+			strings.Join(texts, "\n"),
+		)
+		summary, err := consolidateViaAnthropic(ctx, prompt, cfg)
+		if err != nil {
+			return nil, err
+		}
+		// The Anthropic path predates structured proposals: whatever it
+		// returns accounts for the whole batch, deterministically. The
+		// apply step still tombstones with receipts — only the proposal's
+		// granularity differs.
+		ids := make([]string, 0, len(facts))
+		for _, f := range facts {
+			ids = append(ids, f.ID)
+		}
+		return &consolidationProposal{Summary: strings.TrimSpace(summary), Consumes: ids}, nil
 	case "ollama":
-		return "", ErrConsolidateLLMUnsupported
+		prompt := fmt.Sprintf(
+			"The following are memory facts for an AI agent, each prefixed with its ID. "+
+				"Summarise them into a single concise paragraph (≤5 sentences) that preserves all key "+
+				"information, then list the IDs whose information the summary fully accounts for. "+
+				"Respond with ONLY a JSON object:\n"+
+				`{"summary":"<paragraph>","consumes":["<id>",...],"contradictions":["<optional note>",...]}`+
+				"\n\n%s",
+			strings.Join(rows, "\n"),
+		)
+		return consolidateViaOllama(ctx, prompt, cfg)
 	default:
-		// Consolidation LLM disabled. Decay and pruning still run; only
-		// summarisation is skipped, and that is the configured behaviour
-		// rather than a failure.
-		return "", nil
+		// Unknown provider name. Summarisation is skipped; decay and pruning
+		// still run, and that is the configured behaviour rather than a
+		// failure.
+		return nil, nil
 	}
+}
+
+// ollamaHTTPTimeout bounds one Ollama generate call. Package-level so tests
+// can shorten it; production callers get a patient default because loading a
+// cold model into memory routinely exceeds the first request's patience.
+var ollamaHTTPTimeout = 120 * time.Second
+
+// consolidateViaOllama proposes a consolidation through a local Ollama
+// instance: zero accounts, zero cost, fully offline — the consolidation path
+// that keeps the one-binary zero-infra promise end to end. The request asks
+// Ollama for JSON at the sampler level ("format":"json"); the response is
+// then validated as a strict proposal. One retry on transient failures
+// (transport errors, 5xx, 408, 429); deterministic rejections (4xx) and
+// invalid proposals fail immediately because retrying reproduces them.
+func consolidateViaOllama(ctx context.Context, prompt string, cfg ConsolidateConfig) (*consolidationProposal, error) {
+	base := strings.TrimRight(cfg.GetOllamaURL(), "/")
+	if base == "" {
+		base = "http://localhost:11434"
+	}
+	model := cfg.GetOllamaConsolidateModel()
+	if model == "" {
+		model = "llama3.2"
+	}
+	payload, err := json.Marshal(map[string]any{
+		"model":  model,
+		"prompt": prompt,
+		"stream": false,
+		"format": "json",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ollama: encode request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ollamaHTTPTimeout}
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/api/generate", bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("ollama: build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("ollama: post %s/api/generate: %w", base, err)
+			continue // one retry: cold-model loads routinely exceed the first call
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("ollama: read response: %w", readErr)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("ollama: status %d: %s", resp.StatusCode, truncateForLog(body))
+			if resp.StatusCode >= 500 || resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests {
+				continue
+			}
+			return nil, lastErr
+		}
+		var out struct {
+			Response string `json:"response"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, fmt.Errorf("ollama: decode envelope: %w", err)
+		}
+		return parseProposal(out.Response)
+	}
+	return nil, lastErr
+}
+
+func truncateForLog(b []byte) string {
+	s := string(b)
+	if len(s) > 200 {
+		s = s[:200] + "…"
+	}
+	return s
 }
 
 func consolidateViaAnthropic(ctx context.Context, prompt string, cfg ConsolidateConfig) (string, error) {
@@ -296,4 +604,62 @@ func consolidateViaAnthropic(ctx context.Context, prompt string, cfg Consolidate
 		return "", nil
 	}
 	return msg.Content[0].Text, nil
+}
+
+const (
+	metaKeyConsolidations    = "consolidations"
+	metaKeyFactsConsolidated = "facts_consolidated"
+)
+
+// ReadConsolidationCounters reports lifetime consolidation activity recorded
+// in the store's meta bucket: how many cycles applied at least one proposal,
+// and how many batch facts were consumed across them. Exported because both
+// surfaces that display it — the daemon host's StoreOverview and the direct
+// in-process store — must read the same numbers without either owning the
+// write logic.
+func ReadConsolidationCounters(db *bolt.DB) (cycles, facts int) {
+	_ = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketMeta)
+		if b == nil {
+			return nil
+		}
+		if v := b.Get([]byte(metaKeyConsolidations)); v != nil {
+			cycles, _ = strconv.Atoi(string(v))
+		}
+		if v := b.Get([]byte(metaKeyFactsConsolidated)); v != nil {
+			facts, _ = strconv.Atoi(string(v))
+		}
+		return nil
+	})
+	return cycles, facts
+}
+
+// ConsolidationCounters reads the counters from this store.
+func (s *Store) ConsolidationCounters() (cycles, facts int) {
+	return ReadConsolidationCounters(s.db)
+}
+
+// recordConsolidation bumps both counters once per applied proposal.
+func recordConsolidation(db *bolt.DB, facts int) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketMeta)
+		if b == nil {
+			return fmt.Errorf("meta bucket missing")
+		}
+		bump := func(key string, by int) error {
+			cur := 0
+			if v := b.Get([]byte(key)); v != nil {
+				n, err := strconv.Atoi(string(v))
+				if err != nil {
+					return fmt.Errorf("meta key %q: %w", key, err)
+				}
+				cur = n
+			}
+			return b.Put([]byte(key), []byte(strconv.Itoa(cur+by)))
+		}
+		if err := bump(metaKeyConsolidations, 1); err != nil {
+			return err
+		}
+		return bump(metaKeyFactsConsolidated, facts)
+	})
 }

--- a/pkg/memory/consolidate_ollama_test.go
+++ b/pkg/memory/consolidate_ollama_test.go
@@ -1,0 +1,716 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+)
+
+// The W3 consolidation contract, exercised end to end against fake Ollama
+// servers: propose/apply discipline (ADR-011), tombstone receipts that stay
+// auditable (ADR-007), pinned facts never entering the prompt (invariant
+// I-1), and the extraction watermark (A7).
+
+// ollamaFixture is a store plus a scripted Ollama endpoint. The handler
+// receives every generate call with its parsed prompt payload so tests can
+// inspect what the model was shown and answer with proposals built from the
+// very IDs the prompt carried.
+type ollamaFixture struct {
+	store *Store
+	srv   *httptest.Server
+
+	ch        chan *ollamaRequest
+	responder func(r *ollamaRequest) string
+}
+
+type ollamaRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Format string `json:"format"`
+}
+
+var promptIDRe = regexp.MustCompile(`^- ([0-9A-Z]{26}): `)
+
+// idsInPrompt extracts the fact IDs the model was shown, in order.
+func idsInPrompt(prompt string) []string {
+	var ids []string
+	for _, line := range strings.Split(prompt, "\n") {
+		if m := promptIDRe.FindStringSubmatch(line); m != nil {
+			ids = append(ids, m[1])
+		}
+	}
+	return ids
+}
+
+func newOllamaFixture(t *testing.T, responder func(r *ollamaRequest) string) *ollamaFixture {
+	t.Helper()
+	f := &ollamaFixture{ch: make(chan *ollamaRequest, 64), responder: responder}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var r ollamaRequest
+		_ = json.NewDecoder(req.Body).Decode(&r)
+		select {
+		case f.ch <- &r:
+		default:
+		}
+		fmt.Fprint(w, responder(&r))
+	}))
+	t.Cleanup(f.srv.Close)
+
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	f.store = s
+	return f
+}
+
+func (f *ollamaFixture) drain() []*ollamaRequest {
+	close(f.ch)
+	var reqs []*ollamaRequest
+	for r := range f.ch {
+		reqs = append(reqs, r)
+	}
+	return reqs
+}
+
+func (f *ollamaFixture) cfg(threshold int) *testConsolidateCfg {
+	return &testConsolidateCfg{threshold: threshold, halfLife: 720 * time.Hour,
+		llm: "ollama", ollamaURL: f.srv.URL, ollamaMdl: "test-model"}
+}
+
+// jsonProposal builds an Ollama /api/generate body whose .Response field is a
+// JSON proposal — mirroring what "format":"json" yields.
+func jsonProposal(summary string, consumes []string) string {
+	inner, _ := json.Marshal(map[string]any{"summary": summary, "consumes": consumes})
+	resp, _ := json.Marshal(map[string]any{"response": string(inner)})
+	return string(resp)
+}
+
+func findByText(t *testing.T, facts []Fact, text string) Fact {
+	t.Helper()
+	for _, f := range facts {
+		if f.Text == text {
+			return f
+		}
+	}
+	t.Fatalf("fact %q not found", text)
+	return Fact{}
+}
+
+const (
+	pinnedText    = "ARCHITECTURE DECISION: the ledger is append-only forever"
+	weakA         = "weak observation alpha with filler detail one"
+	weakB         = "weak observation beta with filler detail two"
+	weakC         = "weak observation gamma with filler detail three"
+	strongD       = "strong observation delta with crucial detail four"
+	unpinnedOther = "medium observation epsilon with detail five"
+)
+
+// seedSixWeights plants six facts with distinct weights; the three weakest
+// unpinned ones form the summarisation batch of a 6-fact store.
+func seedSixWeights(t *testing.T, s *Store, agent string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, text := range []string{weakA, weakB, weakC, strongD, unpinnedOther, pinnedText} {
+		if err := s.Put(ctx, agent, text); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	weights := map[string]float64{
+		weakA: 0.05, weakB: 0.06, weakC: 0.07, // the batch
+		strongD:       0.95,
+		unpinnedOther: 0.50,
+		pinnedText:    0.01, // lowest weight overall — the trap for an unfiltered batch
+	}
+	facts, err := s.List(agent)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for i := range facts {
+		w, ok := weights[facts[i].Text]
+		if !ok {
+			t.Fatalf("unseeded fact %q", facts[i].Text)
+		}
+		facts[i].Weight = w
+		if facts[i].Text == pinnedText {
+			now := time.Now().UTC()
+			facts[i].Pinned = true
+			facts[i].PinnedAt = now
+			facts[i].AccessedAt = now.Add(-400 * time.Hour)
+		}
+		if err := s.UpdateFact(agent, facts[i]); err != nil {
+			t.Fatalf("UpdateFact: %v", err)
+		}
+	}
+}
+
+// TestOllamaConsolidation_AppliesValidProposalWithReceipts drives the happy
+// path end to end: the model proposes consuming two of the three shown facts;
+// exactly those are tombstoned toward the real summary fact, receipts stay
+// listed and auditable with their weight intact, the unconsumed batch fact
+// stays live, the pinned fact never reached the prompt, and the counters
+// moved by one cycle and two facts.
+func TestOllamaConsolidation_AppliesValidProposalWithReceipts(t *testing.T) {
+	var consume []string
+	f := newOllamaFixture(t, func(r *ollamaRequest) string {
+		if r.Format != "json" {
+			t.Errorf("request did not ask Ollama for JSON output: format=%q", r.Format)
+		}
+		ids := idsInPrompt(r.Prompt)
+		if len(ids) < 2 {
+			t.Errorf("prompt showed %d facts, want >=2:\n%s", len(ids), r.Prompt)
+		}
+		consume = ids[:2]
+		return jsonProposal("merged summary of the weak observations.", consume)
+	})
+
+	const agent = "receipts-agent"
+	seedSixWeights(t, f.store, agent)
+
+	ctx := context.Background()
+	before, _ := f.store.List(agent)
+	if err := f.store.Consolidate(ctx, agent, f.cfg(4)); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	after, _ := f.store.List(agent)
+	summary := findByText(t, after, "merged summary of the weak observations.")
+
+	for _, id := range consume {
+		var tomb *Fact
+		for i := range after {
+			if after[i].ID == id {
+				tomb = &after[i]
+				break
+			}
+		}
+		if tomb == nil {
+			t.Fatalf("consumed fact %s vanished entirely; receipt lost", id)
+		}
+		if !tomb.IsSuperseded() || tomb.SupersededBy != summary.ID {
+			t.Errorf("fact %s: SupersededBy=%q, want summary ID %q", id, tomb.SupersededBy, summary.ID)
+		}
+		var preWeight float64
+		for _, b := range before {
+			if b.ID == id {
+				preWeight = b.Weight
+			}
+		}
+		if tomb.Weight != preWeight {
+			t.Errorf("tombstone %s weight %.4f != pre-decay %.4f: zeroing it would let the same cycle's prune eat the receipt", id, tomb.Weight, preWeight)
+		}
+	}
+
+	// The third batch fact was not consumed and must be untouched and live.
+	for _, fct := range after {
+		if fct.Text == weakC && fct.IsSuperseded() {
+			t.Error("unconsumed batch fact was tombstoned anyway")
+		}
+	}
+	// Pinned trap survived byte-for-byte.
+	pin := findByText(t, after, pinnedText)
+	if !pin.Pinned || pin.Weight != 0.01 {
+		t.Errorf("pinned fact mutated during consolidation: %+v", pin)
+	}
+
+	cycles, factsConsumed := f.store.ConsolidationCounters()
+	if cycles != 1 || factsConsumed != len(consume) {
+		t.Errorf("counters = (%d cycles, %d facts), want (%d, %d)", cycles, factsConsumed, 1, len(consume))
+	}
+}
+
+// TestOllamaConsolidation_PinnedNeverEntersPrompt pins the I-1 guarantee at
+// the protocol boundary: even the weakest fact in the store must be absent
+// from the payload when it is pinned.
+func TestOllamaConsolidation_PinnedNeverEntersPrompt(t *testing.T) {
+	f := newOllamaFixture(t, func(r *ollamaRequest) string {
+		return jsonProposal("digest.", idsInPrompt(r.Prompt))
+	})
+	seedSixWeights(t, f.store, "pin-prompt-agent")
+
+	if err := f.store.Consolidate(context.Background(), "pin-prompt-agent", f.cfg(4)); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	for _, r := range f.drain() {
+		if strings.Contains(r.Prompt, pinnedText) {
+			t.Errorf("pinned fact leaked into the summarisation prompt:\n%s", r.Prompt)
+		}
+	}
+}
+
+// TestOllamaConsolidation_MalformedProposalDiscarded: a syntactically valid
+// HTTP exchange carrying garbage instead of a JSON object must leave the
+// store byte-intact, fire the hook with ErrInvalidProposal, and move no
+// counter.
+func TestOllamaConsolidation_MalformedProposalDiscarded(t *testing.T) {
+	var reported []error
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+		OnConsolidateError: func(_ string, err error) {
+			reported = append(reported, err)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		fmt.Fprint(w, `{"response":"this is prose, definitely not the JSON object we demanded"}`)
+	}))
+	defer srv.Close()
+
+	const agent = "malformed-agent"
+	seedSixWeights(t, s, agent)
+	cfg := &testConsolidateCfg{threshold: 4, halfLife: 720 * time.Hour,
+		llm: "ollama", ollamaURL: srv.URL}
+
+	if err := s.Consolidate(context.Background(), agent, cfg); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	found := false
+	for _, e := range reported {
+		if errors.Is(e, ErrInvalidProposal) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("discarded proposal reported as %v, want ErrInvalidProposal", reported)
+	}
+	facts, _ := s.List(agent)
+	if len(facts) != 6 {
+		t.Fatalf("store mutated by a discarded proposal: %d facts, want 6", len(facts))
+	}
+	for _, fct := range facts {
+		if fct.IsSuperseded() {
+			t.Errorf("fact %q tombstoned by a discarded proposal", fct.Text)
+		}
+	}
+	if cycles, consumed := s.ConsolidationCounters(); cycles != 0 || consumed != 0 {
+		t.Errorf("counters moved on a discarded proposal: (%d,%d)", cycles, consumed)
+	}
+	_ = calls
+}
+
+// TestOllamaConsolidation_FencedJSONAccepted: models wrap JSON in code fences
+// even when told not to; the fence stripper must absorb that without turning
+// a good proposal into a discard.
+func TestOllamaConsolidation_FencedJSONAccepted(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+		OnConsolidateError: func(_ string, err error) {
+			t.Errorf("valid fenced proposal reported: %v", err)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A valid proposal wrapped in the code fences models insist on.
+		inner := "```json\n{\"summary\":\"fenced digest.\",\"consumes\":[\"ANY\"]}\n```"
+		env, _ := json.Marshal(map[string]any{"response": inner})
+		_, _ = w.Write(env)
+	}))
+	defer srv.Close()
+
+	const agent = "fenced-agent"
+	seedSixWeights(t, s, agent)
+	cfg := &testConsolidateCfg{threshold: 4, halfLife: 720 * time.Hour,
+		llm: "ollama", ollamaURL: srv.URL}
+
+	if err := s.Consolidate(context.Background(), agent, cfg); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if id := s.factIDByText(agent, "fenced digest."); id == "" {
+		t.Error("fenced valid proposal was not applied")
+	}
+	// "ANY" is not a batch ID: clamped to nothing, so nothing was tombstoned
+	// and no counter moved — the summary alone entered the store.
+	if _, consumed := s.ConsolidationCounters(); consumed != 0 {
+		t.Errorf("hallucinated consumes moved the receipt counter: %d", consumed)
+	}
+}
+
+// TestOllamaConsolidation_TransientFailureRetriesThenFallsBack: an endpoint
+// that accepts connections but never answers must be tried exactly twice
+// (one patient retry), then degrade silently-but-audibly to decay+prune with
+// the batch intact.
+func TestOllamaConsolidation_TransientFailureRetriesThenFallsBack(t *testing.T) {
+	oldTimeout := ollamaHTTPTimeout
+	ollamaHTTPTimeout = 80 * time.Millisecond
+	defer func() { ollamaHTTPTimeout = oldTimeout }()
+
+	var reported []error
+	dir := t.TempDir()
+	s, err := Open(StoreConfig{
+		DataDir:       dir,
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+		OnConsolidateError: func(_ string, err error) {
+			reported = append(reported, err)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	attempts := make(chan struct{}, 8)
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts <- struct{}{}
+		<-block // hold until the client gives up
+	}))
+	defer func() { close(block); srv.Close() }()
+
+	const agent = "timeout-agent"
+	seedSixWeights(t, s, agent)
+	cfg := &testConsolidateCfg{threshold: 4, halfLife: 720 * time.Hour,
+		llm: "ollama", ollamaURL: srv.URL}
+
+	start := time.Now()
+	if err := s.Consolidate(context.Background(), agent, cfg); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("fallback took %s; the caller's patience must bound retries", elapsed)
+	}
+	if n := len(attempts); n != 2 {
+		t.Errorf("endpoint hit %d times, want exactly 2 (initial + one retry)", n)
+	}
+	if len(reported) == 0 {
+		t.Error("silent fallback: OnConsolidateError never fired")
+	}
+	facts, _ := s.List(agent)
+	if len(facts) != 6 {
+		t.Errorf("fallback lost data: %d facts, want 6", len(facts))
+	}
+}
+
+// TestOllamaConsolidation_ServerErrorRetriesClientErrorDoesNot pins the retry
+// policy split: 5xx is transient and earns the one retry; a 4xx is a
+// deterministic rejection where retrying can only reproduce it.
+func TestOllamaConsolidation_ServerErrorRetriesClientErrorDoesNot(t *testing.T) {
+	openWithHook := func(hook func(string, error)) *Store {
+		t.Helper()
+		s, err := Open(StoreConfig{
+			DataDir:            t.TempDir(),
+			Embedder:           embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+			DecayHalfLife:      720 * time.Hour,
+			OnConsolidateError: hook,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = s.Close() })
+		return s
+	}
+
+	t.Run("500-then-200-retries", func(t *testing.T) {
+		var calls int
+		s := openWithHook(func(string, error) {})
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			if calls == 1 {
+				http.Error(w, "warming up", http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprint(w, `{"response":"{\"summary\":\"retry arrived.\",\"consumes\":[]}"}`)
+		}))
+		defer srv.Close()
+
+		const agent = "retry-5xx"
+		seedSixWeights(t, s, agent)
+		cfg := &testConsolidateCfg{threshold: 4, halfLife: 720 * time.Hour,
+			llm: "ollama", ollamaURL: srv.URL}
+		if err := s.Consolidate(context.Background(), agent, cfg); err != nil {
+			t.Fatal(err)
+		}
+		if calls != 2 {
+			t.Errorf("5xx earned %d attempts, want 2 (initial + one retry)", calls)
+		}
+		// The retried proposal carries an empty consumes list, so it must be
+		// discarded at validation — proving validation runs after retries.
+		if id := s.factIDByText(agent, "retry arrived."); id != "" {
+			t.Error("empty-consumes proposal was applied after retry")
+		}
+	})
+
+	t.Run("400-single-attempt", func(t *testing.T) {
+		var reported []error
+		var calls int
+		s := openWithHook(func(_ string, err error) { reported = append(reported, err) })
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			http.Error(w, "bad request", http.StatusBadRequest)
+		}))
+		defer srv.Close()
+
+		const agent = "no-retry-4xx"
+		seedSixWeights(t, s, agent)
+		cfg := &testConsolidateCfg{threshold: 4, halfLife: 720 * time.Hour,
+			llm: "ollama", ollamaURL: srv.URL}
+		if err := s.Consolidate(context.Background(), agent, cfg); err != nil {
+			t.Fatal(err)
+		}
+		if calls != 1 {
+			t.Errorf("4xx earned %d attempts, want exactly 1", calls)
+		}
+		if len(reported) == 0 {
+			t.Error("4xx fallback was silent")
+		}
+	})
+}
+
+// TestConsolidation_TombstonePropertyAcrossCycles is playbook property test:
+// across many cycles nobody disappears without a receipt. Any fact present in
+// snapshot k but gone from k+1 must already have been superseded in k, and
+// its receipt target must have existed. Pinned facts survive byte-identical.
+func TestConsolidation_TombstonePropertyAcrossCycles(t *testing.T) {
+	f := newOllamaFixture(t, func(r *ollamaRequest) string {
+		return jsonProposal(fmt.Sprintf("consolidated digest %d.", time.Now().UnixNano()), idsInPrompt(r.Prompt))
+	})
+	const agent = "property-agent"
+
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-24 * 30 * time.Hour)
+	current := base
+	f.store.now = func() time.Time { return current }
+
+	texts := make([]string, 0, 10)
+	for i := 0; i < 9; i++ {
+		txt := fmt.Sprintf("cyclic observation number %d about topic %d", i, i%3)
+		texts = append(texts, txt)
+		if err := f.store.Put(ctx, agent, txt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.store.Put(ctx, agent, pinnedText); err != nil {
+		t.Fatal(err)
+	}
+	facts, _ := f.store.List(agent)
+	for i := range facts {
+		if facts[i].Text == pinnedText {
+			facts[i].Pinned = true
+			facts[i].PinnedAt = current
+			if err := f.store.UpdateFact(agent, facts[i]); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			// Spread ages so each cycle's decay produces a fresh weak half.
+			facts[i].CreatedAt = current.Add(-time.Duration(i+1) * 24 * time.Hour)
+			facts[i].AccessedAt = facts[i].CreatedAt
+			facts[i].Weight = 0.9 - 0.05*float64(i)
+			if err := f.store.UpdateFact(agent, facts[i]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	snapshot := func() map[string]Fact {
+		fs, _ := f.store.List(agent)
+		m := make(map[string]Fact, len(fs))
+		for _, x := range fs {
+			m[x.ID] = x
+		}
+		return m
+	}
+
+	prev := snapshot()
+	for cycle := 0; cycle < 8; cycle++ {
+		current = current.Add(20 * 24 * time.Hour)
+		if err := f.store.Consolidate(ctx, agent, f.cfg(3)); err != nil {
+			t.Fatalf("cycle %d: %v", cycle, err)
+		}
+		next := snapshot()
+
+		for id, old := range prev {
+			if _, alive := next[id]; alive {
+				continue
+			}
+			if !old.IsSuperseded() {
+				t.Fatalf("cycle %d: fact %s (%q) disappeared without ever being superseded", cycle, id, old.Text)
+			}
+			if _, ok := prev[old.SupersededBy]; !ok {
+				t.Fatalf("cycle %d: receipt of %s pointed at %s which did not exist", cycle, id, old.SupersededBy)
+			}
+		}
+		// Invariant I-1 holds across the whole horizon.
+		for id, cur := range next {
+			if cur.Text == pinnedText && (!cur.Pinned || cur.Weight <= 0) {
+				t.Fatalf("cycle %d: pinned fact mutated: %+v", cycle, cur)
+			}
+			_ = id
+		}
+		prev = next
+	}
+
+	cycles, _ := f.store.ConsolidationCounters()
+	if cycles == 0 {
+		t.Fatal("no consolidation ever applied; property vacuously true")
+	}
+}
+
+// countingTypedExtractor and countingGraph feed the watermark tests.
+type countingTypedExtractor struct {
+	typedCalls int
+	lastText   string
+}
+
+func (e *countingTypedExtractor) ExtractIDs(text string) ([]string, error) {
+	e.typedCalls++
+	e.lastText = text
+	return []string{"entity-x"}, nil
+}
+
+func (e *countingTypedExtractor) ExtractTyped(text string) ([]EntityRef, []EntityLink, error) {
+	e.typedCalls++
+	e.lastText = text
+	return []EntityRef{{ID: "entity-x", Label: "Entity X", EntityType: "concept"}}, nil, nil
+}
+
+type countingGraph struct {
+	upserts int
+}
+
+func (g *countingGraph) UpsertNode(id, label, entityType string) error {
+	g.upserts++
+	return nil
+}
+
+func (g *countingGraph) NeighborTexts(string, int) ([]string, error) { return nil, nil }
+
+// TestExtraction_WatermarkSkipsUnchangedAndSuperseded covers A7 plus the
+// tombstone filter: unchanged live facts are extracted once and never again;
+// editing a fact re-extracts exactly that one; retired facts are never fed
+// to the extractor at all.
+func TestExtraction_WatermarkSkipsUnchangedAndSuperseded(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ex := &countingTypedExtractor{}
+	g := &countingGraph{}
+	s.SetKG(g, ex)
+
+	ctx := context.Background()
+	const agent = "wm-agent"
+	for _, txt := range []string{"watermark fact one", "watermark fact two", "watermark fact three"} {
+		if err := s.Put(ctx, agent, txt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := defaultTestCfg()
+
+	if err := s.Consolidate(ctx, agent, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if ex.typedCalls != 3 {
+		t.Fatalf("first pass extracted %d facts, want 3", ex.typedCalls)
+	}
+
+	if err := s.Consolidate(ctx, agent, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if ex.typedCalls != 3 {
+		t.Errorf("unchanged store re-extracted: %d calls total, want 3", ex.typedCalls)
+	}
+
+	// Edit one fact's text; retire another. Next pass: exactly one extract,
+	// none for the tombstone.
+	facts, _ := s.List(agent)
+	var edited, retired Fact
+	n := 0
+	for _, fct := range facts {
+		switch n {
+		case 0:
+			edited = fct
+		case 1:
+			retired = fct
+		}
+		n++
+	}
+	edited.Text += " (revised)"
+	if err := s.UpdateFact(agent, edited); err != nil {
+		t.Fatal(err)
+	}
+	retired.SupersededBy = SupersededByAgent
+	if err := s.UpdateFact(agent, retired); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Consolidate(ctx, agent, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if ex.typedCalls != 4 {
+		t.Errorf("third pass made %d total calls, want 4 (only the edited fact)", ex.typedCalls)
+	}
+	if ex.lastText != edited.Text {
+		t.Errorf("extractor saw %q, want the revised text", ex.lastText)
+	}
+}
+
+// TestDelete_ClearsExtractionWatermark: a deleted fact's signature must go
+// with it, so re-adding the same text later extracts afresh under its new ID.
+func TestDelete_ClearsExtractionWatermark(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ex := &countingTypedExtractor{}
+	s.SetKG(&countingGraph{}, ex)
+
+	ctx := context.Background()
+	const agent = "del-wm-agent"
+	if err := s.Put(ctx, agent, "ephemeral fact"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Consolidate(ctx, agent, defaultTestCfg()); err != nil {
+		t.Fatal(err)
+	}
+	facts, _ := s.List(agent)
+	id := facts[0].ID
+	if _, ok := s.extractedSignature(agent, id); !ok {
+		t.Fatal("signature not recorded on first extraction")
+	}
+
+	if err := s.Delete(agent, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.extractedSignature(agent, id); ok {
+		t.Error("watermark outlived its fact")
+	}
+
+	// Same text, new ULID: must be treated as unseen.
+	if err := s.Put(ctx, agent, "ephemeral fact"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Consolidate(ctx, agent, defaultTestCfg()); err != nil {
+		t.Fatal(err)
+	}
+	if ex.typedCalls != 2 {
+		t.Errorf("extractor called %d times, want 2 (once per incarnation)", ex.typedCalls)
+	}
+}

--- a/pkg/memory/consolidate_test.go
+++ b/pkg/memory/consolidate_test.go
@@ -20,13 +20,17 @@ type testConsolidateCfg struct {
 	llm       string
 	apiKey    string
 	model     string
+	ollamaURL string
+	ollamaMdl string
 }
 
-func (c *testConsolidateCfg) GetAnthropicAPIKey() string     { return c.apiKey }
-func (c *testConsolidateCfg) GetConsolidateLLM() string      { return c.llm }
-func (c *testConsolidateCfg) GetConsolidateModel() string    { return c.model }
-func (c *testConsolidateCfg) GetConsolidateThreshold() int   { return c.threshold }
-func (c *testConsolidateCfg) GetDecayHalfLife() time.Duration { return c.halfLife }
+func (c *testConsolidateCfg) GetAnthropicAPIKey() string        { return c.apiKey }
+func (c *testConsolidateCfg) GetConsolidateLLM() string         { return c.llm }
+func (c *testConsolidateCfg) GetConsolidateModel() string       { return c.model }
+func (c *testConsolidateCfg) GetConsolidateThreshold() int      { return c.threshold }
+func (c *testConsolidateCfg) GetDecayHalfLife() time.Duration   { return c.halfLife }
+func (c *testConsolidateCfg) GetOllamaURL() string              { return c.ollamaURL }
+func (c *testConsolidateCfg) GetOllamaConsolidateModel() string { return c.ollamaMdl }
 
 func defaultTestCfg() *testConsolidateCfg {
 	return &testConsolidateCfg{
@@ -273,13 +277,14 @@ func TestConsolidate_PutBeforeDelete(t *testing.T) {
 	}
 }
 
-// TestConsolidate_OllamaSummariserReportsUnsupported covers a misconfiguration
-// that used to be invisible. Ollama is a supported embedding backend, so
-// setting ConsolidateLLM="ollama" looks reasonable and is accepted by config —
-// but summarisation via Ollama is not implemented, and the code returned an
-// empty summary and no error. Consolidation then ran forever doing decay and
-// pruning only, with nothing anywhere to explain why memory kept growing.
-func TestConsolidate_OllamaSummariserReportsUnsupported(t *testing.T) {
+// TestConsolidate_OllamaUnreachableReports covers the misconfiguration that
+// used to be invisible. Ollama is a supported embedding backend, so setting
+// ConsolidateLLM="ollama" looks reasonable — and when nothing answers on that
+// URL, consolidation must say so through OnConsolidateError instead of
+// quietly doing nothing forever. The cycle itself still runs decay and
+// pruning, and the batch stays live: a broken summariser degrades to the
+// exact behaviour of ConsolidateLLM="".
+func TestConsolidate_OllamaUnreachableReports(t *testing.T) {
 	var reported []error
 	dir := t.TempDir()
 	s, err := Open(StoreConfig{
@@ -296,7 +301,9 @@ func TestConsolidate_OllamaSummariserReportsUnsupported(t *testing.T) {
 	defer s.Close()
 
 	ctx := context.Background()
-	cfg := &testConsolidateCfg{threshold: 3, halfLife: 720 * time.Hour, llm: "ollama"}
+	// Port 1 on localhost is reserved and refuses connections immediately.
+	cfg := &testConsolidateCfg{threshold: 3, halfLife: 720 * time.Hour, llm: "ollama",
+		ollamaURL: "http://127.0.0.1:1"}
 	for i := 0; i < 5; i++ { // over the threshold, so summarisation is attempted
 		if err := s.Put(ctx, "ollama-agent", fmt.Sprintf("observation number %d", i)); err != nil {
 			t.Fatalf("Put: %v", err)
@@ -307,14 +314,17 @@ func TestConsolidate_OllamaSummariserReportsUnsupported(t *testing.T) {
 		t.Fatalf("Consolidate: %v", err)
 	}
 
-	var found bool
+	if len(reported) == 0 {
+		t.Error("an unreachable consolidation LLM reported nothing")
+	}
 	for _, e := range reported {
 		if errors.Is(e, ErrConsolidateLLMUnsupported) {
-			found = true
+			t.Errorf("sentinel ErrConsolidateLLMUnsupported is retired but was returned: %v", e)
 		}
 	}
-	if !found {
-		t.Errorf("configuring an unimplemented consolidation LLM reported nothing; got %v", reported)
+	facts, _ := s.List("ollama-agent")
+	if len(facts) != 5 {
+		t.Errorf("fallback must leave the store untouched; got %d facts, want 5", len(facts))
 	}
 }
 

--- a/pkg/memory/golden_test.go
+++ b/pkg/memory/golden_test.go
@@ -506,3 +506,5 @@ func (goldenConsolidateCfg) GetConsolidateLLM() string         { return "" }
 func (goldenConsolidateCfg) GetConsolidateModel() string       { return "" }
 func (goldenConsolidateCfg) GetConsolidateThreshold() int      { return 100 }
 func (c goldenConsolidateCfg) GetDecayHalfLife() time.Duration { return c.halfLife }
+func (goldenConsolidateCfg) GetOllamaURL() string              { return "" }
+func (goldenConsolidateCfg) GetOllamaConsolidateModel() string { return "" }

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -21,6 +21,10 @@ var (
 	bucketMeta          = []byte("meta")
 	bucketAgents        = []byte("agents")
 	bucketPendingVector = []byte("pending_vector")
+	// bucketKGExtracted is the extraction watermark (A7): key
+	// "<agentID>\x00<factID>" → text signature of the last successfully
+	// extracted version of the fact, so consolidation passes are incremental.
+	bucketKGExtracted = []byte("kg_extracted")
 
 	// ErrStoreReadOnly is returned by mutating methods when the store was opened
 	// in read-only mode (e.g. another process holds the write lock).
@@ -234,7 +238,7 @@ func Open(cfg StoreConfig) (*Store, error) {
 	if !readOnly {
 		// Ensure top-level buckets exist.
 		if err := db.Update(func(tx *bolt.Tx) error {
-			for _, name := range [][]byte{bucketFacts, bucketSessions, bucketMeta, bucketAgents, bucketPendingVector} {
+			for _, name := range [][]byte{bucketFacts, bucketSessions, bucketMeta, bucketAgents, bucketPendingVector, bucketKGExtracted} {
 				if _, err := tx.CreateBucketIfNotExists(name); err != nil {
 					return err
 				}
@@ -441,17 +445,27 @@ func (s *Store) Put(ctx context.Context, agentID, text string) error {
 	return nil
 }
 
-// Delete removes a fact by ID for agentID.
+// Delete removes a fact by ID for agentID, together with its KG extraction
+// watermark: a signature for a deleted fact is unbounded garbage, and a
+// future re-add of the same text lands under a new ID (new key) so it must
+// extract again.
 func (s *Store) Delete(agentID, factID string) error {
 	if s.readOnly {
 		return ErrStoreReadOnly
 	}
 	return s.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucketFacts).Bucket([]byte(agentID))
+		parent := tx.Bucket(bucketFacts)
+		b := parent.Bucket([]byte(agentID))
 		if b == nil {
 			return nil
 		}
-		return b.Delete([]byte(factID))
+		if err := b.Delete([]byte(factID)); err != nil {
+			return err
+		}
+		if kb := tx.Bucket(bucketKGExtracted); kb != nil {
+			return kb.Delete([]byte(agentID + "\x00" + factID))
+		}
+		return nil
 	})
 }
 


### PR DESCRIPTION
Implements W3 of the hardening playbook (ADR-011). Three audit findings, one subsystem: A5 (summarisation hard-deleted its batch, the one path violating ADR-007), A6 (`ConsolidateLLM=ollama` accepted by config, rejected at runtime), A7 (every cycle re-extracted every fact into the graph).

**Propose/apply (ADR-011)**

- The summariser returns a structured proposal: `{"summary", "consumes", "contradictions"}`. Application is deterministic: summary Puts first; `consumes` is clamped to the batch shown; consumed facts become tombstones pointing at the *real* summary fact ID.
- Tombstones **keep their post-decay weight**: zeroing it would let the same cycle's prune step eat each receipt milliseconds after writing it. They leave recall immediately, stay listed/exportable/auditable, and decay collects them on schedule.
- Invalid proposals (malformed JSON after fence stripping, empty summary/consumes) are discarded with an `OnConsolidateError` hook carrying `ErrInvalidProposal`, and zero store mutation. Worst case equals `ConsolidateLLM=""`.

**Ollama local summariser**

- `/api/generate` with sampler-level `"format":"json"`; model via `GRAYMATTER_OLLAMA_CONSOLIDATE_MODEL` (default llama3.2). One retry, only on transient failures (transport, 5xx, 408, 429); a 4xx fails immediately. Unreachable Ollama reports via the hook - the retired `ErrConsolidateLLMUnsupported` sentinel is never returned. No account, no key, offline.

**A7 extraction watermark**

- SHA-256 text signature per fact in a new `kg_extracted` bucket; re-extract only on text change or new ID. Superseded facts are skipped entirely (they would feed retired content back into the graph). `Delete` drops the signature with the fact.

**Counters:** applied cycles bump `consolidations`/`facts_consumed` in the meta bucket; surfaced in `status` (human + JSON), `StoreOverview`, and `doctor`'s store check.

**Tests** (all green locally; full suite both modules)

- httptest Ollama fakes: valid proposal applies with exact receipts; malformed JSON discarded + hook + store intact; fenced JSON accepted; hanging endpoint retried exactly twice then silent-but-reported fallback; 5xx retries / 4xx does not; pinned fact provably absent from every prompt
- Property across 8 advancing cycles: nothing vanishes without a superseded receipt whose target existed
- Watermark: second pass extracts nothing; edit extracts exactly one; tombstones never extracted; Delete clears signatures
- Corpus gate in CI (`benchmarks/retrieval_quality/consolidation_test.go`): canonical recall@8 over a 500-fact store before vs after 6 applied cycles - non-regression asserted, measured 1.000 -> 1.000
- Offline parity preserved by the existing suite

Docs: ADR-011 (+ index rows for 010 and 011), AGENTS.md env/config notes.
