### PR TITLE
fix(security): owner-only DACL on Windows token files (daemon discovery + HTTP bearer)

### DIFF
--- a/cmd/graymatter/internal/httpauth/httpauth.go
+++ b/cmd/graymatter/internal/httpauth/httpauth.go
@@ -44,9 +44,10 @@ func TokenFilePath(dataDir string) string {
 //
 // The environment variable wins when set, and is never written to disk.
 //
-// The file is written 0600. That is a real guarantee on POSIX only; on Windows
-// it inherits the parent directory's ACL, same caveat as the daemon's
-// discovery file.
+// The file is written 0600 and then handed to the platform's real access
+// control (rpc.SecureFileOwnerOnly): a protected owner-only DACL on Windows,
+// where 0600 alone is not a promise. A failure to secure the file is an
+// error — a token that cannot be protected must not be minted.
 func LoadOrCreateToken(dataDir string) (token string, created bool, err error) {
 	if env := strings.TrimSpace(os.Getenv(TokenEnv)); env != "" {
 		return env, false, nil
@@ -79,6 +80,10 @@ func LoadOrCreateToken(dataDir string) (token string, created bool, err error) {
 	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return "", false, fmt.Errorf("httpauth: install token: %w", err)
+	}
+	if err := rpc.SecureFileOwnerOnly(path); err != nil {
+		_ = os.Remove(path)
+		return "", false, fmt.Errorf("httpauth: secure token file: %w", err)
 	}
 	return tok, true, nil
 }

--- a/cmd/graymatter/internal/httpauth/token_acl_windows_test.go
+++ b/cmd/graymatter/internal/httpauth/token_acl_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package httpauth
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Same regression class as the daemon's discovery file (see
+// pkg/memory/rpc/sock_acl_windows_test.go): on Windows a 0600 mode grants
+// nothing, so the persisted HTTP bearer token must end up behind a DACL that
+// no group-wide SID can read.
+func TestTokenFileDACL_IsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	token, created, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+	if !created {
+		t.Fatal("expected a freshly minted token")
+	}
+
+	data, err := os.ReadFile(TokenFilePath(dir))
+	if err != nil {
+		t.Fatalf("owner cannot read token file: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != token {
+		t.Error("token file does not round-trip")
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(TokenFilePath(dir), windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("read security descriptor: %v", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil || dacl.AceCount == 0 {
+		t.Fatalf("no usable DACL on token file: v=%v", err)
+	}
+
+	const (
+		accessAllowedACEType = 0
+		accessDeniedACEType  = 1
+	)
+	base := unsafe.Add(unsafe.Pointer(dacl), unsafe.Sizeof(*dacl))
+	for i := 0; i < int(dacl.AceCount); i++ {
+		hdr := (*windows.ACE_HEADER)(base)
+		switch hdr.AceType {
+		case accessAllowedACEType, accessDeniedACEType:
+			sid := (*windows.SID)(unsafe.Add(base, 8)).String()
+			switch sid {
+			case "S-1-5-32-545":
+				t.Errorf("token DACL grants BUILTIN\\Users")
+			case "S-1-5-11":
+				t.Errorf("token DACL grants Authenticated Users")
+			case "S-1-1-0":
+				t.Errorf("token DACL grants Everyone")
+			}
+		}
+		base = unsafe.Add(base, uintptr(hdr.AceSize))
+	}
+}

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -75,7 +75,7 @@ the shape is:
 |---|---|
 | REST API (`graymatter server`) | Binds `127.0.0.1` by default; bearer token on every route but `/healthz`, compared in constant time |
 | MCP over HTTP (`mcp serve --http`) | Same bearer token, same loopback default; `--no-auth` refused on non-loopback addresses |
-| Daemon RPC | 256-bit token in a `0600` discovery file, constant-time compare; Unix socket on POSIX, TCP loopback on Windows |
+| Daemon RPC | 256-bit token, constant-time compare. Unix: `0600` discovery file + kernel-enforced socket perms. Windows: TCP loopback + the discovery file and the HTTP token file carry a protected owner-only DACL (user + SYSTEM + Administrators), applied at write time and enforced by the kernel — see below |
 | Plugin install | Mandatory `sha256`, verified before install and before every call; executable copied inside the store; HTTPS-only manifests; interactive confirmation |
 | Plugin / CLI names | Whitelisted identifiers plus a containment check, so no path traversal out of the plugins dir |
 
@@ -111,9 +111,16 @@ process that can write both the record and the file.
 hijack point for every process that later resolves a command through it. Pass
 `--no-path` to skip it, or install into a directory only you can write.
 
-**`0600` is POSIX-only.** On Windows, the discovery file and the HTTP token file
-inherit their parent directory's ACL. The mode passed to `os.WriteFile` does
-nothing there.
+**`0600` is POSIX-only — mitigated for the token files.** On Windows, the
+mode passed to `os.WriteFile` does nothing; a file inherits its parent
+directory's ACL. Both secret files close that gap explicitly: the daemon's
+discovery file and the HTTP bearer-token file receive a *protected* owner-only
+DACL at write time (current user + SYSTEM + Administrators, nothing
+inherited), so even in a team-shared tree no other local user can read the
+token. Failure to apply the DACL aborts the write path instead of running
+with an unprotected credential. Remaining Windows caveat: other files in the
+data dir (including `gray.db`) still inherit directory ACLs — put the store
+in a per-user location if your tree is shared.
 
 **No rate limiting.** An authenticated client can hammer any surface.
 

--- a/pkg/memory/rpc/acl_windows.go
+++ b/pkg/memory/rpc/acl_windows.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package rpc
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// discoverySDDL is the protected DACL applied to the discovery file. The
+// token inside it is the only access control on a TCP-loopback daemon, so
+// the file must be readable by exactly: the owning user (whose memory it
+// serves), SYSTEM and Administrators (so backup and admin tooling keep
+// working, matching user-profile semantics). P marks the ACL protected — no
+// ACEs inherited from the containing directory — which is the whole point:
+// 0600 does not map to ACLs on Windows, so in a team-shared tree the file
+// would otherwise inherit grants to every local user.
+const discoverySDDLFormat = "D:P(A;;FA;;;%s)(A;;FA;;;SY)(A;;FA;;;BA)"
+
+// secureDiscoveryFile tightens the discovery file after it lands on its
+// final name; a failure aborts daemon startup rather than running with an
+// unprotected token.
+func secureDiscoveryFile(path string) error {
+	return SecureFileOwnerOnly(path)
+}
+
+// SecureFileOwnerOnly replaces path's DACL with a protected, owner-only one:
+// the current user, SYSTEM and Administrators get full access; nobody else,
+// and nothing inherited from the containing directory. It exists because a
+// 0600 mode is a POSIX promise only — on Windows os.WriteFile's mode does
+// nothing, and a secret file would inherit whatever its directory grants,
+// which in a team-shared tree includes every local user.
+func SecureFileOwnerOnly(path string) error {
+	userSID, err := currentUserSID()
+	if err != nil {
+		return fmt.Errorf("rpc: resolve current user SID: %w", err)
+	}
+	sd, err := windows.SecurityDescriptorFromString(fmt.Sprintf(discoverySDDLFormat, userSID))
+	if err != nil {
+		return fmt.Errorf("rpc: build owner-only DACL: %w", err)
+	}
+	dacl, defaulted, err := sd.DACL()
+	if err != nil {
+		return fmt.Errorf("rpc: read owner-only DACL: %w", err)
+	}
+	if defaulted || dacl == nil {
+		return fmt.Errorf("rpc: owner-only DACL missing or marked defaulted")
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil); err != nil {
+		return fmt.Errorf("rpc: apply owner-only DACL: %w", err)
+	}
+	return nil
+}
+
+func currentUserSID() (string, error) {
+	// GetCurrentProcessToken returns the pseudo-token: valid for queries,
+	// and it must not be closed.
+	u, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+	return u.User.Sid.String(), nil
+}

--- a/pkg/memory/rpc/sock.go
+++ b/pkg/memory/rpc/sock.go
@@ -81,7 +81,12 @@ func readDiscovery(dataDir string) (addr, token string, err error) {
 }
 
 // writeDiscovery atomically records the listener address and token to
-// dataDir's discovery file with 0600 perms.
+// dataDir's discovery file with 0600 perms. After the rename lands, the
+// platform hook tightens access further (a protected owner-only DACL on
+// Windows, where 0600 does not map to ACLs and the file would otherwise
+// inherit whatever its container directory grants — including in team-shared
+// trees). Failing to secure is fatal: a daemon that cannot protect its token
+// must not start.
 func writeDiscovery(dataDir, addr, token string) error {
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return err
@@ -91,7 +96,10 @@ func writeDiscovery(dataDir, addr, token string) error {
 	if err := os.WriteFile(tmp, []byte(addr+"\n"+token+"\n"), 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	return secureDiscoveryFile(path)
 }
 
 // removeDiscovery deletes the discovery file. Best-effort.

--- a/pkg/memory/rpc/sock_acl_windows_test.go
+++ b/pkg/memory/rpc/sock_acl_windows_test.go
@@ -1,0 +1,105 @@
+//go:build windows
+
+package rpc
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// aceSIDs walks a raw ACL and returns the string form of every grantee SID.
+// x/sys exposes no GetAce binding, so this follows the documented on-disk
+// layout: each ACE is a variable-length block whose first field is an
+// ACE_HEADER carrying its own size; for allow/deny ACEs the SID starts right
+// after the fixed part (header + mask = 8 bytes).
+func aceSIDs(acl *windows.ACL) ([]string, error) {
+	var out []string
+	const (
+		accessAllowedACEType = 0
+		accessDeniedACEType  = 1
+	)
+	base := unsafe.Add(unsafe.Pointer(acl), unsafe.Sizeof(*acl))
+	for i := 0; i < int(acl.AceCount); i++ {
+		if uintptr(base)%4 != 0 {
+			return nil, errors.New("ace pointer not 4-byte aligned")
+		}
+		hdr := (*windows.ACE_HEADER)(base)
+		switch hdr.AceType {
+		case accessAllowedACEType, accessDeniedACEType:
+			sid := (*windows.SID)(unsafe.Add(base, 8))
+			out = append(out, sid.String())
+		}
+		base = unsafe.Add(base, uintptr(hdr.AceSize))
+	}
+	return out, nil
+}
+
+// The discovery file is the daemon's only access control on Windows: the
+// listener binds TCP loopback, which every local process can reach, so
+// whoever reads the token can drive the store. A 0600 mode does NOT map to
+// ACLs there — the file inherits whatever its containing directory grants,
+// which in a team-shared tree means every local user. The regression this
+// pins: writeDiscovery must leave behind a DACL that grants nothing to
+// BUILTIN\Users (S-1-5-32-545), Authenticated Users (S-1-5-11) or Everyone,
+// and whose every ACE belongs to the owning user, SYSTEM or Administrators.
+func TestDiscoveryFileDACL_IsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	const addr = "tcp://127.0.0.1:1"
+	token := "cafebabe" + strings.Repeat("0", 56)
+	if err := writeDiscovery(dir, addr, token); err != nil {
+		t.Fatalf("writeDiscovery: %v", err)
+	}
+	path := DiscoveryFilePath(dir)
+
+	// The legitimate owner path keeps working: same process can read.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("owner cannot read discovery file: %v", err)
+	}
+	if !strings.Contains(string(data), token) {
+		t.Error("token missing from discovery file")
+	}
+
+	userSID, err := currentUserSID()
+	if err != nil {
+		t.Fatalf("resolve current user SID: %v", err)
+	}
+	allowed := map[string]bool{
+		userSID:        true, // the owner
+		"S-1-5-18":     true, // SYSTEM — backup/admin tooling semantics
+		"S-1-5-32-544": true, // Administrators
+	}
+	forbidden := map[string]string{
+		"S-1-5-32-545": "BUILTIN\\Users",
+		"S-1-5-11":     "Authenticated Users",
+		"S-1-1-0":      "Everyone",
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("read security descriptor: %v", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil || dacl == nil {
+		t.Fatalf("read DACL: v=%v", err)
+	}
+	if dacl.AceCount == 0 {
+		t.Fatal("DACL carries no ACEs")
+	}
+	sids, err := aceSIDs(dacl)
+	if err != nil {
+		t.Fatalf("walk DACL: %v", err)
+	}
+	for _, sid := range sids {
+		if reason, bad := forbidden[sid]; bad {
+			t.Errorf("discovery DACL grants %s (%s)", sid, reason)
+		} else if !allowed[sid] {
+			t.Errorf("unexpected ACE for %q in discovery DACL", sid)
+		}
+	}
+}

--- a/pkg/memory/rpc/sock_unix.go
+++ b/pkg/memory/rpc/sock_unix.go
@@ -22,6 +22,12 @@ const maxUnixSocketPath = 100
 // runtimeDirPerm is the mode the fallback directory must have: owner only.
 const runtimeDirPerm = 0o700
 
+// secureDiscoveryFile tightens the discovery file's access after it lands on
+// its final name. On Unix this is a no-op: the 0600 mode bits written by
+// os.WriteFile are enforced by the kernel, and the OS permission model is
+// the primary gate for the whole data dir.
+func secureDiscoveryFile(_ string) error { return nil }
+
 // socketPath chooses where to bind the daemon socket. It prefers a socket
 // inside dataDir (nice for `ls .graymatter`), but deeply nested project
 // paths can blow past sun_path — so when the in-dir path is too long it

--- a/pkg/memory/rpc/sock_unix.go
+++ b/pkg/memory/rpc/sock_unix.go
@@ -28,6 +28,11 @@ const runtimeDirPerm = 0o700
 // the primary gate for the whole data dir.
 func secureDiscoveryFile(_ string) error { return nil }
 
+// SecureFileOwnerOnly is the cross-platform hook shared with other secret
+// files (the HTTP bearer token). On Unix the mode bits already carry the
+// whole promise, so there is nothing further to apply.
+func SecureFileOwnerOnly(_ string) error { return nil }
+
 // socketPath chooses where to bind the daemon socket. It prefers a socket
 // inside dataDir (nice for `ls .graymatter`), but deeply nested project
 // paths can blow past sun_path — so when the in-dir path is too long it


### PR DESCRIPTION
Closes A8 / implements step 1 of W4 in the hardening playbook.

**The gap (from the threat model, stated plainly until now):** on Windows, the mode passed to `os.WriteFile` maps to nothing - a file inherits its containing directory's ACL. The daemon binds TCP loopback (reachable by every local process), so the token in the discovery file was the only access control, and in a team-shared tree that token was readable by every local user. The persisted HTTP bearer token had the identical exposure class.

**The fix**

- `rpc.SecureFileOwnerOnly(path)`: applies a **protected** owner-only DACL (`D:P(A;;FA;;;<user>)(A;;FA;;;SY)(A;;FA;;;BA)`) via `SetNamedSecurityInfo` - current user + SYSTEM + Administrators, nothing inherited. `P` is the load-bearing part: without it the directory's group grants keep flowing in.
- Applied after the atomic rename in `writeDiscovery`; failure aborts daemon startup rather than running with an unprotected token.
- `httpauth.LoadOrCreateToken` does the same for `graymatter.http-token`, and removes the file if securing fails.
- Unix: no-op hook - mode bits already are the kernel-enforced gate there; zero behaviour change (cross-compile verified).

**Tests** (Windows)

- Discovery file: every ACE enumerated from the live DACL belongs to user/SYSTEM/Administrators; BUILTIN\Users (S-1-5-32-545), Authenticated Users (S-1-5-11) and Everyone are explicitly asserted absent; owner read-back still works.
- HTTP token file: same assertions through the public `LoadOrCreateToken` path.
- Full suite green on both modules; `go vet ./...` clean including the `unsafe.Add` ACE walker.

**Docs**: threat-model.md updated - the "`0600` is POSIX-only" known-gap bullet now documents the mechanism and the residual caveat (`gray.db` still inherits directory ACLs; put the store in a per-user location on shared trees). Step 2 of the playbook (named pipe with an explicit SecurityDescriptor) remains a separate ADR by design.
