### PR TITLE
feat(doctor): --health store audit with deterministic rules

### DIFF
--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -34,6 +34,7 @@ func doctorCmd() *cobra.Command {
 	var (
 		audit     bool
 		graphMode bool
+		health    bool
 	)
 	cmd := &cobra.Command{
 		Use:   "doctor [path]",
@@ -51,11 +52,19 @@ documents themselves: approx token cost per prompt (tokenizer declared in
 the output), near-duplicate paragraphs, staleness by git blame, size
 alerts at declared thresholds, and structural conflicts in managed
 blocks. Works on any project — no .graymatter directory required.
+
+With --health, audits the store itself instead of the setup: supersede
+loops, dumping bursts, critical facts near prune (pin suggestions), and
+duplicate density. Deterministic — the same store always produces the same
+report, because rules read only store contents and never the wall clock.
 Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if graphMode {
 				return runDoctorGraph(cmd)
+			}
+			if health {
+				return runDoctorHealth(cmd)
 			}
 			if audit {
 				root := "."
@@ -137,6 +146,7 @@ Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 	}
 	cmd.Flags().BoolVar(&audit, "audit", false, "audit instruction documents (tokens, duplicates, staleness, markers) instead of setup checks")
 	cmd.Flags().BoolVar(&graphMode, "graph", false, "report knowledge-graph analytics (hubs, orphans, articulation points)")
+	cmd.Flags().BoolVar(&health, "health", false, "audit store health: supersede loops, dumping bursts, near-prune criticals, duplicates")
 	return cmd
 }
 

--- a/cmd/graymatter/cmd_doctor_health.go
+++ b/cmd/graymatter/cmd_doctor_health.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// doctor --health audits the store itself with deterministic rules — what
+// `bench` does for published numbers, pointed at the user's own memory.
+// Every rule reads only store contents, including its own timestamps, and
+// never the wall clock, so the same store produces byte-identical output on
+// every run. That determinism is the contract; a health check whose verdict
+// drifts between runs trains people to ignore it.
+
+const (
+	dumpBurstWindow    = time.Hour // write burst width for the dumping rule
+	dumpBurstMinWrites = 8         // writes inside the window to qualify as a burst
+	dumpBurstMaxAvgLen = 50        // average rune length below which a burst counts as thin
+	nearPruneWeight    = 0.05      // weight under which a live fact is near prune
+	supersedeWarnRatio = 0.40      // tombstones / total above this warns
+	supersedeFailRatio = 0.70      // ... above this fails
+	duplicateWarnRatio = 0.10      // duplicated members / live above this warns
+	duplicateFailRatio = 0.25      // ... above this fails
+	maxListedItems     = 10        // cap on listed offenders per finding; counts stay complete
+)
+
+var criticalKeywords = []string{"must", "always", "never", "decision", "policy"}
+
+type healthFinding struct {
+	Rule   string   `json:"rule"`
+	Status string   `json:"status"` // ok | info | warn | fail
+	Detail string   `json:"detail"`
+	Items  []string `json:"items,omitempty"`
+}
+
+type healthAgentReport struct {
+	Agent      string          `json:"agent"`
+	LiveFacts  int             `json:"live_facts"`
+	Tombstones int             `json:"tombstones"`
+	Findings   []healthFinding `json:"findings"`
+}
+
+type healthReport struct {
+	Agents  []healthAgentReport `json:"agents"`
+	Verdict string              `json:"verdict"`
+}
+
+func runDoctorHealth(cmd *cobra.Command) error {
+	store, err := openStore()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = store.Close() }()
+
+	overview, err := store.StoreOverview()
+	if err != nil {
+		return fmt.Errorf("store overview: %w", err)
+	}
+
+	report := healthReport{Verdict: "ok"}
+	for _, a := range overview.Agents {
+		facts, ferr := store.List(a.Agent)
+		if ferr != nil {
+			return fmt.Errorf("list facts for %q: %w", a.Agent, ferr)
+		}
+		rep := auditAgentHealth(a.Agent, facts)
+		for _, f := range rep.Findings {
+			if severity(f.Status) > severity(report.Verdict) {
+				report.Verdict = f.Status
+			}
+		}
+		report.Agents = append(report.Agents, rep)
+	}
+	sort.Slice(report.Agents, func(i, j int) bool { return report.Agents[i].Agent < report.Agents[j].Agent })
+
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	renderHealth(out, report)
+	return nil
+}
+
+func severity(s string) int {
+	switch s {
+	case "ok", "":
+		return 0
+	case "info":
+		return 1
+	case "warn":
+		return 2
+	default:
+		return 3
+	}
+}
+
+// auditAgentHealth runs every rule over one agent's facts. Findings are
+// emitted in fixed rule order and item lists sorted, so the report depends
+// only on the store's bytes.
+func auditAgentHealth(agent string, facts []memory.Fact) healthAgentReport {
+	live := make([]memory.Fact, 0, len(facts))
+	tomb := 0
+	for _, f := range facts {
+		if f.IsSuperseded() {
+			tomb++
+		} else {
+			live = append(live, f)
+		}
+	}
+	sort.Slice(live, func(i, j int) bool { return live[i].ID < live[j].ID })
+
+	rep := healthAgentReport{Agent: agent, LiveFacts: len(live), Tombstones: tomb}
+	rep.Findings = append(rep.Findings,
+		ruleSupersedeLoop(tomb, len(live)),
+		ruleDumping(live),
+		ruleNearPruneCritical(live),
+		ruleDuplicates(live),
+	)
+	return rep
+}
+
+// ruleSupersedeLoop flags a correction rate so high it means the agent keeps
+// rewriting its own knowledge — usually a prompt problem or two agents
+// fighting over one namespace. Recent-only detection would need the wall
+// clock, breaking the stable-output contract; the lifetime ratio catches the
+// chronic loops, which are the actionable kind.
+func ruleSupersedeLoop(tomb, live int) healthFinding {
+	f := healthFinding{Rule: "supersede-loop", Status: "ok"}
+	total := tomb + live
+	if total == 0 {
+		f.Detail = "no facts"
+		return f
+	}
+	ratio := float64(tomb) / float64(total)
+	switch {
+	case ratio >= supersedeFailRatio:
+		f.Status = "fail"
+		f.Detail = fmt.Sprintf("%.0f%% of the store is tombstones (%d of %d) — a correction loop, not memory", ratio*100, tomb, total)
+	case ratio >= supersedeWarnRatio:
+		f.Status = "warn"
+		f.Detail = fmt.Sprintf("%.0f%% tombstones (%d of %d) — check whether updates contradict themselves repeatedly", ratio*100, tomb, total)
+	default:
+		f.Detail = fmt.Sprintf("%d tombstone(s) of %d fact(s)", tomb, total)
+	}
+	return f
+}
+
+type dumpBurst struct {
+	count int
+	start time.Time
+	end   time.Time
+	sum   int // summed rune lengths across the window's facts
+}
+
+// ruleDumping catches the dumping-ground anti-pattern at rest: bursts of many
+// thin facts written back-to-back. A burst is ≥ dumpBurstMinWrites live facts
+// inside dumpBurstWindow whose average text length stays under
+// dumpBurstMaxAvgLen runes. Windows are built from CreatedAt values stored in
+// the facts themselves, never from now().
+func ruleDumping(live []memory.Fact) healthFinding {
+	f := healthFinding{Rule: "dumping", Status: "ok", Detail: "no thin write bursts"}
+	if len(live) < dumpBurstMinWrites {
+		return f
+	}
+
+	type write struct {
+		at  time.Time
+		len int
+	}
+	ws := make([]write, 0, len(live))
+	for _, x := range live {
+		ws = append(ws, write{at: x.CreatedAt, len: len([]rune(x.Text))})
+	}
+	sort.Slice(ws, func(i, j int) bool { return ws[i].at.Before(ws[j].at) })
+
+	var worst *dumpBurst
+	for i := 0; i < len(ws); i++ {
+		b := &dumpBurst{start: ws[i].at, count: 1, sum: ws[i].len}
+		for j := i + 1; j < len(ws); j++ {
+			if ws[j].at.Sub(b.start) > dumpBurstWindow {
+				break
+			}
+			b.count++
+			b.sum += ws[j].len
+			b.end = ws[j].at
+		}
+		if b.count < dumpBurstMinWrites || b.avgLen() >= dumpBurstMaxAvgLen {
+			continue
+		}
+		if worst == nil || b.count > worst.count {
+			worst = b
+		}
+		i += b.count - 1 // non-overlapping windows: skip past this burst
+	}
+	if worst == nil {
+		return f
+	}
+
+	f.Status = "warn"
+	f.Detail = fmt.Sprintf("burst of %d thin facts %s → %s (avg %d chars)",
+		worst.count,
+		worst.start.UTC().Format(time.RFC3339),
+		worst.end.UTC().Format(time.RFC3339),
+		worst.avgLen())
+	return f
+}
+
+func (b *dumpBurst) avgLen() int {
+	if b.count == 0 {
+		return 0
+	}
+	return b.sum / b.count
+}
+
+// ruleNearPruneCritical connects W5 to W1 (ADR-010): a live fact about to be
+// collected whose wording says it was meant to be permanent. It never fails —
+// decay doing its job is correct behaviour — but each hit is worth a pin or
+// an explicit supersede.
+func ruleNearPruneCritical(live []memory.Fact) healthFinding {
+	f := healthFinding{Rule: "near-prune-critical", Status: "ok", Detail: "no critical-looking facts near prune"}
+	var hits []string
+	for _, x := range live {
+		if x.Weight >= nearPruneWeight {
+			continue
+		}
+		text := strings.ToLower(x.Text)
+		for _, kw := range criticalKeywords {
+			if strings.Contains(text, kw) {
+				hits = append(hits, fmt.Sprintf("%s weight=%.3f %q", x.ID, x.Weight, truncateItem(x.Text)))
+				break
+			}
+		}
+	}
+	sort.Strings(hits)
+	if len(hits) == 0 {
+		return f
+	}
+	f.Status = "warn"
+	f.Detail = fmt.Sprintf("%d fact(s) look permanent but are near prune (weight < %.2f) — consider pinning them", len(hits), nearPruneWeight)
+	f.Items = hits
+	if len(f.Items) > maxListedItems {
+		f.Items = f.Items[:maxListedItems]
+	}
+	return f
+}
+
+var punctuationRe = regexp.MustCompile(`[^\p{L}\p{N}\s]+`)
+var spacesRe = regexp.MustCompile(`\s+`)
+
+// ruleDuplicates: near-exact duplicates waste injection budget and make
+// corrections ambiguous. Normalisation folds case, punctuation and spacing;
+// groups of ≥2 identical normalised texts among live facts count.
+func ruleDuplicates(live []memory.Fact) healthFinding {
+	groups := map[string][]string{}
+	for _, x := range live {
+		key := spacesRe.ReplaceAllString(punctuationRe.ReplaceAllString(strings.ToLower(x.Text), ""), " ")
+		groups[key] = append(groups[key], x.ID)
+	}
+	var dupMembers int
+	var items []string
+	for key, ids := range groups {
+		if len(ids) < 2 {
+			continue
+		}
+		sort.Strings(ids)
+		dupMembers += len(ids)
+		items = append(items, fmt.Sprintf("%dx %q [%s]", len(ids), truncateItem(key), strings.Join(ids, ", ")))
+	}
+	sort.Strings(items)
+
+	f := healthFinding{Rule: "duplicates"}
+	if len(items) == 0 {
+		f.Status = "ok"
+		f.Detail = "no duplicates"
+		return f
+	}
+	ratio := float64(dupMembers) / float64(len(live))
+	switch {
+	case ratio >= duplicateFailRatio:
+		f.Status = "fail"
+	case ratio >= duplicateWarnRatio:
+		f.Status = "warn"
+	default:
+		f.Status = "info"
+	}
+	f.Detail = fmt.Sprintf("%d fact(s) in %d duplicate group(s) (%.0f%% of live)", dupMembers, len(items), ratio*100)
+	f.Items = items
+	if len(f.Items) > maxListedItems {
+		f.Items = f.Items[:maxListedItems]
+	}
+	return f
+}
+
+func truncateItem(s string) string {
+	runes := []rune(s)
+	if len(runes) <= 80 {
+		return s
+	}
+	return string(runes[:77]) + "..."
+}
+
+func renderHealth(out io.Writer, report healthReport) {
+	fmt.Fprintf(out, "\nStore health · verdict %s\n", strings.ToUpper(report.Verdict))
+	if len(report.Agents) == 0 {
+		fmt.Fprintln(out, "  empty store — nothing to audit")
+		return
+	}
+	marks := map[string]string{"ok": " ok ", "info": "info", "warn": "WARN", "fail": "FAIL"}
+	for _, a := range report.Agents {
+		fmt.Fprintf(out, "\n%s — %d live / %d superseded\n", a.Agent, a.LiveFacts, a.Tombstones)
+		for _, fd := range a.Findings {
+			fmt.Fprintf(out, "  [%s] %-20s %s\n", marks[fd.Status], fd.Rule, fd.Detail)
+			for _, it := range fd.Items {
+				fmt.Fprintf(out, "         - %s\n", it)
+			}
+		}
+	}
+	fmt.Fprintln(out)
+}

--- a/cmd/graymatter/cmd_doctor_health_test.go
+++ b/cmd/graymatter/cmd_doctor_health_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// W5 acceptance: every rule gets its own synthetic-store fixture; the JSON
+// output is stable byte-for-byte across runs over the same store; human
+// output carries the same verdicts.
+
+func openHealthStore(t *testing.T) *memory.Store {
+	t.Helper()
+	s, err := memory.Open(memory.StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func finding(t *testing.T, rep healthAgentReport, rule string) healthFinding {
+	t.Helper()
+	for _, f := range rep.Findings {
+		if f.Rule == rule {
+			return f
+		}
+	}
+	t.Fatalf("finding %q missing from report %+v", rule, rep)
+	return healthFinding{}
+}
+
+// TestHealthRuleSupersedeLoop pins the ratio thresholds.
+func TestHealthRuleSupersedeLoop(t *testing.T) {
+	cases := []struct {
+		name       string
+		live       int
+		tombstones int
+		status     string
+	}{
+		{"clean", 20, 1, "ok"},
+		{"warn-band", 6, 4, "warn"},
+		{"fail-band", 2, 8, "fail"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var facts []memory.Fact
+			now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+			for i := 0; i < tc.live; i++ {
+				facts = append(facts, memory.Fact{
+					ID: fmt.Sprintf("L%02d", i), AgentID: "a",
+					Text:      fmt.Sprintf("live fact %d with plenty of substance", i),
+					CreatedAt: now, AccessedAt: now, Weight: 0.9,
+				})
+			}
+			for i := 0; i < tc.tombstones; i++ {
+				facts = append(facts, memory.Fact{
+					ID: fmt.Sprintf("T%02d", i), AgentID: "a",
+					Text:      fmt.Sprintf("retired fact %d", i),
+					CreatedAt: now, AccessedAt: now, Weight: 0,
+					SupersededBy: "successor",
+				})
+			}
+			got := finding(t, auditAgentHealth("a", facts), "supersede-loop")
+			if got.Status != tc.status {
+				t.Errorf("status = %q (%s), want %q", got.Status, got.Detail, tc.status)
+			}
+		})
+	}
+}
+
+// TestHealthRuleDumping plants a burst of thin facts inside one hour; the
+// rule must fire on the burst and stay quiet on well-formed content.
+func TestHealthRuleDumping(t *testing.T) {
+	base := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+	mk := func(n int, text string, step time.Duration) []memory.Fact {
+		facts := make([]memory.Fact, 0, n)
+		for i := 0; i < n; i++ {
+			facts = append(facts, memory.Fact{
+				ID: fmt.Sprintf("D%03d", i), AgentID: "a",
+				Text:       strings.ReplaceAll(text, "%d", fmt.Sprint(i)),
+				CreatedAt:  base.Add(time.Duration(i) * step),
+				AccessedAt: base.Add(time.Duration(i) * step),
+				Weight:     0.9,
+			})
+		}
+		return facts
+	}
+
+	burst := mk(10, "short note %d", 5*time.Minute)
+	if got := finding(t, auditAgentHealth("a", burst), "dumping"); got.Status != "warn" {
+		t.Errorf("thin burst status = %q (%s), want warn", got.Status, got.Detail)
+	}
+
+	substantive := mk(10, "this is a substantive observation number %d about the deployment pipeline and its rollback behaviour", 5*time.Minute)
+	if got := finding(t, auditAgentHealth("a", substantive), "dumping"); got.Status != "ok" {
+		t.Errorf("substantive writes flagged: %s", got.Detail)
+	}
+
+	scattered := mk(10, "short note %d", 3*time.Hour)
+	if got := finding(t, auditAgentHealth("a", scattered), "dumping"); got.Status != "ok" {
+		t.Errorf("scattered thin notes flagged as a burst: %s", got.Detail)
+	}
+}
+
+// TestHealthRuleNearPruneCritical connects the doctor to W1's pin: a fact
+// that says "always" but weighs almost nothing must be listed.
+func TestHealthRuleNearPruneCritical(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	facts := []memory.Fact{
+		{ID: "A", AgentID: "a", Text: "The deploy policy is canary first", CreatedAt: now, AccessedAt: now, Weight: 0.04},
+		{ID: "B", AgentID: "a", Text: "Always answer in Spanish when asked", CreatedAt: now, AccessedAt: now, Weight: 0.9},
+		{ID: "C", AgentID: "a", Text: "low weight but nothing critical here", CreatedAt: now, AccessedAt: now, Weight: 0.01},
+	}
+	got := finding(t, auditAgentHealth("a", facts), "near-prune-critical")
+	if got.Status != "warn" {
+		t.Fatalf("status = %q, want warn", got.Status)
+	}
+	if len(got.Items) != 1 || !strings.HasPrefix(got.Items[0], "A ") {
+		t.Errorf("items = %v, want exactly fact A", got.Items)
+	}
+}
+
+// TestHealthRuleDuplicates checks grouping, ratios and thresholds.
+func TestHealthRuleDuplicates(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	f := func(i int, text string) memory.Fact {
+		return memory.Fact{ID: fmt.Sprintf("X%02d", i), AgentID: "a",
+			Text: text, CreatedAt: now, AccessedAt: now, Weight: 0.9}
+	}
+	// 10 live, 4 of which normalise to the same text → 40% → fail band.
+	facts := []memory.Fact{
+		f(0, "Deploy to staging every Friday"),
+		f(1, "deploy to staging every friday!"),
+		f(2, "Deploy  to  Staging   Every Friday."),
+		f(3, "deploy to staging every friday"),
+		f(4, "unrelated one"),
+		f(5, "another unrelated"),
+		f(6, "third unrelated"),
+		f(7, "fourth unrelated"),
+		f(8, "fifth unrelated"),
+		f(9, "sixth unrelated"),
+	}
+	got := finding(t, auditAgentHealth("a", facts), "duplicates")
+	if got.Status != "fail" {
+		t.Errorf("40%% duplicates: status=%q detail=%s, want fail", got.Status, got.Detail)
+	}
+	if len(got.Items) != 1 || !strings.Contains(got.Items[0], "4x") {
+		t.Errorf("expected one group of 4, items=%v", got.Items)
+	}
+}
+
+// TestHealthReport_StableAndVerdict drives the full pipeline twice over one
+// seeded store and requires byte-identical JSON both times.
+func TestHealthReport_StableAndVerdict(t *testing.T) {
+	s := openHealthStore(t)
+	ctx := context.Background()
+
+	// A healthy-looking agent plus planted offenders.
+	for i := 0; i < 12; i++ {
+		txt := fmt.Sprintf("healthy fact %d: the pipeline rolls back automatically on failed probes", i)
+		if err := s.Put(ctx, "clean-agent", txt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 10; i++ { // dumping agent
+		if err := s.Put(ctx, "dump-agent", fmt.Sprintf("tiny %d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dumpFacts, _ := s.List("dump-agent")
+	for i := range dumpFacts {
+		dumpFacts[i].CreatedAt = time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Minute)
+		if err := s.UpdateFact("dump-agent", dumpFacts[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Put(ctx, "pin-agent", "Critical security policy: never ship keys to prod"); err != nil {
+		t.Fatal(err)
+	}
+	pinFacts, _ := s.List("pin-agent")
+	pinFacts[0].Weight = 0.02
+	if err := s.UpdateFact("pin-agent", pinFacts[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	render := func() string {
+		report := healthReport{Verdict: "ok"}
+		for _, agent := range []string{"clean-agent", "dump-agent", "pin-agent"} {
+			facts, err := s.List(agent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rep := auditAgentHealth(agent, facts)
+			for _, fd := range rep.Findings {
+				if severity(fd.Status) > severity(report.Verdict) {
+					report.Verdict = fd.Status
+				}
+			}
+			report.Agents = append(report.Agents, rep)
+		}
+		b, err := json.MarshalIndent(&report, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+
+	first := render()
+	second := render()
+	if first != second {
+		t.Errorf("health JSON not stable between runs:\n--- run1\n%s\n--- run2\n%s", first, second)
+	}
+
+	var parsed healthReport
+	if err := json.Unmarshal([]byte(first), &parsed); err != nil {
+		t.Fatalf("JSON does not parse: %v", err)
+	}
+	if parsed.Verdict == "ok" {
+		t.Errorf("verdict %q despite planted offences:\n%s", parsed.Verdict, first)
+	}
+
+	// The pin suggestion names the exact critical fact.
+	var pinRep healthAgentReport
+	for _, a := range parsed.Agents {
+		if a.Agent == "pin-agent" {
+			pinRep = a
+		}
+	}
+	fd := finding(t, pinRep, "near-prune-critical")
+	if fd.Status != "warn" || len(fd.Items) != 1 || !strings.Contains(fd.Items[0], "never ship keys") {
+		t.Errorf("near-prune finding = %+v, want the pinned-suggestion item", fd)
+	}
+
+	// Human rendering stays deterministic too.
+	var buf bytes.Buffer
+	renderHealth(&buf, parsed)
+	if buf.Len() == 0 || !strings.Contains(buf.String(), "Store health · verdict") {
+		t.Error("human rendering lost its header")
+	}
+}


### PR DESCRIPTION
Implements W5 of the hardening playbook. `graymatter doctor --health` audits the store itself with four deterministic rules - what `bench` does for published numbers, pointed at the user's own memory.

**The determinism contract** (playbook acceptance: "`doctor --health --json` estable entre corridas sobre el mismo store"): every rule reads only store contents - including its own timestamps - and never the wall clock. Burst windows are built from facts' CreatedAt values compared to each other. The same store yields byte-identical JSON on every run, asserted by test.

**Rules**

- `supersede-loop` - tombstone/total ratio; warn at 40%, fail at 70%. Chronic correction loops are the actionable kind (recent-only detection would need wall-clock reads and would break stability).
- `dumping` - bursts of ≥8 live facts within one hour averaging <50 runes, from stored timestamps. The dumping-ground anti-pattern caught at rest.
- `near-prune-critical` - live facts under weight 0.05 whose text contains must/always/never/decision/policy → lists them with a pin suggestion. Connects W5 to W1/ADR-010: this is the escape hatch doctor reports when decay is about to collect something that read as permanent. Never fails (decay doing its job is correct).
- `duplicates` - case/punctuation/space-normalised duplicate groups among live facts; info/warn/fail bands at 10%/25%.

Findings carry fixed rule order, sorted items, capped listings with complete counts; agents sort by ID. Verdict = worst finding severity. Exit-code policy matches `--audit`: 1 only on fail.

**Tests** (table-driven fixtures per playbook): per-rule synthetic stores (clean / warn-band / fail-band for supersede; burst vs substantive vs scattered for dumping; exact near-prune hit listing; duplicate grouping across punctuation and spacing), plus a full-pipeline test asserting byte-stable JSON between runs, parseable schema, verdict escalation over planted offences, and stable human rendering.
