### PR TITLE
doctor --embeddings: audit the vector channel the way the store observed it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **`graymatter doctor --embeddings` makes the silent keyword-only fallback visible.**
+  `Put` degrades a fact to keyword-only whenever the embedder errors and still returns nil,
+  so a broken backend was indistinguishable from an empty store. The store now records the
+  lifetime degradation count and the last error (`Store.EmbeddingHealth`, `Store.CountEmbeddings`),
+  and the new audit reports vector coverage over live facts, degraded writes, the retry
+  backlog, and which of the three honest states you are in: healthy channel, supported
+  keyword-only (ADR-005), or a failing backend hiding behind that silence. Deterministic like
+  `doctor --health` — reads only store bytes, byte-identical output per store, works with the
+  daemon down.
+
 ### Fixed
 
 - **The embeddings chain's third slot works.** It dialled

--- a/cmd/graymatter/cmd_doctor.go
+++ b/cmd/graymatter/cmd_doctor.go
@@ -32,9 +32,10 @@ type checkResult struct {
 
 func doctorCmd() *cobra.Command {
 	var (
-		audit     bool
-		graphMode bool
-		health    bool
+		audit      bool
+		graphMode  bool
+		health     bool
+		embeddings bool
 	)
 	cmd := &cobra.Command{
 		Use:   "doctor [path]",
@@ -57,7 +58,13 @@ With --health, audits the store itself instead of the setup: supersede
 loops, dumping bursts, critical facts near prune (pin suggestions), and
 duplicate density. Deterministic — the same store always produces the same
 report, because rules read only store contents and never the wall clock.
-Exit code is 1 only when a finding is a failure; warnings exit 0.`,
+Exit code is 1 only when a finding is a failure; warnings exit 0.
+
+With --embeddings, audits the vector channel as the store observed it:
+how many live facts carry a vector, how many writes degraded to
+keyword-only because the embedder failed, the last failure's message,
+and the vector retry backlog. Deterministic like --health, and it works
+even when the daemon is down (read-only probe of gray.db).`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if graphMode {
@@ -65,6 +72,9 @@ Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 			}
 			if health {
 				return runDoctorHealth(cmd)
+			}
+			if embeddings {
+				return runDoctorEmbeddings(cmd)
 			}
 			if audit {
 				root := "."
@@ -147,6 +157,7 @@ Exit code is 1 only when a finding is a failure; warnings exit 0.`,
 	cmd.Flags().BoolVar(&audit, "audit", false, "audit instruction documents (tokens, duplicates, staleness, markers) instead of setup checks")
 	cmd.Flags().BoolVar(&graphMode, "graph", false, "report knowledge-graph analytics (hubs, orphans, articulation points)")
 	cmd.Flags().BoolVar(&health, "health", false, "audit store health: supersede loops, dumping bursts, near-prune criticals, duplicates")
+	cmd.Flags().BoolVar(&embeddings, "embeddings", false, "audit the vector channel as the store observed it: coverage, degraded writes, retry backlog")
 	return cmd
 }
 

--- a/cmd/graymatter/cmd_doctor_embeddings.go
+++ b/cmd/graymatter/cmd_doctor_embeddings.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// doctor --embeddings audits the vector channel as the store itself observed
+// it: how many live facts carry a vector, how many writes degraded to
+// keyword-only because the embedder failed, what the last failure said, and
+// how much of the retry backlog remains. It reads only store bytes, so the
+// same store produces byte-identical output on every run — the same contract
+// as --health. It works even when the daemon is down, which is precisely
+// when you most need to know whether memory was quietly losing its vectors.
+
+type embeddingsFinding struct {
+	Rule   string `json:"rule"`
+	Status string `json:"status"` // ok | info | warn | fail
+	Detail string `json:"detail"`
+	Hint   string `json:"hint,omitempty"`
+}
+
+type embeddingsReport struct {
+	EmbedDims      int                 `json:"embed_dims"`
+	LiveFacts      int                 `json:"live_facts"`
+	FactsWithVec   int                 `json:"facts_with_vector"`
+	DegradedFacts  int                 `json:"degraded_facts"`
+	LastDegradErr  string              `json:"last_degrade_error,omitempty"`
+	PendingVectors int                 `json:"pending_vectors"`
+	Findings       []embeddingsFinding `json:"findings"`
+	Verdict        string              `json:"verdict"`
+}
+
+func runDoctorEmbeddings(cmd *cobra.Command) error {
+	store, err := memory.Open(memory.StoreConfig{DataDir: dataDir, ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("open store read-only: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	rep := buildEmbeddingsReport(store)
+
+	out := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rep)
+	}
+	renderEmbeddings(out, rep)
+	return nil
+}
+
+// buildEmbeddingsReport runs every rule over the store in fixed order.
+// Findings depend only on the store's bytes.
+func buildEmbeddingsReport(store *memory.Store) embeddingsReport {
+	rep := embeddingsReport{Verdict: "ok"}
+
+	h, err := store.EmbeddingHealth()
+	if err == nil {
+		rep.EmbedDims = h.EmbedDims
+		rep.DegradedFacts = h.DegradedFacts
+		rep.LastDegradErr = h.LastDegradError
+		rep.PendingVectors = h.PendingVectors
+	}
+	withVec, total, err := store.CountEmbeddings()
+	if err == nil {
+		rep.FactsWithVec = withVec
+		rep.LiveFacts = total
+	}
+
+	cover := ruleVectorCoverage(rep)
+	degr := ruleEmbedDegradation(rep)
+	pend := rulePendingVectors(rep)
+	rep.Findings = append(rep.Findings, cover, degr, pend)
+
+	for _, f := range rep.Findings {
+		if severity(f.Status) > severity(rep.Verdict) {
+			rep.Verdict = f.Status
+		}
+	}
+	return rep
+}
+
+func ruleVectorCoverage(rep embeddingsReport) embeddingsFinding {
+	f := embeddingsFinding{Rule: "vector-coverage"}
+	switch {
+	case rep.LiveFacts == 0:
+		f.Status = "info"
+		f.Detail = "no live facts stored yet - nothing to index"
+	case rep.FactsWithVec == rep.LiveFacts:
+		f.Status = "ok"
+		f.Detail = fmt.Sprintf("every live fact carries a vector (%d/%d, dims %d)", rep.FactsWithVec, rep.LiveFacts, rep.EmbedDims)
+	case rep.FactsWithVec > 0:
+		f.Status = "info"
+		f.Detail = fmt.Sprintf("mixed store: %d of %d live facts carry a vector", rep.FactsWithVec, rep.LiveFacts)
+		f.Hint = "facts written while no provider was configured stay keyword-only; new writes pick up the current provider automatically"
+	default:
+		f.Status = "info"
+		if rep.DegradedFacts == 0 {
+			f.Detail = fmt.Sprintf("keyword-only memory: %d live facts, none indexed, no recorded failures", rep.LiveFacts)
+			f.Hint = "keyword-only is a supported configuration (ADR-005); for vectors, make Ollama reachable or set OPENAI_API_KEY / VOYAGE_API_KEY"
+		} else {
+			f.Status = "warn"
+			f.Detail = fmt.Sprintf("%d live facts, none indexed, %d write(s) degraded", rep.LiveFacts, rep.DegradedFacts)
+		}
+	}
+	return f
+}
+
+func ruleEmbedDegradation(rep embeddingsReport) embeddingsFinding {
+	f := embeddingsFinding{Rule: "embed-degradation"}
+	if rep.DegradedFacts == 0 {
+		f.Status = "ok"
+		f.Detail = "no embedder failures recorded"
+		return f
+	}
+	f.Status = "warn"
+	f.Detail = fmt.Sprintf("%d fact(s) were written keyword-only because the embedder failed", rep.DegradedFacts)
+	if rep.LastDegradErr != "" {
+		f.Detail += "; last error: " + rep.LastDegradErr
+	}
+	f.Hint = "check your embedding configuration: Ollama reachable (GRAYMATTER_OLLAMA_URL), or OPENAI_API_KEY, or VOYAGE_API_KEY"
+	return f
+}
+
+func rulePendingVectors(rep embeddingsReport) embeddingsFinding {
+	f := embeddingsFinding{Rule: "pending-vectors"}
+	if rep.PendingVectors == 0 {
+		f.Status = "ok"
+		f.Detail = "vector retry queue empty"
+		return f
+	}
+	f.Status = "warn"
+	f.Detail = fmt.Sprintf("%d pending vector write(s)", rep.PendingVectors)
+	f.Hint = "a queue that never drains means the embedding backend keeps failing - check your embedding configuration"
+	return f
+}
+
+func renderEmbeddings(out interface{ Write([]byte) (int, error) }, rep embeddingsReport) {
+	fmt.Fprintf(out, "Embedding channel audit\n\n")
+	fmt.Fprintf(out, "  dims %d   live facts %d   with vector %d   degraded %d   pending %d\n\n",
+		rep.EmbedDims, rep.LiveFacts, rep.FactsWithVec, rep.DegradedFacts, rep.PendingVectors)
+	for _, f := range rep.Findings {
+		fmt.Fprintf(out, "  [%s] %-17s %s\n", f.Status, f.Rule, f.Detail)
+		if f.Hint != "" {
+			fmt.Fprintf(out, "        hint: %s\n", f.Hint)
+		}
+	}
+	fmt.Fprintf(out, "\n  verdict: %s\n", rep.Verdict)
+}

--- a/cmd/graymatter/cmd_doctor_embeddings_test.go
+++ b/cmd/graymatter/cmd_doctor_embeddings_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
+)
+
+// The --embeddings report must be byte-identical across runs over the same
+// store (the --health contract), and its verdicts must separate the three
+// honest states: healthy vector channel, supported keyword-only, and a
+// failing backend that used to hide behind Put's silence.
+
+func openEmbeddingsStore(t *testing.T, p embedding.Provider) *memory.Store {
+	t.Helper()
+	s, err := memory.Open(memory.StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      p,
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func finding2(t *testing.T, rep embeddingsReport, rule string) embeddingsFinding {
+	t.Helper()
+	for _, f := range rep.Findings {
+		if f.Rule == rule {
+			return f
+		}
+	}
+	t.Fatalf("finding %q missing from report %+v", rule, rep)
+	return embeddingsFinding{}
+}
+
+func TestEmbeddingsReportFailingBackendWarns(t *testing.T) {
+	s := openEmbeddingsStore(t, failingCLIEmbedder{err: errors.New("dial tcp: connection refused")})
+	for i := 0; i < 2; i++ {
+		if err := s.Put(context.Background(), "a", "fact"); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	rep := buildEmbeddingsReport(s)
+	if rep.Verdict != "warn" {
+		t.Errorf("verdict = %q, want warn", rep.Verdict)
+	}
+	d := finding2(t, rep, "embed-degradation")
+	if d.Status != "warn" {
+		t.Errorf("degradation status = %q, want warn", d.Status)
+	}
+	if rep.DegradedFacts != 2 || rep.LiveFacts != 2 || rep.FactsWithVec != 0 {
+		t.Errorf("counters = %+v, want 2 degraded / 2 live / 0 indexed", rep)
+	}
+}
+
+func TestEmbeddingsReportKeywordOnlyIsInfo(t *testing.T) {
+	s := openEmbeddingsStore(t, embedding.NewKeyword())
+	if err := s.Put(context.Background(), "a", "keyword fact"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	rep := buildEmbeddingsReport(s)
+	if rep.Verdict == "fail" {
+		t.Errorf("verdict = %q; keyword-only is supported configuration, never failure", rep.Verdict)
+	}
+	cov := finding2(t, rep, "vector-coverage")
+	if cov.Status != "info" {
+		t.Errorf("coverage status = %q, want info for keyword-only", cov.Status)
+	}
+}
+
+func TestEmbeddingsReportHealthyIsOk(t *testing.T) {
+	s := openEmbeddingsStore(t, staticCLIEmbedder{})
+	if err := s.Put(context.Background(), "a", "vectorised fact"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	rep := buildEmbeddingsReport(s)
+	if rep.Verdict != "ok" {
+		t.Errorf("verdict = %q, want ok", rep.Verdict)
+	}
+	cov := finding2(t, rep, "vector-coverage")
+	if cov.Status != "ok" {
+		t.Errorf("coverage status = %q, want ok", cov.Status)
+	}
+}
+
+func TestEmbeddingsReportJSONByteStableAcrossRuns(t *testing.T) {
+	s := openEmbeddingsStore(t, embedding.NewKeyword())
+	if err := s.Put(context.Background(), "a", "determinism fact"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	first, err := json.Marshal(buildEmbeddingsReport(s))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	second, err := json.Marshal(buildEmbeddingsReport(s))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("report is not deterministic:\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+// Local stubs: the pkg/memory test helpers are not exported on purpose.
+type failingCLIEmbedder struct{ err error }
+
+func (f failingCLIEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, f.err
+}
+func (failingCLIEmbedder) Dimensions() int { return 1024 }
+func (failingCLIEmbedder) Name() string    { return "failing-cli-test" }
+
+type staticCLIEmbedder struct{}
+
+func (staticCLIEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{0.5}, nil
+}
+func (staticCLIEmbedder) Dimensions() int { return 1 }
+func (staticCLIEmbedder) Name() string    { return "static-cli-test" }

--- a/pkg/memory/embedhealth.go
+++ b/pkg/memory/embedhealth.go
@@ -1,0 +1,154 @@
+package memory
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// Embedding health is the store-observed truth about the vector channel:
+// not what the configuration intends, but what actually happened to facts
+// as they were written. The embeddings chain degrades silently by design —
+// a fact whose embedder failed is stored keyword-only and Put still returns
+// nil — so without a durable record, a broken backend looks identical to an
+// empty store. These counters are that record.
+
+const (
+	metaKeyVectorDegraded     = "vector_degraded"
+	metaKeyVectorDegradedLast = "vector_degraded_last"
+	maxDegradedErrBytes       = 256
+)
+
+// EmbeddingHealth reports the store's observed embedding state.
+type EmbeddingHealth struct {
+	// EmbedDims is the dimension declared by the first provider that opened
+	// this store for writing (recorded eagerly at Open). 0 means every open
+	// so far used a provider without declared dimensions — keyword-only.
+	// Declared intent, not proof of indexing: use CountEmbeddings for what
+	// actually landed.
+	EmbedDims int `json:"embed_dims"`
+	// DegradedFacts counts lifetime writes where the embedder returned an
+	// error. Keyword providers that return (nil, nil) do not count: that is
+	// supported configuration, not failure.
+	DegradedFacts int `json:"degraded_facts"`
+	// LastDegradError is the most recent embedder error, truncated. Empty
+	// when nothing has degraded.
+	LastDegradError string `json:"last_degrade_error,omitempty"`
+	// PendingVectors is the current size of the retry queue for facts whose
+	// bbolt write succeeded but whose vector upsert has not landed yet.
+	PendingVectors int `json:"pending_vectors"`
+}
+
+// recordEmbedDegraded bumps the degradation counter and stores the last
+// error for doctor --embeddings. A diagnostic must never be able to fail
+// the write it is describing; callers ignore the error deliberately.
+func recordEmbedDegraded(db *bolt.DB, embedErr error) {
+	if embedErr == nil {
+		return
+	}
+	msg := embedErr.Error()
+	if len(msg) > maxDegradedErrBytes {
+		msg = msg[:maxDegradedErrBytes]
+	}
+	_ = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketMeta)
+		if b == nil {
+			return nil // read-only or pre-bucketing open: nothing to record into
+		}
+		cur := 0
+		if v := b.Get([]byte(metaKeyVectorDegraded)); v != nil {
+			n, err := strconv.Atoi(string(v))
+			if err != nil {
+				return fmt.Errorf("meta key %q: %w", metaKeyVectorDegraded, err)
+			}
+			cur = n
+		}
+		if err := b.Put([]byte(metaKeyVectorDegraded), []byte(strconv.Itoa(cur+1))); err != nil {
+			return err
+		}
+		return b.Put([]byte(metaKeyVectorDegradedLast), []byte(
+			strconv.Itoa(int(time.Now().Unix()))+"\x00"+msg))
+	})
+}
+
+// ReadEmbeddingHealth reads the recorded embedding state from a database.
+// Exported alongside ReadConsolidationCounters for the same reason: every
+// surface that displays it reads the same numbers without owning the write
+// logic.
+func ReadEmbeddingHealth(db *bolt.DB) (EmbeddingHealth, error) {
+	h := EmbeddingHealth{}
+	err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketMeta)
+		if b == nil {
+			return nil
+		}
+		if v := b.Get([]byte("embed_dims")); v != nil {
+			_ = json.Unmarshal(v, &h.EmbedDims)
+		}
+		if v := b.Get([]byte(metaKeyVectorDegraded)); v != nil {
+			n, err := strconv.Atoi(string(v))
+			if err == nil {
+				h.DegradedFacts = n
+			}
+		}
+		if v := b.Get([]byte(metaKeyVectorDegradedLast)); v != nil {
+			h.LastDegradError = lastDegradedMessage(v)
+		}
+		return nil
+	})
+	if err != nil {
+		return EmbeddingHealth{}, err
+	}
+	return h, nil
+}
+
+// lastDegradedMessage strips the timestamp prefix written by
+// recordEmbedDegraded and returns the message part only.
+func lastDegradedMessage(raw []byte) string {
+	for i, c := range raw {
+		if c == 0 {
+			return string(raw[i+1:])
+		}
+	}
+	return string(raw)
+}
+
+// EmbeddingHealth reads this store's observed embedding state.
+func (s *Store) EmbeddingHealth() (EmbeddingHealth, error) {
+	h, err := ReadEmbeddingHealth(s.db)
+	if err != nil {
+		return EmbeddingHealth{}, err
+	}
+	h.PendingVectors = s.PendingVectorCount()
+	return h, nil
+}
+
+// CountEmbeddings returns the number of live facts carrying a vector,
+// against the number of live facts total, across all agents. Tombstones are
+// excluded on both sides: retired facts say nothing about the channel's
+// present state.
+func (s *Store) CountEmbeddings() (withVector, total int, err error) {
+	agents, err := s.ListAgents()
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, a := range agents {
+		facts, err := s.List(a)
+		if err != nil {
+			return 0, 0, err
+		}
+		for _, f := range facts {
+			if f.IsSuperseded() {
+				continue
+			}
+			total++
+			if len(f.Embedding) > 0 {
+				withVector++
+			}
+		}
+	}
+	return withVector, total, nil
+}

--- a/pkg/memory/embedhealth_test.go
+++ b/pkg/memory/embedhealth_test.go
@@ -1,0 +1,147 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+)
+
+// failingEmbedder fails every call: the regression surface for degradation
+// recording. Before this existed, a store configured with a broken backend
+// was indistinguishable from an empty one.
+type failingEmbedder struct{ err error }
+
+func (f failingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, f.err
+}
+func (failingEmbedder) Dimensions() int { return 1024 }
+func (failingEmbedder) Name() string    { return "failing-test" }
+
+// staticEmbedder always succeeds with a fixed vector.
+type staticEmbedder struct{}
+
+func (staticEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+func (staticEmbedder) Dimensions() int { return 3 }
+func (staticEmbedder) Name() string    { return "static-test" }
+
+func openEmbedHealthStore(t *testing.T, p embedding.Provider) *Store {
+	t.Helper()
+	s, err := Open(StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      p,
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestEmbedHealthRecordsDegradedWrites(t *testing.T) {
+	s := openEmbedHealthStore(t, failingEmbedder{err: errors.New("boom: connection refused")})
+
+	for i := 0; i < 3; i++ {
+		if err := s.Put(context.Background(), "agent-a", "fact text"); err != nil {
+			t.Fatalf("Put %d: %v", i, err)
+		}
+	}
+
+	h, err := s.EmbeddingHealth()
+	if err != nil {
+		t.Fatalf("EmbeddingHealth: %v", err)
+	}
+	if h.DegradedFacts != 3 {
+		t.Errorf("DegradedFacts = %d, want 3", h.DegradedFacts)
+	}
+	if !strings.Contains(h.LastDegradError, "connection refused") {
+		t.Errorf("LastDegradError = %q, want it to carry the cause", h.LastDegradError)
+	}
+	// Dims are the provider's declaration, recorded eagerly at Open — not
+	// proof anything indexed. The failing stub declares 1024; the observed
+	// truth lives in CountEmbeddings below.
+	if h.EmbedDims != 1024 {
+		t.Errorf("EmbedDims = %d, want 1024 (the failing provider's declared dims)", h.EmbedDims)
+	}
+
+	withVec, total, err := s.CountEmbeddings()
+	if err != nil {
+		t.Fatalf("CountEmbeddings: %v", err)
+	}
+	if withVec != 0 || total != 3 {
+		t.Errorf("CountEmbeddings = (%d,%d), want (0,3)", withVec, total)
+	}
+}
+
+func TestEmbedHealthKeywordProviderIsNotDegradation(t *testing.T) {
+	// Keyword providers return (nil, nil): supported configuration per
+	// ADR-005, never a failure. This pins the distinction the counter lives on.
+	s := openEmbedHealthStore(t, embedding.NewKeyword())
+
+	if err := s.Put(context.Background(), "agent-a", "keyword fact"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	h, err := s.EmbeddingHealth()
+	if err != nil {
+		t.Fatalf("EmbeddingHealth: %v", err)
+	}
+	if h.DegradedFacts != 0 {
+		t.Errorf("DegradedFacts = %d, want 0: keyword-only is not degradation", h.DegradedFacts)
+	}
+}
+
+func TestEmbedHealthyChannelReportsZeroDegraded(t *testing.T) {
+	s := openEmbedHealthStore(t, staticEmbedder{})
+
+	if err := s.Put(context.Background(), "agent-a", "vectorised"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	h, err := s.EmbeddingHealth()
+	if err != nil {
+		t.Fatalf("EmbeddingHealth: %v", err)
+	}
+	if h.DegradedFacts != 0 || h.EmbedDims != 3 || h.PendingVectors != 0 {
+		t.Errorf("health = %+v, want clean healthy state (dims 3, nothing degraded or pending)", h)
+	}
+
+	withVec, total, err := s.CountEmbeddings()
+	if err != nil {
+		t.Fatalf("CountEmbeddings: %v", err)
+	}
+	if withVec != 1 || total != 1 {
+		t.Errorf("CountEmbeddings = (%d,%d), want (1,1)", withVec, total)
+	}
+}
+
+func TestEmbedHealthTombstonesExcludedFromCoverage(t *testing.T) {
+	s := openEmbedHealthStore(t, failingEmbedder{err: errors.New("down")})
+
+	if err := s.Put(context.Background(), "agent-a", "retired fact"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	facts, _ := s.List("agent-a")
+	if len(facts) == 0 {
+		t.Fatal("expected a stored fact")
+	}
+	// Retire via tombstone, exactly as memory_reflect forget does.
+	facts[0].SupersededBy = SupersededByAgent
+	if err := s.UpdateFact("agent-a", facts[0]); err != nil {
+		t.Fatalf("UpdateFact: %v", err)
+	}
+
+	_, total, err := s.CountEmbeddings()
+	if err != nil {
+		t.Fatalf("CountEmbeddings: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d after retiring the only fact, want 0 (tombstones are not live)", total)
+	}
+}

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -342,7 +342,10 @@ func (s *Store) IsReadOnly() bool { return s.readOnly }
 // Put stores a new observation for agentID.
 //
 // Durability model:
-//  1. Compute embedding (best-effort; on failure the fact is keyword-only).
+//  1. Compute embedding (best-effort; on failure the fact is keyword-only
+//     and the failure is recorded in the store's embedding health, so a
+//     broken backend is visible via EmbeddingHealth / doctor --embeddings
+//     instead of being indistinguishable from an empty store).
 //  2. Single bbolt transaction commits the fact AND, if an embedding exists,
 //     a marker in bucketPendingVector. The marker is the durable "this still
 //     needs to land in the vector store" intent.
@@ -389,10 +392,10 @@ func (s *Store) Put(ctx context.Context, agentID, text string) error {
 	start := time.Now()
 
 	var emb []float32
+	var embedErr error
 	if s.embedder != nil {
-		var err error
-		emb, err = s.embedder.Embed(ctx, text)
-		if err != nil {
+		emb, embedErr = s.embedder.Embed(ctx, text)
+		if embedErr != nil {
 			emb = nil
 		}
 	}
@@ -438,6 +441,11 @@ func (s *Store) Put(ctx context.Context, agentID, text string) error {
 		} else {
 			s.clearPendingVector(agentID, f.ID)
 		}
+	} else if embedErr != nil {
+		// The fact is durably keyword-only. Record the degradation so the
+		// failure surfaces in EmbeddingHealth instead of vanishing; a
+		// diagnostic counter must never fail the write it describes.
+		recordEmbedDegraded(s.db, embedErr)
 	}
 
 	if s.cfg.OnPut != nil {


### PR DESCRIPTION
## What this delivers

\graymatter doctor --embeddings\ answers, in one command, the question every operator eventually asks: **is my memory actually using vectors?**

- Vector coverage over live facts (how many carry a vector, dims declared)
- Lifetime count of writes that degraded to keyword-only, plus the last error message
- The vector retry backlog
- A verdict that distinguishes the three states: healthy channel / supported keyword-only (ADR-005) / backend misconfigured

Deterministic like \doctor --health\: reads only store bytes, byte-identical output per store. Works through a read-only probe, so it functions even while the daemon is down - exactly when you need it.

## How

New library surface: \Store.EmbeddingHealth()\ and \Store.CountEmbeddings()\ (tombstones excluded on both sides of the ratio). \Put\ records embedder failures into durable meta counters; keyword providers returning \(nil, nil)\ deliberately do not count - that is supported configuration, not failure.

Tests cover all three verdict states plus a JSON byte-stability contract over repeated runs.