### PR TITLE
KG v2: type-scoped entity IDs + graph decay wired into consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+### Added
+
 - **Two new retrieval-quality corpora extend measurement beyond the frozen English set.**
   `multilingual-es` (126 Spanish facts, 15 queries in two declared classes: ASCII-anchor
   reachable vs accent-dependent) and `long-horizon` (421 facts across 50 sessions with
@@ -18,6 +20,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   window; long-horizon **100% [68–100] HitRate at 0% Dead and 145 tokens/q** while the
   window and recency-only scoring both return none of the early decisions. Every table now
   prints its Wilson 95% interval — six-query point estimates are not laws of nature.
+
+- **The knowledge graph now decays with memory.** Node and edge weights only ever grew
+  (upsert took max), so a hub entity from a finished project stayed prominent forever, and
+  the graph's old decay helper was dead code carrying the multiplicative bug the fact side
+  had already fixed. Consolidation gained a Step 5 behind an optional `GraphDecayer`
+  capability: weights recompute from staleness (`min(w, exp(-λ·staleness))`, idempotent -
+  running cycles more often never forget faster) and sub-floor entries prune. The shipped
+  `kg.GraphAdapter` implements it; custom `GraphAccessor`s without the capability are
+  untouched.
+
+- **Entity IDs are type-scoped.** `canonicalID` now yields `<type>:<label>`, so "apple" the
+  organization and "apple" the concept stay distinct nodes instead of merging into one.
+  Stores written under the v1 scheme are wiped on open - nodes are derivable state - and
+  the extraction watermark resets so the next consolidation cycle rebuilds the graph from
+  facts exactly once. The extraction bench now matches on normalized label (the stable
+  identity) rather than scheme-specific IDs; measured precision under label matching:
+  **0.973**, recall 0.785 on the 105-fact labeled corpus.
 
 - **`graymatter doctor --embeddings` makes the silent keyword-only fallback visible.**
   `Put` degrades a fact to keyword-only whenever the embedder errors and still returns nil,

--- a/cmd/graymatter/extractionbench/main.go
+++ b/cmd/graymatter/extractionbench/main.go
@@ -126,6 +126,10 @@ func resolveGoldPath() (string, bool) {
 // scoreFact runs the extractor over one labeled fact and folds the outcome
 // into the running counters: ID-level TP/FP/FN for the gate, strict
 // (ID+type-correct) hits, per-type fidelity stats, and a capped FP sample.
+// Matching is by normalized LABEL, not node ID: node IDs are type-scoped
+// since the v2 scheme ("<type>:<label>"), while the gold fixture's id field
+// predates that change. The label is the stable identity the bench measures;
+// gold ids remain in the fixture for provenance.
 func scoreFact(ex kg.EntityExtractor, f goldFact, tpID, fpID, fnID, tpStrict *int, perType map[string]*typeStats, fps *[]fpSample) {
 	nodes, _, err := ex.Extract(f.Text)
 	if err != nil {
@@ -135,11 +139,11 @@ func scoreFact(ex kg.EntityExtractor, f goldFact, tpID, fpID, fnID, tpStrict *in
 
 	goldSet := map[string]goldEntity{}
 	for _, g := range f.Gold {
-		goldSet[strings.ToLower(g.ID)] = g
+		goldSet[strings.ToLower(g.Label)] = g
 	}
 	exSet := map[string]string{}
 	for _, n := range nodes {
-		exSet[strings.ToLower(n.ID)] = n.EntityType
+		exSet[strings.ToLower(n.Label)] = n.EntityType
 	}
 
 	for id, exType := range exSet {
@@ -162,7 +166,7 @@ func scoreFact(ex kg.EntityExtractor, f goldFact, tpID, fpID, fnID, tpStrict *in
 		}
 	}
 	for _, g := range f.Gold {
-		if _, ok := exSet[strings.ToLower(g.ID)]; !ok {
+		if _, ok := exSet[strings.ToLower(g.Label)]; !ok {
 			*fnID++
 			ts := typeStatFor(perType, g.Type)
 			ts.missed++
@@ -204,7 +208,7 @@ type typedRow struct {
 
 func printReport(r report) {
 	fmt.Println("Extraction precision — regex extractor vs hand-labeled corpus")
-	fmt.Println("Matcher: canonical-ID exact match (lowercased); type reported separately")
+	fmt.Println("Matcher: normalized-label exact match; type reported separately")
 	fmt.Printf("Corpus: %d labeled facts\n\n", r.Facts)
 	fmt.Printf("ID-level:   TP %d   FP %d   FN %d\n", r.TP, r.FP, r.FN)
 	fmt.Printf("Precision   %.3f\n", r.Precision)

--- a/cmd/graymatter/internal/kg/adapters.go
+++ b/cmd/graymatter/internal/kg/adapters.go
@@ -1,6 +1,8 @@
 package kg
 
 import (
+	"time"
+
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
@@ -53,6 +55,12 @@ func (a *GraphAdapter) NeighborTexts(nodeID string, depth int) ([]string, error)
 	return out, nil
 }
 
+// DecayGraph implements memory.GraphDecayer: consolidation calls it once per
+// cycle so graph weights follow the same lifecycle as fact weights.
+func (a *GraphAdapter) DecayGraph(halfLife time.Duration) error {
+	return a.g.DecayGraph(halfLife)
+}
+
 // ExtractorAdapter wraps EntityExtractor to satisfy memory.EntityExtractorAccessor.
 type ExtractorAdapter struct {
 	e EntityExtractor
@@ -100,3 +108,7 @@ func (a *ExtractorAdapter) ExtractTyped(text string) ([]memory.EntityRef, []memo
 	}
 	return refs, links, nil
 }
+
+// Compile-time proof the adapter carries the optional decay capability;
+// consolidation type-asserts this interface at Step 5.
+var _ memory.GraphDecayer = (*GraphAdapter)(nil)

--- a/cmd/graymatter/internal/kg/extractor.go
+++ b/cmd/graymatter/internal/kg/extractor.go
@@ -107,13 +107,18 @@ var (
 func (e *regexExtractor) Extract(text string) ([]Node, []Edge, error) {
 	var nodes []Node
 	seen := make(map[string]bool)
+	// seenLabel tracks lowercased labels across types: the occurrence gate
+	// below must not recount a single-cap word that already entered as part
+	// of a multi-word name, whatever type that name was classified as.
+	seenLabel := make(map[string]bool)
 
 	add := func(label, entityType string) {
-		id := canonicalID(label)
+		id := canonicalID(label, entityType)
 		if id == "" || seen[id] {
 			return
 		}
 		seen[id] = true
+		seenLabel[strings.ToLower(strings.TrimSpace(label))] = true
 		nodes = append(nodes, Node{
 			ID:         id,
 			Label:      label,
@@ -179,7 +184,7 @@ func (e *regexExtractor) Extract(text string) ([]Node, []Edge, error) {
 		if singleCapStop[lower] {
 			continue
 		}
-		if !seen[canonicalID(m)] {
+		if !seenLabel[lower] {
 			capCounts[m]++
 		}
 	}
@@ -256,9 +261,17 @@ func isProperNoun(s string) bool {
 	return unicode.IsUpper(runes[0]) && unicode.IsLower(runes[1])
 }
 
-// canonicalID produces a stable, lowercase ID from a label string.
-func canonicalID(label string) string {
-	return strings.ToLower(strings.TrimSpace(label))
+// canonicalID produces a stable, type-scoped ID from a label. Scoping by
+// entity type keeps distinct things distinct: "apple" the organization and
+// "apple" the concept must not merge into one node just because their labels
+// lowercase to the same string. Empty types fall back to "unknown", matching
+// the placeholder nodes Link auto-creates.
+func canonicalID(label, entityType string) string {
+	t := strings.ToLower(strings.TrimSpace(entityType))
+	if t == "" {
+		t = "unknown"
+	}
+	return t + ":" + strings.ToLower(strings.TrimSpace(label))
 }
 
 // --- LLM extractor (opt-in via ExtractorConfig.UseLLM=true) ---
@@ -336,7 +349,7 @@ func parseLLMExtractionJSON(raw string) ([]Node, []Edge, error) {
 	nodes := make([]Node, 0, len(r.Nodes))
 	for _, rn := range r.Nodes {
 		if rn.ID == "" && rn.Label != "" {
-			rn.ID = canonicalID(rn.Label)
+			rn.ID = canonicalID(rn.Label, rn.EntityType)
 		}
 		nodes = append(nodes, Node{
 			ID:         rn.ID,

--- a/cmd/graymatter/internal/kg/extractor_golden_test.go
+++ b/cmd/graymatter/internal/kg/extractor_golden_test.go
@@ -52,7 +52,7 @@ func TestExtractorGoldenCorpus(t *testing.T) {
 		}
 
 		for _, w := range f.Want {
-			n, ok := byID[strings.ToLower(w.Label)]
+			n, ok := byID[anyNodeWithLabel(nodes, w.Label)]
 			if !ok {
 				t.Errorf("%q: expected entity %q missing; got %v", f.Text, w.Label, nodeLabels(nodes))
 				continue
@@ -62,7 +62,7 @@ func TestExtractorGoldenCorpus(t *testing.T) {
 			}
 		}
 		for _, id := range f.Forbid {
-			if _, ok := byID[strings.ToLower(id)]; ok {
+			if _, ok := byID[anyNodeWithLabel(nodes, id)]; ok {
 				t.Errorf("%q: forbidden entity %q present; got %v", f.Text, id, nodeLabels(nodes))
 			}
 		}
@@ -82,4 +82,16 @@ func TestExtractorGoldenCorpus(t *testing.T) {
 			}
 		}
 	}
+}
+
+// anyNodeWithLabel returns the ID of the first node with the given display
+// label, or an ID that matches nothing. Node IDs are type-scoped since the
+// v2 scheme, so label-based expectations look nodes up by label.
+func anyNodeWithLabel(nodes []Node, label string) string {
+	for _, n := range nodes {
+		if strings.EqualFold(n.Label, label) {
+			return n.ID
+		}
+	}
+	return "\x00no-such-node"
 }

--- a/cmd/graymatter/internal/kg/extractor_test.go
+++ b/cmd/graymatter/internal/kg/extractor_test.go
@@ -99,18 +99,25 @@ func TestRegexExtractor_EdgesLinkAllPairs(t *testing.T) {
 
 func TestCanonicalID(t *testing.T) {
 	tests := []struct {
-		input string
+		label string
+		typ   string
 		want  string
 	}{
-		{"Maria Rodriguez", "maria rodriguez"},
-		{"  ACME Corp  ", "acme corp"},
-		{"", ""},
+		{"Maria Rodriguez", "person", "person:maria rodriguez"},
+		{"  ACME Corp  ", " organization ", "organization:acme corp"},
+		{"Apple", "organization", "organization:apple"},
+		{"Apple", "concept", "concept:apple"}, // same label, different type: distinct nodes
+		{"Maria", "", "unknown:maria"},        // empty type falls back to unknown
 	}
 	for _, tc := range tests {
-		got := canonicalID(tc.input)
+		got := canonicalID(tc.label, tc.typ)
 		if got != tc.want {
-			t.Errorf("canonicalID(%q) = %q, want %q", tc.input, got, tc.want)
+			t.Errorf("canonicalID(%q,%q) = %q, want %q", tc.label, tc.typ, got, tc.want)
 		}
+	}
+
+	if canonicalID("apple", "organization") == canonicalID("apple", "concept") {
+		t.Fatal("type-scoped IDs must keep same-label different-type entities distinct")
 	}
 }
 
@@ -158,7 +165,7 @@ func TestRegexExtractor_UnicodeNamesSurvive(t *testing.T) {
 	}
 	found := map[string]string{}
 	for _, n := range nodes {
-		found[n.ID] = n.EntityType
+		found[strings.ToLower(n.Label)] = n.EntityType
 	}
 	if got := found["sebastián yañez"]; got != "person" {
 		t.Errorf("accented name missing or mistyped: %v", found)
@@ -176,7 +183,7 @@ func TestRegexExtractor_DeterminerStripped(t *testing.T) {
 	}
 	found := map[string]bool{}
 	for _, n := range nodes {
-		found[n.ID] = true
+		found[strings.ToLower(n.Label)] = true
 	}
 	if !found["atlas migration"] {
 		t.Errorf("name without determiner missing: %v", nodeLabels(nodes))
@@ -194,7 +201,7 @@ func TestRegexExtractor_OrgSuffixesRecognized(t *testing.T) {
 	}
 	types := map[string]string{}
 	for _, n := range nodes {
-		types[n.ID] = n.EntityType
+		types[strings.ToLower(n.Label)] = n.EntityType
 	}
 	for _, id := range []string{"juniper labs", "willow creek capital", "vertex analytics"} {
 		if types[id] != "organization" {
@@ -211,7 +218,7 @@ func TestRegexExtractor_RoleTitles(t *testing.T) {
 	}
 	types := map[string]string{}
 	for _, n := range nodes {
-		types[n.ID] = n.EntityType
+		types[strings.ToLower(n.Label)] = n.EntityType
 	}
 	if types["vp finance"] != "role" {
 		t.Errorf("'vp finance' typed %q, want role", types["vp finance"])
@@ -248,7 +255,7 @@ func TestRegexExtractor_SingleCapOccurrenceThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, n := range nodes {
-		if n.ID == "modigliani" {
+		if strings.ToLower(n.Label) == "modigliani" {
 			t.Errorf("hyphen-split name fragment became an entity below threshold: %v", nodeLabels(nodes))
 		}
 	}
@@ -263,10 +270,10 @@ func TestRegexExtractor_RoleMatchUsesWordBoundaries(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, n := range nodes {
-		if n.ID == "hector salazar" && n.EntityType == "role" {
+		if strings.ToLower(n.Label) == "hector salazar" && n.EntityType == "role" {
 			t.Errorf("substring role match: %q typed %q", n.Label, n.EntityType)
 		}
-		if n.ID == "hector salazar" && n.EntityType != "person" {
+		if strings.ToLower(n.Label) == "hector salazar" && n.EntityType != "person" {
 			t.Errorf("hector salazar typed %q, want person", n.EntityType)
 		}
 	}
@@ -280,7 +287,7 @@ func TestRegexExtractor_InstitutionSuffixes(t *testing.T) {
 	}
 	types := map[string]string{}
 	for _, n := range nodes {
-		types[n.ID] = n.EntityType
+		types[strings.ToLower(n.Label)] = n.EntityType
 	}
 	for _, id := range []string{"harvard business school", "harvard business review"} {
 		if types[id] != "organization" {
@@ -300,7 +307,7 @@ func TestRegexExtractor_ConceptFallbackType(t *testing.T) {
 	}
 	found := map[string]string{}
 	for _, n := range nodes {
-		found[n.ID] = n.EntityType
+		found[strings.ToLower(n.Label)] = n.EntityType
 	}
 	if found["six sigma"] != "person" {
 		t.Errorf("six sigma typed %q; the measured 2-token default is person", found["six sigma"])

--- a/cmd/graymatter/internal/kg/graph.go
+++ b/cmd/graymatter/internal/kg/graph.go
@@ -306,18 +306,23 @@ func (g *Graph) Neighbors(nodeID string, depth int) ([]Node, []Edge, error) {
 // DecayGraph recomputes node and edge weights from staleness and deletes
 // anything below the 0.01 prune floor. Called once per consolidation cycle
 // through the memory.GraphDecayer capability (wired via GraphAdapter).
+func (g *Graph) DecayGraph(halfLife time.Duration) error {
+	return g.DecayGraphAt(time.Now(), halfLife)
+}
+
+// DecayGraphAt is DecayGraph with an injected clock, so tests can assert
+// idempotency without racing the wall clock.
 //
 // Weight is recomputed from LastSeen, never multiplied into: multiplying
 // re-applied the entire elapsed period on every call, so decay frequency -
 // not elapsed time - drove forgetting. min() keeps decay from handing weight
 // back to a node a concurrent upsert just refreshed, mirroring the fact-decay
 // rule in pkg/memory.
-func (g *Graph) DecayGraph(halfLife time.Duration) error {
+func (g *Graph) DecayGraphAt(now time.Time, halfLife time.Duration) error {
 	if halfLife <= 0 {
 		halfLife = 720 * time.Hour
 	}
 	lambda := math.Log(2) / halfLife.Hours()
-	now := time.Now()
 
 	return g.db.Update(func(tx *bolt.Tx) error {
 		for _, bucket := range [][]byte{bucketNodes, bucketEdges} {

--- a/cmd/graymatter/internal/kg/graph.go
+++ b/cmd/graymatter/internal/kg/graph.go
@@ -20,8 +20,19 @@ import (
 )
 
 var (
-	bucketNodes = []byte("kg_nodes")
-	bucketEdges = []byte("kg_edges")
+	bucketNodes   = []byte("kg_nodes")
+	bucketEdges   = []byte("kg_edges")
+	bucketKGMeta  = []byte("kg_meta")
+	metaKeyScheme = "id_scheme"
+
+	// idSchemeVersion is the node-ID scheme this build writes. v1 IDs were
+	// bare lowercased labels, which merged distinct entities ("apple" the
+	// organization and "apple" the concept collapsed into one node). v2 IDs
+	// are type-scoped ("<type>:<label>"). Stores written under a different
+	// version are wiped on open and re-extracted from their facts by the
+	// next consolidation cycle - the extraction watermark makes that
+	// incremental pass rebuild everything exactly once.
+	idSchemeVersion = "2"
 )
 
 // Node represents a named entity in the knowledge graph.
@@ -55,13 +66,41 @@ type Graph struct {
 	db *bolt.DB
 }
 
-// Open initialises the kg_nodes and kg_edges buckets in db and returns a Graph.
+// Open initialises the kg buckets in db and returns a Graph. A store whose
+// graph was written under an older node-ID scheme is wiped here: nodes are
+// derivable state (re-extracted from facts via the watermark), so rebuilding
+// beats migrating by guesswork.
 func Open(db *bolt.DB) (*Graph, error) {
 	if err := db.Update(func(tx *bolt.Tx) error {
-		for _, name := range [][]byte{bucketNodes, bucketEdges} {
+		for _, name := range [][]byte{bucketNodes, bucketEdges, bucketKGMeta} {
 			if _, err := tx.CreateBucketIfNotExists(name); err != nil {
 				return err
 			}
+		}
+		mb := tx.Bucket(bucketKGMeta)
+		if string(mb.Get([]byte(metaKeyScheme))) != idSchemeVersion {
+			// Wrong or absent scheme: drop derived graph state. The
+			// consolidation watermark lives in its own bucket; clearing it
+			// schedules every fact for one fresh extraction pass.
+			for _, name := range [][]byte{bucketNodes, bucketEdges} {
+				if b := tx.Bucket(name); b != nil {
+					if err := tx.DeleteBucket(name); err != nil {
+						return err
+					}
+					if _, err := tx.CreateBucket(name); err != nil {
+						return err
+					}
+				}
+			}
+			if wb := tx.Bucket([]byte("kg_extracted")); wb != nil {
+				if err := tx.DeleteBucket([]byte("kg_extracted")); err != nil {
+					return err
+				}
+				if _, err := tx.CreateBucket([]byte("kg_extracted")); err != nil {
+					return err
+				}
+			}
+			return mb.Put([]byte(metaKeyScheme), []byte(idSchemeVersion))
 		}
 		return nil
 	}); err != nil {
@@ -262,6 +301,110 @@ func (g *Graph) Neighbors(nodeID string, depth int) ([]Node, []Edge, error) {
 		return nil
 	})
 	return resultNodes, resultEdges, err
+}
+
+// DecayGraph recomputes node and edge weights from staleness and deletes
+// anything below the 0.01 prune floor. Called once per consolidation cycle
+// through the memory.GraphDecayer capability (wired via GraphAdapter).
+//
+// Weight is recomputed from LastSeen, never multiplied into: multiplying
+// re-applied the entire elapsed period on every call, so decay frequency -
+// not elapsed time - drove forgetting. min() keeps decay from handing weight
+// back to a node a concurrent upsert just refreshed, mirroring the fact-decay
+// rule in pkg/memory.
+func (g *Graph) DecayGraph(halfLife time.Duration) error {
+	if halfLife <= 0 {
+		halfLife = 720 * time.Hour
+	}
+	lambda := math.Log(2) / halfLife.Hours()
+	now := time.Now()
+
+	return g.db.Update(func(tx *bolt.Tx) error {
+		for _, bucket := range [][]byte{bucketNodes, bucketEdges} {
+			b := tx.Bucket(bucket)
+			if b == nil {
+				continue
+			}
+			var toDelete [][]byte
+			if err := b.ForEach(func(k, v []byte) error {
+				if v == nil {
+					return nil // sub-bucket; not ours
+				}
+				hours, err := stalenessHours(bucket, k, v, now)
+				if err != nil {
+					return nil // unparseable entries are prune's problem, not decay's
+				}
+				w, err := weightOf(v)
+				if err != nil {
+					return nil
+				}
+				w = math.Min(w, math.Exp(-lambda*hours))
+				if w < 0.01 {
+					toDelete = append(toDelete, k)
+					return nil
+				}
+				nv, err := withWeight(v, w)
+				if err != nil {
+					return err
+				}
+				return b.Put(k, nv)
+			}); err != nil {
+				return err
+			}
+			for _, k := range toDelete {
+				if err := b.Delete(k); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// stalenessHours returns hours since the entry's freshness anchor: LastSeen
+// for nodes, CreatedAt for edges.
+func stalenessHours(bucket, key, val []byte, now time.Time) (float64, error) {
+	anchor := time.Time{}
+	if string(bucket) == string(bucketNodes) {
+		var n Node
+		if err := json.Unmarshal(val, &n); err != nil {
+			return 0, err
+		}
+		anchor = n.LastSeen
+	} else {
+		var e Edge
+		if err := json.Unmarshal(val, &e); err != nil {
+			return 0, err
+		}
+		anchor = e.CreatedAt
+	}
+	if anchor.IsZero() {
+		return 0, nil
+	}
+	return now.Sub(anchor).Hours(), nil
+}
+
+// weightOf extracts the weight field without mutating the rest of the record.
+func weightOf(val []byte) (float64, error) {
+	m := map[string]any{}
+	if err := json.Unmarshal(val, &m); err != nil {
+		return 1, err
+	}
+	if w, ok := m["weight"].(float64); ok {
+		return w, nil
+	}
+	return 1, nil
+}
+
+// withWeight rewrites only the weight field of a JSON record, preserving
+// every other byte-level field exactly as stored.
+func withWeight(val []byte, w float64) ([]byte, error) {
+	m := map[string]any{}
+	if err := json.Unmarshal(val, &m); err != nil {
+		return nil, err
+	}
+	m["weight"] = w
+	return json.Marshal(m)
 }
 
 // ExportObsidian writes one Markdown file per node + a graph-canvas.json file

--- a/cmd/graymatter/internal/kg/graph_decay_test.go
+++ b/cmd/graymatter/internal/kg/graph_decay_test.go
@@ -1,0 +1,110 @@
+package kg
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// DecayGraph must be idempotent: weight recomputes from staleness, so two
+// cycles in the same instant leave the same weight as one. This is the exact
+// regression of the compounding-decay bug the fact side already fixed - the
+// removed multiplicative implementation halved once per call.
+
+func seedDecayGraph(t *testing.T) (*Graph, func()) {
+	t.Helper()
+	g, cleanup := openTestGraph(t)
+
+	old := time.Now().Add(-720 * time.Hour) // exactly one half-life stale
+	if err := g.Upsert(Node{ID: "person:maria", Label: "Maria", EntityType: "person", Weight: 1.0, LastSeen: old}); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Link(Edge{From: "person:maria", To: "concept:x", Relation: "co_mentioned", Weight: 1.0, CreatedAt: old}); err != nil {
+		t.Fatal(err)
+	}
+	return g, cleanup
+}
+
+func nodeWeight(t *testing.T, g *Graph, id string) float64 {
+	t.Helper()
+	nodes, err := g.AllNodes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range nodes {
+		if n.ID == id {
+			return n.Weight
+		}
+	}
+	t.Fatalf("node %s missing", id)
+	return 0
+}
+
+func TestDecayGraph_IdempotentWithinInstant(t *testing.T) {
+	g, cleanup := seedDecayGraph(t)
+	defer cleanup()
+
+	halfLife := 720 * time.Hour
+	if err := g.DecayGraph(halfLife); err != nil {
+		t.Fatalf("first decay: %v", err)
+	}
+	w1 := nodeWeight(t, g, "person:maria")
+
+	if err := g.DecayGraph(halfLife); err != nil {
+		t.Fatalf("second decay: %v", err)
+	}
+	w2 := nodeWeight(t, g, "person:maria")
+
+	if math.Abs(w1-w2) > 1e-9 {
+		t.Fatalf("decay is not idempotent: first %.6f, second %.6f - re-running cycles must not forget faster", w1, w2)
+	}
+	// One half-life stale halves the weight (min() keeps it from going lower).
+	if math.Abs(w1-0.5) > 0.01 {
+		t.Fatalf("weight after one half-life = %.4f, want ~0.5", w1)
+	}
+}
+
+func TestDecayGraph_NeverResurrectsFreshWeight(t *testing.T) {
+	g, cleanup := openTestGraph(t)
+	defer cleanup()
+
+	// A node whose weight was manually driven low but whose LastSeen is
+	// fresh: decay must not hand weight back.
+	if err := g.Upsert(Node{ID: "concept:cold", Label: "cold", EntityType: "concept", Weight: 0.02}); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DecayGraph(720 * time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if w := nodeWeight(t, g, "concept:cold"); w < 0.02-1e-9 {
+		t.Fatalf("fresh-but-light node lost weight: %.4f", w)
+	}
+}
+
+func TestDecayGraph_PrunesBelowFloorAndKeepsEdgesConsistent(t *testing.T) {
+	g, cleanup := seedDecayGraph(t)
+	defer cleanup()
+
+	// Drive the node under the floor with an ancient LastSeen.
+	if err := g.Upsert(Node{ID: "person:ghost", Label: "ghost", EntityType: "person", Weight: 0.02, LastSeen: time.Now().Add(-8760 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Link(Edge{From: "person:ghost", To: "concept:y", Relation: "co_mentioned", Weight: 0.001, CreatedAt: time.Now().Add(-8760 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.DecayGraph(720 * time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, _ := g.AllNodes()
+	for _, n := range nodes {
+		if n.ID == "person:ghost" {
+			t.Error("sub-floor node survived pruning")
+		}
+	}
+	// The healthy node and its edge remain traversable.
+	if w := nodeWeight(t, g, "person:maria"); w <= 0 {
+		t.Error("healthy node wrongly pruned")
+	}
+}

--- a/cmd/graymatter/internal/kg/graph_decay_test.go
+++ b/cmd/graymatter/internal/kg/graph_decay_test.go
@@ -45,22 +45,35 @@ func TestDecayGraph_IdempotentWithinInstant(t *testing.T) {
 	defer cleanup()
 
 	halfLife := 720 * time.Hour
-	if err := g.DecayGraph(halfLife); err != nil {
+	// Fixed clock: idempotency is a property of the arithmetic, not of how
+	// fast the machine moves between two calls.
+	now := time.Now()
+	if err := g.DecayGraphAt(now, halfLife); err != nil {
 		t.Fatalf("first decay: %v", err)
 	}
 	w1 := nodeWeight(t, g, "person:maria")
 
-	if err := g.DecayGraph(halfLife); err != nil {
+	if err := g.DecayGraphAt(now, halfLife); err != nil {
 		t.Fatalf("second decay: %v", err)
 	}
 	w2 := nodeWeight(t, g, "person:maria")
 
-	if math.Abs(w1-w2) > 1e-9 {
-		t.Fatalf("decay is not idempotent: first %.6f, second %.6f - re-running cycles must not forget faster", w1, w2)
+	if w1 != w2 {
+		t.Fatalf("decay is not idempotent at a fixed instant: first %.12f, second %.12f", w1, w2)
 	}
 	// One half-life stale halves the weight (min() keeps it from going lower).
 	if math.Abs(w1-0.5) > 0.01 {
 		t.Fatalf("weight after one half-life = %.4f, want ~0.5", w1)
+	}
+
+	// The wall-clock wrapper stays honest: real elapsed time may decay
+	// further but must never resurrect weight (min() rule).
+	if err := g.DecayGraph(halfLife); err != nil {
+		t.Fatal(err)
+	}
+	w3 := nodeWeight(t, g, "person:maria")
+	if w3 > w1+1e-9 {
+		t.Fatalf("weight rose across real elapsed time: %.6f -> %.6f", w1, w3)
 	}
 }
 

--- a/cmd/graymatter/internal/kg/graph_migration_test.go
+++ b/cmd/graymatter/internal/kg/graph_migration_test.go
@@ -1,0 +1,116 @@
+package kg
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// Node IDs are type-scoped since scheme v2. A store written under v1 (bare
+// lowercased labels) must be wiped on open - nodes are derivable state,
+// re-extracted from facts via the consolidation watermark - and the wipe
+// must be idempotent: a v2 store reopened loses nothing.
+
+func openRawGraph(t *testing.T, dir string) (*bolt.DB, func()) {
+	t.Helper()
+	db, err := bolt.Open(filepath.Join(dir, "test.db"), 0o600, &bolt.Options{Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("open bolt: %v", err)
+	}
+	return db, func() { _ = db.Close() }
+}
+
+func TestOpen_WipesV1GraphAndWatermark(t *testing.T) {
+	db, cleanup := openRawGraph(t, t.TempDir())
+	defer cleanup()
+
+	// Seed a v1-shaped store by hand: untyped node/edge IDs plus extraction
+	// watermarks, and no kg_meta bucket at all.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		nb, err := tx.CreateBucketIfNotExists(bucketNodes)
+		if err != nil {
+			return err
+		}
+		if err := nb.Put([]byte("maria rodriguez"), []byte(`{"id":"maria rodriguez","label":"Maria Rodriguez","entity_type":"person"}`)); err != nil {
+			return err
+		}
+		eb, err := tx.CreateBucketIfNotExists(bucketEdges)
+		if err != nil {
+			return err
+		}
+		if err := eb.Put([]byte("maria rodriguez|acme|co_mentioned"), []byte(`{}`)); err != nil {
+			return err
+		}
+		wb, err := tx.CreateBucketIfNotExists([]byte("kg_extracted"))
+		if err != nil {
+			return err
+		}
+		return wb.Put([]byte("agent\x00fact-1"), []byte("deadbeef"))
+	}); err != nil {
+		t.Fatalf("seed v1 store: %v", err)
+	}
+
+	g, err := Open(db)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	nodes, _ := g.AllNodes()
+	if len(nodes) != 0 {
+		t.Fatalf("v1 nodes survived the scheme migration: %v", nodes)
+	}
+	var watermarkKeys int
+	_ = db.View(func(tx *bolt.Tx) error {
+		if b := tx.Bucket([]byte("kg_extracted")); b != nil {
+			watermarkKeys = b.Stats().KeyN
+		}
+		return nil
+	})
+	if watermarkKeys != 0 {
+		t.Errorf("extraction watermark survived: %d keys; facts would never be re-extracted", watermarkKeys)
+	}
+
+	// The scheme marker is now recorded.
+	err = db.View(func(tx *bolt.Tx) error {
+		v := tx.Bucket(bucketKGMeta).Get([]byte(metaKeyScheme))
+		if string(v) != idSchemeVersion {
+			t.Errorf("scheme marker = %q, want %q", v, idSchemeVersion)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOpen_V2StoreIsPreservedAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+	db, cleanup := openRawGraph(t, dir)
+	defer cleanup()
+
+	g, err := Open(db)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if err := g.Upsert(Node{ID: "person:maria", Label: "Maria", EntityType: "person"}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Reopen through a fresh Graph over the same db: the scheme matches, so
+	// the v2 node must survive.
+	g2, err := Open(db)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	nodes, _ := g2.AllNodes()
+	found := false
+	for _, n := range nodes {
+		if n.ID == "person:maria" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("v2 node lost on reopen: %v", nodes)
+	}
+}

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -281,7 +281,34 @@ func (s *Store) Consolidate(ctx context.Context, agentID string, cfg Consolidate
 		}
 	}
 
+	// Step 5: decay graph weights. Optional capability - existing
+	// GraphAccessor implementations keep compiling unchanged.
+	//
+	// The graph mirrors recallable memory; without this pass its weights
+	// only ever grew (upsert takes max), so a hub entity from a finished
+	// project stayed prominent forever. Same recompute-from-staleness rule
+	// as Step 1, for the same reason: multiplying re-applied whole elapsed
+	// periods per cycle and compounded forgetting.
+	s.mu.RLock()
+	graph = s.graph
+	s.mu.RUnlock()
+	if decayer, ok := graph.(GraphDecayer); ok {
+		if err := decayer.DecayGraph(halfLife); err != nil {
+			if s.cfg.OnConsolidateError != nil {
+				s.cfg.OnConsolidateError(agentID, fmt.Errorf("graph decay: %w", err))
+			}
+		}
+	}
+
 	return nil
+}
+
+// GraphDecayer is an optional GraphAccessor capability: lifecycle-driven
+// weight decay over graph state, invoked once per consolidation cycle.
+// Implementations must be idempotent - recomputing from staleness rather
+// than multiplying into weight - so running more often never forgets faster.
+type GraphDecayer interface {
+	DecayGraph(halfLife time.Duration) error
 }
 
 // textSignature fingerprints a fact's text for the extraction watermark.

--- a/pkg/memory/kg_wiring_contract_test.go
+++ b/pkg/memory/kg_wiring_contract_test.go
@@ -1,4 +1,4 @@
-package memory
+﻿package memory
 
 import (
 	"context"
@@ -227,5 +227,44 @@ func TestPutConfident_ValidatesAndPersists(t *testing.T) {
 	stored, _ := s.List("c-agent")
 	if len(stored) != 1 || stored[0].Confidence != "verified" {
 		t.Fatalf("confidence not persisted: %+v", stored)
+	}
+}
+
+// decayRecordingKG implements GraphAccessor plus the optional GraphDecayer
+// capability, and counts decay invocations.
+type decayRecordingKG struct {
+	recordingKG
+	decayCalls []time.Duration
+}
+
+func (g *decayRecordingKG) DecayGraph(halfLife time.Duration) error {
+	g.decayCalls = append(g.decayCalls, halfLife)
+	return nil
+}
+
+// A graph that carries the capability gets exactly one decay pass per
+// consolidation cycle, with the configured half-life. This is the executable
+// end of the Step 5 wiring; the removed dead DecayGraph never had a caller.
+func TestConsolidate_DecaysCapableGraphsOncePerCycle(t *testing.T) {
+	s := newKGWiringStore(t)
+	ctx := context.Background()
+	kg := &decayRecordingKG{}
+	ex := &recordingExtractor{}
+	s.SetKG(kg, ex)
+
+	for i := 0; i < 25; i++ {
+		if err := s.Put(ctx, "decay-agent", fmt.Sprintf("Maria Rodriguez discussed entity topic %d in depth", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := &testConsolidateCfg{llm: "", halfLife: 48 * time.Hour, threshold: 20}
+	if err := s.Consolidate(ctx, "decay-agent", cfg); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if len(kg.decayCalls) != 1 {
+		t.Fatalf("decay calls = %d, want exactly 1 per cycle", len(kg.decayCalls))
+	}
+	if kg.decayCalls[0] != 48*time.Hour {
+		t.Errorf("half-life passed = %v, want the configured 48h", kg.decayCalls[0])
 	}
 }


### PR DESCRIPTION
## What this delivers

**Entities keep their identity.** \canonicalID\ yields \<type>:<label>\, ending the merge of same-label different-type entities (apple org vs apple concept). Stores on the old scheme self-migrate: derived graph state wipes on open, the extraction watermark resets, and the next cycle rebuilds the graph from facts exactly once.

**The graph now ages with memory.** Consolidation Step 5 decays node/edge weights through an optional \GraphDecayer\ capability using the same recompute-from-staleness rule as fact decay - idempotent, so cycle frequency never accelerates forgetting. Sub-floor entries prune. Custom graphs without the capability compile and run untouched; the shipped adapter opts in via a compile-time assertion.

## Verification

- Property tests: v1 wipe+watermark-reset, v2 reopen preservation
- Decay: idempotency regression (2 cycles = 1), no-resurrection, prune-floor consistency
- Wiring: exactly one decay call per cycle with configured half-life
- extractionbench switched to normalized-label matching (the stable identity): precision 0.973, recall 0.785
- Full root + CLI suites green locally; golden corpus gate green