### PR TITLE
Production write path: batched access tracking + O(1) confident writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-### Added
+### Changed
+
+- **The production write path stops fighting itself.** Recall access tracking used to spawn
+  one goroutine holding one bbolt write transaction per returned fact - up to eight write
+  transactions and eight goroutines per recall contending with real writers for
+  bookkeeping; it now flushes as one batched transaction, update-never-create, so a fact
+  deleted mid-recall cannot be resurrected by its own bump. `PutConfident` no longer
+  re-lists the entire agent namespace and text-scans for the fact it just wrote: the write
+  path hands back exactly what landed, making confident writes O(1), race-free, and
+  guaranteed to embed once.
 
 ### Added
 

--- a/pkg/memory/recall.go
+++ b/pkg/memory/recall.go
@@ -204,6 +204,7 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 	}
 	result := make([]string, 0, topK)
 	seen := make(map[string]bool, topK)
+	touched := make([]Fact, 0, topK)
 	for _, sc := range allScored[:topK] {
 		f, ok := factByID[sc.id]
 		if !ok {
@@ -211,15 +212,16 @@ func (s *Store) Recall(ctx context.Context, agentID, query string, topK int) ([]
 		}
 		result = append(result, f.Text)
 		seen[f.Text] = true
-		// Update access metadata (best-effort, non-blocking).
+		// Access metadata rides on one batched transaction after the loop.
+		// The previous shape spawned one goroutine holding one bbolt write
+		// transaction PER RETURNED FACT - up to eight write txns and eight
+		// goroutines per recall, contending with writers under load for
+		// bookkeeping. One txn for the batch carries the same information.
 		f.AccessCount++
 		f.AccessedAt = nowT.UTC()
-		s.wg.Add(1)
-		go func(fact Fact) {
-			defer s.wg.Done()
-			_ = s.UpdateFact(fact.AgentID, fact)
-		}(*f)
+		touched = append(touched, *f)
 	}
+	s.touchFacts(touched)
 
 	// Enrich with knowledge graph neighbors (optional; graph may be nil).
 	s.mu.RLock()

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -365,29 +365,34 @@ func (s *Store) PutConfident(ctx context.Context, agentID, text, confidence stri
 	default:
 		return fmt.Errorf("confidence must be verified|inferred|unverified, got %q", confidence)
 	}
-	if err := s.Put(ctx, agentID, text); err != nil {
-		return err
-	}
-	// Attach the marker by updating the just-written fact in place: one
-	// extra transaction on the cold path, zero API churn.
-	stored, err := s.List(agentID)
+	// The write path hands back the fact it just committed, so attaching the
+	// marker is one direct update. The previous implementation re-listed the
+	// whole agent and text-scanned for the new arrival - O(N) per confident
+	// write and racy against concurrent writers.
+	f, err := s.putReturningFact(ctx, agentID, text)
 	if err != nil {
 		return err
 	}
-	for i := range stored {
-		if stored[i].Text == text && stored[i].Confidence == "" {
-			stored[i].Confidence = confidence
-			return s.UpdateFact(agentID, stored[i])
-		}
+	if f.Confidence != "" {
+		return nil // a same-text write raced ahead and already stamped one
 	}
-	return nil
+	f.Confidence = confidence
+	return s.UpdateFact(agentID, f)
 }
 
 // This closes the crash window between the bbolt write and the vector write:
 // after a crash, reconcileVectors() at Open() drains the pending bucket.
 func (s *Store) Put(ctx context.Context, agentID, text string) error {
+	_, err := s.putReturningFact(ctx, agentID, text)
+	return err
+}
+
+// putReturningFact is the single durable write path: it commits the fact and
+// returns exactly what landed, so callers never have to find their own write
+// again by scanning.
+func (s *Store) putReturningFact(ctx context.Context, agentID, text string) (Fact, error) {
 	if s.readOnly {
-		return ErrStoreReadOnly
+		return Fact{}, ErrStoreReadOnly
 	}
 	start := time.Now()
 
@@ -429,7 +434,7 @@ func (s *Store) Put(ctx context.Context, agentID, text string) error {
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("put fact: %w", err)
+		return Fact{}, fmt.Errorf("put fact: %w", err)
 	}
 
 	if hasEmbedding {
@@ -451,7 +456,7 @@ func (s *Store) Put(ctx context.Context, agentID, text string) error {
 	if s.cfg.OnPut != nil {
 		s.cfg.OnPut(agentID, f.ID, time.Since(start))
 	}
-	return nil
+	return f, nil
 }
 
 // Delete removes a fact by ID for agentID, together with its KG extraction
@@ -554,6 +559,43 @@ func (s *Store) Stats(agentID string) (MemoryStats, error) {
 	}
 	st.AvgWeight = weightSum / float64(len(facts))
 	return st, nil
+}
+
+// touchFacts persists access-metadata bumps for a recall batch in ONE
+// transaction. Best-effort by contract: a lost bump is statistical noise on
+// decay/recency curves measured in days, never a correctness event, so an
+// error here degrades to a log-free no-op rather than failing the recall
+// that already returned its results.
+func (s *Store) touchFacts(facts []Fact) {
+	if len(facts) == 0 {
+		return
+	}
+	_ = s.db.Update(func(tx *bolt.Tx) error {
+		for i := range facts {
+			parent := tx.Bucket(bucketFacts)
+			if parent == nil {
+				return nil
+			}
+			b := parent.Bucket([]byte(facts[i].AgentID))
+			if b == nil {
+				continue
+			}
+			data, err := facts[i].marshal()
+			if err != nil {
+				continue
+			}
+			// Update, never create: if the fact vanished mid-recall (forget
+			// racing the batch), a Put here would resurrect it - the exact
+			// class of bug the UpdateFact guard closed.
+			if b.Get([]byte(facts[i].ID)) == nil {
+				continue
+			}
+			if err := b.Put([]byte(facts[i].ID), data); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // UpdateFact persists a modified fact (used by consolidation + decay).

--- a/pkg/memory/writepath_test.go
+++ b/pkg/memory/writepath_test.go
@@ -1,0 +1,175 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/pkg/embedding"
+)
+
+// The recall write-back used to spawn one goroutine holding one bbolt write
+// transaction PER RETURNED FACT. These tests pin the batched contract: every
+// returned fact is touched exactly once, unreturned facts are untouched, and
+// a fact deleted mid-flight cannot be resurrected by its own access bump.
+
+func openTouchStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      embedding.AutoDetect(embedding.Config{Mode: embedding.ModeKeyword}),
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestRecallTouchesEveryReturnedFactOnce(t *testing.T) {
+	s := openTouchStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 12; i++ {
+		if err := s.Put(ctx, "a", strings.Repeat("rollback procedure note ", 1)+string(rune('a'+i))+" unique suffix"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.Recall(ctx, "a", "rollback", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected recalls")
+	}
+
+	facts, _ := s.List("a")
+	touchedCount := 0
+	for _, f := range facts {
+		isReturned := false
+		for _, g := range got {
+			if g == f.Text {
+				isReturned = true
+				break
+			}
+		}
+		switch {
+		case isReturned && f.AccessCount != 1:
+			t.Errorf("returned fact touched %d times, want exactly 1", f.AccessCount)
+		case isReturned:
+			touchedCount++
+		case !isReturned && f.AccessCount != 0:
+			t.Errorf("unreturned fact was touched: %+v", f)
+		}
+	}
+	if touchedCount != len(got) {
+		t.Errorf("touched %d facts, recalled %d", touchedCount, len(got))
+	}
+}
+
+func TestTouchFactsCannotResurrectDeletedFact(t *testing.T) {
+	s := openTouchStore(t)
+	ctx := context.Background()
+
+	if err := s.Put(ctx, "a", "soon forgotten"); err != nil {
+		t.Fatal(err)
+	}
+	facts, _ := s.List("a")
+	victim := facts[0]
+	victim.AccessCount++
+	victim.AccessedAt = time.Now().UTC()
+
+	// Delete between recall and the touch flush - the forget race.
+	if err := s.Delete("a", victim.ID); err != nil {
+		t.Fatal(err)
+	}
+	s.touchFacts([]Fact{victim})
+
+	if remaining, _ := s.List("a"); len(remaining) != 0 {
+		t.Fatalf("deleted fact resurrected by its own access bump: %d remain", len(remaining))
+	}
+}
+
+// --- PutConfident -----------------------------------------------------------
+
+// countingEmbedder counts Embed calls so the confident-write path can assert
+// it embeds exactly once (the old List-scan version had no such guarantee to
+// break, which was part of the problem).
+type countingEmbedder struct{ calls atomic.Int64 }
+
+func (c *countingEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	n := c.calls.Add(1)
+	return []float32{float32(n)}, nil
+}
+func (*countingEmbedder) Dimensions() int { return 2 }
+func (*countingEmbedder) Name() string    { return "counting-test" }
+
+func TestPutConfident_StampsWithoutFullScan(t *testing.T) {
+	s, cleanup := openConfidentStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed background volume: the old implementation re-listed all of this on
+	// every confident write.
+	for i := 0; i < 200; i++ {
+		if err := s.Put(ctx, "bulk", strings.Repeat("bulk fact padding ", 3)+time.Duration(i).String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const target = "the verified decision of record"
+	if err := s.Put(ctx, "confident", target); err != nil {
+		t.Fatal(err)
+	}
+	before := s.embedCallsSnapshot()
+	if before != 201 {
+		t.Fatalf("precondition: expected 201 embeds, got %d", before)
+	}
+
+	if err := s.PutConfident(ctx, "confident", target, "verified"); err != nil {
+		t.Fatalf("PutConfident: %v", err)
+	}
+
+	after := s.embedCallsSnapshot()
+	if after != before+1 {
+		t.Fatalf("PutConfident triggered %d extra embeds, want exactly 1", after-before)
+	}
+
+	facts, _ := s.List("confident")
+	stamped := 0
+	for _, f := range facts {
+		if f.Text == target && f.Confidence == "verified" {
+			stamped++
+		}
+	}
+	if stamped != 1 {
+		t.Fatalf("stamped %d facts with confidence, want exactly 1", stamped)
+	}
+}
+
+func openConfidentStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	ce := &countingEmbedder{}
+	s, err := Open(StoreConfig{
+		DataDir:       t.TempDir(),
+		Embedder:      ce,
+		DecayHalfLife: 720 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	return s, func() { _ = s.Close() }
+}
+
+// embedCallsSnapshot reads the counter the store was opened with, or -1 when
+// the store carries none (keeps the test honest about its own fixture).
+func (s *Store) embedCallsSnapshot() int64 {
+	if c, ok := s.embedder.(*countingEmbedder); ok {
+		return c.calls.Load()
+	}
+	return -1
+}


### PR DESCRIPTION
## Why this matters in production

Two hot-path shapes that are invisible at demo scale and measurable at production scale:

1. **Recall spawned a goroutine holding a bbolt write transaction per returned fact.** Every agent query - the most frequent operation in the system - cost up to 8 write transactions and 8 goroutines of pure bookkeeping, contending with actual writers. Access metadata now flushes as **one batched transaction** after the result loop.
2. **PutConfident re-listed the entire namespace and text-scanned for its own write** - O(N) and racy against concurrent writers on exactly the path agents use to self-curate memory (memory_add with confidence). The write path now returns what it landed: **O(1), race-free, embeds exactly once.**

Correctness contracts pinned by tests:
- Every returned fact touched exactly once; unreturned facts untouched
- A fact deleted mid-recall cannot be resurrected by its own access bump (the forget race)
- Confident write stamps precisely one fact - the just-written one