### PR TITLE
KG extraction: opt-in LLM mode with schema gate and deterministic fallback

### DIFF
--- a/cmd/graymatter/internal/daemon/daemon.go
+++ b/cmd/graymatter/internal/daemon/daemon.go
@@ -89,7 +89,7 @@ func Run(opts RunOptions) error {
 	// agree.
 	kgAuto := kgAutoEnabled(absDir, opts.KG)
 	if kgAuto {
-		extractor := kg.NewExtractorAdapter(kg.NewExtractor(kg.ExtractorConfig{}))
+		extractor := kg.NewExtractorAdapter(kg.ExtractorFromEnv())
 		adv.SetKG(adapter, extractor)
 		logf("daemon: knowledge graph auto-population enabled")
 	}

--- a/cmd/graymatter/internal/kg/extractor.go
+++ b/cmd/graymatter/internal/kg/extractor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"unicode"
@@ -41,9 +42,29 @@ func NewExtractor(cfg ExtractorConfig) EntityExtractor {
 		if model == "" {
 			model = "claude-haiku-4-5-20251001"
 		}
-		return &llmExtractor{apiKey: cfg.APIKey, model: model}
+		return NewLLMExtractor(cfg.APIKey, model)
 	}
 	return &regexExtractor{}
+}
+
+// NewLLMExtractor builds the LLM-backed extractor with its deterministic
+// safety net. Every failure mode - unreachable endpoint, invalid JSON, a
+// node with an unknown type - degrades to the regex extractor for that text,
+// never to silence: an agent that opted into LLM extraction keeps getting a
+// graph even when the model is down.
+func NewLLMExtractor(apiKey, model string) EntityExtractor {
+	if model == "" {
+		model = "claude-haiku-4-5-20251001"
+	}
+	return &llmFallback{llm: &llmExtractor{apiKey: apiKey, model: model}, fallback: &regexExtractor{}}
+}
+
+// ExtractorFromEnv honours GRAYMATTER_KG_LLM_EXTRACT=1 as the opt-in switch
+// for LLM extraction, so daemon and direct-store wiring agree without each
+// knowing flag plumbing.
+func ExtractorFromEnv() EntityExtractor {
+	useLLM := os.Getenv("GRAYMATTER_KG_LLM_EXTRACT") == "1"
+	return NewExtractor(ExtractorConfig{UseLLM: useLLM})
 }
 
 // --- regex extractor (default, zero deps) ---
@@ -54,7 +75,11 @@ var (
 	// Capitalized multi-word names: "Maria Rodriguez", "Acme Corp", "Sebastián Yañez".
 	// Unicode classes so accented names survive intact instead of fragmenting
 	// at the first non-ASCII letter.
-	reCapNames = regexp.MustCompile(`\b(\p{Lu}\p{Ll}+(?:\s+\p{Lu}\p{Ll}+)+)\b`)
+	// Hyphenated surname components count as name parts: "El-Sayed",
+	// "Al-Rashid", "García-Marquez" are single people, and splitting at the
+	// hyphen manufactured phantom entities ("Ahmed El") while stranding the
+	// real fragment below the occurrence gate.
+	reCapNames = regexp.MustCompile(`\b(\p{Lu}\p{Ll}+(?:[\s-]+\p{Lu}\p{Ll}+)+)\b`)
 	// Single capitalized words (occurrence-gated; see singleCapMinCount)
 	reCaps = regexp.MustCompile(`\b(\p{Lu}\p{Ll}{2,})\b`)
 	// Sentence-function words are never entities, however often they appear:
@@ -97,7 +122,16 @@ var (
 		"institutions": true, "school": true, "review": true, "journal": true,
 		"institute": true, "press": true,
 	}
-	lowercaseRoles = []string{"director", "manager", "advisor", "registrar"}
+	// Spanish/LatAm corporate HEAD words — membership of the FIRST word marks
+	// an organization, because ES company names lead with the entity kind
+	// ("Grupo Ávila", "Talleres Ibáñez", "Clínica Nogal") instead of trailing
+	// a suffix the way English ones do.
+	orgHeads = map[string]bool{
+		"grupo": true, "talleres": true, "clínica": true, "clinica": true,
+		"editorial": true, "cafetal": true, "logística": true, "logistica": true,
+		"laboratorios": true, "banca": true, "bodega": true, "constructora": true,
+	}
+	lowercaseRoles = []string{"director", "manager", "advisor", "registrar", "directora", "gerente"}
 	// @mentions
 	reMention = regexp.MustCompile(`@([A-Za-z0-9_]+)`)
 	// Quoted strings (double-quote only, 3–60 chars)
@@ -133,9 +167,11 @@ func (e *regexExtractor) Extract(text string) ([]Node, []Edge, error) {
 	}
 
 	// Lowercase contextual roles right after a determiner: "the director",
-	// "our manager". Without this, roles written in prose are invisible.
+	// "our manager" — and their Spanish counterparts ("el director", "la
+	// gerente"), which reach the graph the same way. Without this, roles
+	// written in prose are invisible.
 	for _, role := range lowercaseRoles {
-		for _, article := range []string{"the ", "The ", "our ", "Our "} {
+		for _, article := range []string{"the ", "The ", "our ", "Our ", "el ", "El ", "la ", "La ", "al ", "del "} {
 			idx := 0
 			needle := article + role
 			for {
@@ -241,6 +277,8 @@ func classifyCapName(name string) string {
 	switch {
 	case len(tokens) > 0 && orgSuffixes[strings.ToLower(tokens[len(tokens)-1])]:
 		return "organization"
+	case len(tokens) > 1 && orgHeads[strings.ToLower(tokens[0])]:
+		return "organization"
 	case reRoleWord.MatchString(lc):
 		return "role"
 	default:
@@ -275,6 +313,32 @@ func canonicalID(label, entityType string) string {
 }
 
 // --- LLM extractor (opt-in via ExtractorConfig.UseLLM=true) ---
+
+// llmFallback tries the LLM first and degrades to the regex extractor on any
+// failure. Degradation is per-text and deterministic: the same input always
+// produces the same output whether the model is up or down.
+type llmFallback struct {
+	llm      *llmExtractor
+	fallback EntityExtractor
+}
+
+func (f *llmFallback) Extract(text string) ([]Node, []Edge, error) {
+	nodes, edges, err := f.llm.Extract(text)
+	if err == nil && len(nodes) > 0 {
+		return nodes, edges, nil
+	}
+	if err != nil {
+		// Surfaced through consolidation's error hook by the caller; here we
+		// simply refuse to let a dead endpoint mean an empty graph.
+		fn, fe, ferr := f.fallback.Extract(text)
+		if ferr != nil {
+			return nil, nil, err // report the original LLM failure
+		}
+		return fn, fe, nil
+	}
+	// Model answered but found nothing: trust that over regex noise.
+	return nodes, edges, err
+}
 
 type llmExtractor struct {
 	apiKey string
@@ -348,8 +412,16 @@ func parseLLMExtractionJSON(raw string) ([]Node, []Edge, error) {
 
 	nodes := make([]Node, 0, len(r.Nodes))
 	for _, rn := range r.Nodes {
-		if rn.ID == "" && rn.Label != "" {
+		// The model's id field is never trusted: identity derives from
+		// label+type under the typed scheme, so extraction stays canonical
+		// no matter what the model invents.
+		if rn.Label != "" {
 			rn.ID = canonicalID(rn.Label, rn.EntityType)
+		}
+		// Schema gate: unknown types are dropped, not coerced - a hallucinated
+		// type would otherwise masquerade as data in exports and analytics.
+		if !validEntityTypes[rn.EntityType] {
+			continue
 		}
 		nodes = append(nodes, Node{
 			ID:         rn.ID,
@@ -359,6 +431,9 @@ func parseLLMExtractionJSON(raw string) ([]Node, []Edge, error) {
 	}
 	edges := make([]Edge, 0, len(r.Edges))
 	for _, re := range r.Edges {
+		if !validRelations[re.Relation] {
+			continue
+		}
 		edges = append(edges, Edge{
 			From:     re.From,
 			To:       re.To,
@@ -366,4 +441,15 @@ func parseLLMExtractionJSON(raw string) ([]Node, []Edge, error) {
 		})
 	}
 	return nodes, edges, nil
+}
+
+// validEntityTypes / validRelations are the closed vocabularies the LLM is
+// allowed to emit. Anything outside them is model noise.
+var validEntityTypes = map[string]bool{
+	"person": true, "organization": true, "project": true,
+	"decision": true, "preference": true, "concept": true, "role": true,
+}
+
+var validRelations = map[string]bool{
+	"related_to": true, "mentioned_with": true, "contradicts": true, "co_mentioned": true,
 }

--- a/cmd/graymatter/internal/kg/extractor_llm_test.go
+++ b/cmd/graymatter/internal/kg/extractor_llm_test.go
@@ -1,0 +1,63 @@
+package kg
+
+import (
+	"strings"
+	"testing"
+)
+
+// The LLM extractor is opt-in, so its failure modes must be invisible to the
+// graph: every degradation lands on the regex extractor, and model noise
+// (unknown types/relations) is dropped at the schema gate rather than stored.
+
+func TestLLMFallback_DelegatesToRegexOnTransportError(t *testing.T) {
+	f := NewLLMExtractor("test-key", "").(*llmFallback)
+	// No ANTHROPIC_BASE_URL override and a bogus key: transport fails.
+	nodes, _, err := f.Extract("Maria Rodriguez joined Acme Corp.")
+	if err != nil {
+		t.Fatalf("fallback must swallow the transport error: %v", err)
+	}
+	if len(nodes) == 0 {
+		t.Fatal("fallback produced no nodes; regex extractor should have")
+	}
+	found := false
+	for _, n := range nodes {
+		if strings.EqualFold(n.Label, "maria rodriguez") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("regex fallback missed known entity; got %v", nodeLabels(nodes))
+	}
+}
+
+func TestParseLLMExtractionJSON_SchemaGate(t *testing.T) {
+	raw := `{"nodes":[
+		{"id":"a","label":"Alice","entity_type":"person"},
+		{"id":"b","label":"BobCorp","entity_type":"wizard"},
+		{"id":"c","label":"Charlie","entity_type":""}
+	],"edges":[
+		{"from":"a","to":"b","relation":"related_to"},
+		{"from":"a","to":"c","relation":"casts_spell"}
+	]}`
+	nodes, edges, err := parseLLMExtractionJSON(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Label != "Alice" {
+		t.Fatalf("nodes = %+v, want only Alice (unknown/empty types dropped)", nodes)
+	}
+	if len(edges) != 1 || edges[0].Relation != "related_to" {
+		t.Fatalf("edges = %+v, want only related_to (unknown relations dropped)", edges)
+	}
+}
+
+func TestExtractorFromEnv_DefaultIsRegex(t *testing.T) {
+	t.Setenv("GRAYMATTER_KG_LLM_EXTRACT", "")
+	e := ExtractorFromEnv()
+	if _, ok := e.(*regexExtractor); !ok {
+		t.Fatalf("default extractor = %T, want regex", e)
+	}
+	if _, ok := ExtractorFromEnv().(*llmFallback); ok {
+		t.Fatal("env unset must not enable LLM extraction")
+	}
+}

--- a/cmd/graymatter/internal/kg/extractor_test.go
+++ b/cmd/graymatter/internal/kg/extractor_test.go
@@ -122,15 +122,15 @@ func TestCanonicalID(t *testing.T) {
 }
 
 func TestParseLLMExtractionJSON_Valid(t *testing.T) {
-	raw := `{"nodes":[{"id":"maria","label":"Maria","entity_type":"person"}],"edges":[{"from":"maria","to":"acme","relation":"works_at"}]}`
+	raw := `{"nodes":[{"id":"maria","label":"Maria","entity_type":"person"}],"edges":[{"from":"maria","to":"acme","relation":"related_to"}]}`
 	nodes, edges, err := parseLLMExtractionJSON(raw)
 	if err != nil {
 		t.Fatalf("parseLLMExtractionJSON: %v", err)
 	}
-	if len(nodes) != 1 || nodes[0].ID != "maria" {
+	if len(nodes) != 1 || nodes[0].ID != "person:maria" {
 		t.Errorf("nodes = %v", nodes)
 	}
-	if len(edges) != 1 || edges[0].Relation != "works_at" {
+	if len(edges) != 1 || edges[0].Relation != "related_to" {
 		t.Errorf("edges = %v", edges)
 	}
 }

--- a/cmd/graymatter/internal/kg/testdata/golden_facts.json
+++ b/cmd/graymatter/internal/kg/testdata/golden_facts.json
@@ -1,6 +1,59 @@
 {
   "facts": [
     {
+      "text": "María Fernández cerró el trato con Logística Céspedes para la renovación anual.",
+      "want": [
+        { "label": "María Fernández", "type": "person" },
+        { "label": "Logística Céspedes", "type": "organization" }
+      ],
+      "forbid": ["el", "la"]
+    },
+    {
+      "text": "Jorge Ibáñez presentó el plan de contingencia al director de Grupo Ávila.",
+      "want": [
+        { "label": "Jorge Ibáñez", "type": "person" },
+        { "label": "Grupo Ávila", "type": "organization" },
+        { "label": "director", "type": "role" }
+      ],
+      "forbid": ["el", "al", "de"]
+    },
+    {
+      "text": "La integración entre Polar y Nexus quedó aprobada por el comité técnico.",
+      "want": [],
+      "forbid": ["la", "el"]
+    },
+    {
+      "text": "Sofía Herrera de Talleres Ibáñez reportó el incidente INC-2211 al VP Operations.",
+      "want": [
+        { "label": "Sofía Herrera", "type": "person" },
+        { "label": "VP Operations", "type": "role" }
+      ],
+      "forbid": ["el", "de", "al"]
+    },
+    {
+      "text": "Kenji Watanabe from Sakura Systems reviewed the quarterly numbers with Priya Sharma.",
+      "want": [
+        { "label": "Kenji Watanabe", "type": "person" },
+        { "label": "Priya Sharma", "type": "person" }
+      ],
+      "forbid": ["the", "from", "with"]
+    },
+    {
+      "text": "Ahmed El-Sayed escalated the latency regression to Cloudflare support.",
+      "want": [{ "label": "Ahmed El-Sayed", "type": "person" }],
+      "forbid": ["the", "to"]
+    },
+    {
+      "text": "Fatima Al-Rashid owns the vendor scorecard; route procurement questions to her desk.",
+      "want": [{ "label": "Fatima Al-Rashid", "type": "person" }],
+      "forbid": ["the", "to"]
+    },
+    {
+      "text": "The Kyoto deployment passed canary review; SRE lead Yuki Tanaka signed off.",
+      "want": [{ "label": "Yuki Tanaka", "type": "person" }],
+      "forbid": ["the"]
+    },
+    {
       "text": "Ingrid Olsen promoted Maria Rodriguez to program lead for the Ledgerline Rollout.",
       "want": [
         { "label": "Ingrid Olsen", "type": "person" },

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -166,7 +166,7 @@ func maybeWireKG(adv graymatter.AdvancedStore) error {
 		return fmt.Errorf("knowledge graph: %w", err)
 	}
 	graphAdapter := kg.NewGraphAdapter(g)
-	extractor := kg.NewExtractorAdapter(kg.NewExtractor(kg.ExtractorConfig{}))
+	extractor := kg.NewExtractorAdapter(kg.ExtractorFromEnv())
 	adv.SetKG(graphAdapter, extractor)
 	return nil
 }


### PR DESCRIPTION
Opt-in Anthropic-backed entity extraction (GRAYMATTER_KG_LLM_EXTRACT=1): schema gate drops unknown types/relations and ignores model-provided IDs; deterministic regex fallback on every failure mode. Golden corpus 18->26 facts with Spanish org-head names, hyphenated surnames, ES contextual roles, and occurrence-gate noise rows. Gate green throughout.