### PR TITLE
README advertises v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ scoop install graymatter
 
 ```bash
 # Linux (x86_64)
-curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.14.0/graymatter_0.14.0_linux_amd64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
+curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.15.0/graymatter_0.15.0_linux_amd64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.14.0/graymatter_0.14.0_darwin_arm64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
+curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.15.0/graymatter_0.15.0_darwin_arm64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
 
 # Windows (PowerShell)
-iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.14.0/graymatter_0.14.0_windows_amd64.zip -OutFile graymatter.zip
+iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.15.0/graymatter_0.15.0_windows_amd64.zip -OutFile graymatter.zip
 Expand-Archive graymatter.zip -DestinationPath .
 ```
 </details>
@@ -462,4 +462,4 @@ It is exactly one thing: **the missing stateful layer for Go agents**, packaged 
 
 ---
 
-*GrayMatter — v0.14.0 — August 2026*
+*GrayMatter — v0.15.0 — August 2026*


### PR DESCRIPTION
Install download URLs and the version footer point at the release being published; the historical roadmap reference stays pinned at v0.14.0 where it belongs.