### PR TITLE
fix(hooks): inject the __shared__ namespace - the documented home of project conventions was a silent hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **The hooks never injected `__shared__` — the documented path for project-wide conventions led to a silent hole.** `AGENTS.md` tells every agent that project conventions belong in the reserved `__shared__` namespace, and both automatic hooks ignored it: `SessionStart` and the `UserPromptSubmit` recall called `Recall` with the cwd agent only, so a convention archived there was invisible to Claude Code at session open and on every turn — with zero errors, zero warnings, empty stdout, the exact failure mode that reads as "memory is broken". Both runners now recall the shared namespace under its own budget (session-start top-5 agent + top-3 shared, per-turn top-3 + top-3) and render it as a labeled `## Shared memory (project-wide)` section — separate budgets, because a merged ranking on session-start (where recency is the only ranked signal) would let old conventions displace the agent's freshest facts. The failure contract holds per namespace: one recall failing never costs the other's facts, the degraded injection still goes out, and the error lands in `hooks.log`. The instant-save path gains `remember shared: <text>`, closing the write-side asymmetry — until now nothing typed in a prompt could reach `__shared__`. The identical-block throttle keeps working on merged blocks, and `graymatter status`'s INJECTION line now estimates the block the hooks actually inject instead of a generic top-8.
+
+---
+
 ## [0.17.0] - 2026-08-27
 
 ### What users get

--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ tool:
 
 | Hook | What it does |
 |------|--------------|
-| `SessionStart` | Injects the freshest live facts — and re-injects after `/compact` (your memory survives compaction) |
-| `UserPromptSubmit` | Short per-turn recall (top-3), suppressed when identical to the previous turn; `remember: <text>` in a prompt is an instant deterministic save |
+| `SessionStart` | Injects the freshest live facts plus project-wide `__shared__` conventions — and re-injects after `/compact` (your memory survives compaction) |
+| `UserPromptSubmit` | Short per-turn recall (top-3 agent + top-3 shared), suppressed when identical to the previous turn; `remember: <text>` in a prompt is an instant deterministic save, `remember shared: <text>` saves into the shared namespace every agent reads |
 | `PreCompact` | Deterministic checkpoint before context compaction |
 | `SessionEnd` | Checkpoint + detached consolidation (survives the editor closing) |
 

--- a/cmd/graymatter/cmd_bench.go
+++ b/cmd/graymatter/cmd_bench.go
@@ -324,25 +324,25 @@ func measureStoreAgent(agent string, facts []memory.Fact) storeAgentRow {
 		window = window[:8]
 	}
 	row.Sliding8Tokens = tokens.Approx(strings.Join(window, "\n"))
-	row.Top8WeightedTok = estimateTop8Tokens(facts)
+	row.Top8WeightedTok = estimateTopN(facts, 8)
 	return row
 }
 
-// estimateTop8Tokens estimates what injecting an agent's eight highest-weight
-// live facts would cost, without issuing a Recall (which would bump access
+// estimateTopN estimates what injecting an agent's n highest-weight live
+// facts would cost, without issuing a Recall (which would bump access
 // counters via detached writebacks). Shared by bench --store and status so
 // both surfaces quote the same number for the same store.
-func estimateTop8Tokens(facts []memory.Fact) int {
+func estimateTopN(facts []memory.Fact, n int) int {
 	byWeight := make([]memory.Fact, len(facts))
 	copy(byWeight, facts)
 	sort.SliceStable(byWeight, func(i, j int) bool { return byWeight[i].Weight > byWeight[j].Weight })
-	top := make([]string, 0, 8)
+	top := make([]string, 0, n)
 	for _, f := range byWeight {
 		if f.SupersededBy != "" {
 			continue
 		}
 		top = append(top, f.Text)
-		if len(top) == 8 {
+		if len(top) == n {
 			break
 		}
 	}

--- a/cmd/graymatter/cmd_hooks_test.go
+++ b/cmd/graymatter/cmd_hooks_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 // The settings.json this package writes is a contract with Claude Code's hook
@@ -552,5 +555,352 @@ func TestHookRun_UnknownEvent(t *testing.T) {
 	withHooksEnv(t)
 	if _, err := dispatchHook("session-middle", hookEventPayload{}); err == nil {
 		t.Error("unknown event must be a dispatch error")
+	}
+}
+
+// --- __shared__ injection (HS-28AGO) --------------------------------------------
+//
+// AGENTS.md directs project-wide conventions to the reserved __shared__
+// namespace; the hooks are the automatic injection path, so both reading
+// events must merge it in, and the remember: path must be able to write it.
+
+// seedSharedFacts plants facts in the __shared__ namespace of the test store.
+func seedSharedFacts(t *testing.T, facts ...string) {
+	t.Helper()
+	store, err := openStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for _, f := range facts {
+		if err := store.PutShared(ctx, f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = store.Close()
+}
+
+// TestHookRun_SessionStart_SharedNamespace: session-start must inject the
+// shared namespace alongside the agent's own — shared-only, agent-only
+// (legacy shape, byte-compatible), and both together.
+func TestHookRun_SessionStart_SharedNamespace(t *testing.T) {
+	t.Run("shared only", func(t *testing.T) {
+		withHooksEnv(t)
+		seedSharedFacts(t, "Deploys freeze on Fridays: do not deploy to production on Fridays")
+
+		out, err := dispatchHook("session-start", hookEventPayload{CWD: mustWorkdir()})
+		if err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+		if !strings.Contains(out, "## Shared memory (project-wide)") || !strings.Contains(out, "Deploys freeze on Fridays") {
+			t.Errorf("shared-only injection = %q, want the shared section carrying the convention", out)
+		}
+		if strings.Contains(out, "## Memory\n") {
+			t.Errorf("shared-only injection must not render an empty agent section: %q", out)
+		}
+	})
+
+	t.Run("agent only keeps the legacy block", func(t *testing.T) {
+		withHooksEnv(t)
+		agent := deriveAgentID(mustWorkdir())
+		store, err := openStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Remember(context.Background(), agent, "The catalog service talks to Postgres on db-01"); err != nil {
+			t.Fatal(err)
+		}
+		_ = store.Close()
+
+		out, err := dispatchHook("session-start", hookEventPayload{CWD: mustWorkdir()})
+		if err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+		if !strings.HasPrefix(out, "## Memory\n") || !strings.Contains(out, "Postgres on db-01") {
+			t.Errorf("agent-only injection = %q, want the legacy Memory block", out)
+		}
+		if strings.Contains(out, "Shared memory") {
+			t.Errorf("agent-only injection must not carry a shared section: %q", out)
+		}
+	})
+
+	t.Run("both namespaces", func(t *testing.T) {
+		withHooksEnv(t)
+		agent := deriveAgentID(mustWorkdir())
+		seedSharedFacts(t, "Deploys freeze on Fridays: do not deploy to production on Fridays")
+		store, err := openStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Remember(context.Background(), agent, "The catalog service talks to Postgres on db-01"); err != nil {
+			t.Fatal(err)
+		}
+		_ = store.Close()
+
+		out, err := dispatchHook("session-start", hookEventPayload{CWD: mustWorkdir()})
+		if err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+		memIdx := strings.Index(out, "## Memory\n")
+		shrIdx := strings.Index(out, "## Shared memory (project-wide)")
+		if memIdx < 0 || shrIdx < 0 || memIdx > shrIdx {
+			t.Errorf("both-namespaces injection = %q, want Memory section before Shared memory", out)
+		}
+		if !strings.Contains(out, "Postgres on db-01") || !strings.Contains(out, "Deploys freeze on Fridays") {
+			t.Errorf("both-namespaces injection lost a fact: %q", out)
+		}
+	})
+}
+
+// TestHookRun_UserPrompt_SharedNamespace: the per-turn recall must match
+// against the shared namespace too — a prompt about a project convention
+// brings the convention back.
+func TestHookRun_UserPrompt_SharedNamespace(t *testing.T) {
+	withHooksEnv(t)
+	agent := deriveAgentID(mustWorkdir())
+
+	// Shared-only.
+	seedSharedFacts(t, "The API rate limit for shared tenants is 60 requests per minute")
+	out, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "what is the rate limit"})
+	if err != nil {
+		t.Fatalf("shared-only store: %v", err)
+	}
+	if !strings.Contains(out, "rate limit") || !strings.Contains(out, "## Shared memory (project-wide)") {
+		t.Errorf("shared-only per-turn injection = %q, want the shared convention", out)
+	}
+
+	// Both namespaces against one query.
+	store, err := openStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Remember(context.Background(), agent, "The agent-local retry budget is three attempts"); err != nil {
+		t.Fatal(err)
+	}
+	_ = store.Close()
+
+	out, err = dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "retry budget and rate limit"})
+	if err != nil {
+		t.Fatalf("both namespaces: %v", err)
+	}
+	if !strings.Contains(out, "retry budget") || !strings.Contains(out, "rate limit") {
+		t.Errorf("per-turn injection lost a namespace: %q", out)
+	}
+}
+
+// TestHookRun_UserPrompt_SharedThrottle: the identical-block suppression must
+// hold on merged blocks — an unchanged turn injects nothing, a changed shared
+// namespace re-injects.
+func TestHookRun_UserPrompt_SharedThrottle(t *testing.T) {
+	withHooksEnv(t)
+	seedSharedFacts(t, "Deploys freeze on Fridays: do not deploy to production on Fridays")
+
+	first, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "can I deploy on a Friday"})
+	if err != nil {
+		t.Fatalf("first turn: %v", err)
+	}
+	if !strings.Contains(first, "Deploys freeze on Fridays") {
+		t.Fatalf("first injection = %q, want the shared convention", first)
+	}
+
+	second, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "and what about Saturday"})
+	if err != nil {
+		t.Fatalf("second turn: %v", err)
+	}
+	if second != "" {
+		t.Errorf("second injection = %q, want suppressed (identical merged block)", second)
+	}
+
+	// A changed shared fact changes the block: it must inject again.
+	store, err := openStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutShared(context.Background(), "Ship window reopens Monday 09:00 UTC"); err != nil {
+		t.Fatal(err)
+	}
+	_ = store.Close()
+	third, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "when does the ship window reopen"})
+	if err != nil {
+		t.Fatalf("third turn: %v", err)
+	}
+	if third == "" || !strings.Contains(third, "Ship window reopens") {
+		t.Errorf("changed shared namespace must re-inject, got %q", third)
+	}
+}
+
+// TestHookRun_UserPromptRememberShared: "remember shared: <text>" is the
+// deterministic instant-save into the namespace every agent reads.
+func TestHookRun_UserPromptRememberShared(t *testing.T) {
+	withHooksEnv(t)
+	agent := deriveAgentID(mustWorkdir())
+
+	out, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "remember shared: All PRs need one approval from a CODEOWNER"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if !strings.Contains(out, "Saved to shared memory") || !strings.Contains(out, "All PRs need one approval") {
+		t.Errorf("confirmation = %q, want it to name the shared save", out)
+	}
+
+	// Case-insensitive prefix, same destination.
+	if _, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "REMEMBER SHARED: Standups are async in writing"}); err != nil {
+		t.Fatalf("shouty prefix: %v", err)
+	}
+
+	store, err := openStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	shared, err := store.List(memory.SharedAgentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, f := range shared {
+		got[f.Text] = true
+	}
+	for _, want := range []string{
+		"All PRs need one approval from a CODEOWNER",
+		"Standups are async in writing",
+	} {
+		if !got[want] {
+			t.Errorf("shared namespace missing %q (has %v)", want, got)
+		}
+	}
+	agentFacts, err := store.List(agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agentFacts) != 0 {
+		t.Errorf("remember shared: leaked %d facts into the agent namespace", len(agentFacts))
+	}
+
+	// "remember shared:" with nothing after it is a user error the runner
+	// must survive (error → silent path), not store junk.
+	if _, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "remember shared:   "}); err == nil {
+		t.Error("empty shared remember must be an error")
+	}
+}
+
+// hookRecallStub is a cliStore whose two recall calls answer from canned
+// values, so the degradation contract is testable without a store that fails
+// selectively. Only Recall and RecallShared are ever called on it.
+type hookRecallStub struct {
+	cliStore
+	agentFacts  []string
+	agentErr    error
+	sharedFacts []string
+	sharedErr   error
+}
+
+func (s *hookRecallStub) Recall(context.Context, string, string, int) ([]string, error) {
+	return s.agentFacts, s.agentErr
+}
+
+func (s *hookRecallStub) RecallShared(context.Context, string, int) ([]string, error) {
+	return s.sharedFacts, s.sharedErr
+}
+
+// TestHookRecallBlock_Degradation: one namespace failing never costs the
+// other's facts; only a total failure aborts the injection.
+func TestHookRecallBlock_Degradation(t *testing.T) {
+	okAgent := &hookRecallStub{agentFacts: []string{"agent fact"}, sharedErr: fmt.Errorf("shared boom")}
+	block, degrade := hookRecallBlock(okAgent, "a", "q", 3, 3)
+	if block == "" || !strings.Contains(block, "agent fact") {
+		t.Errorf("shared failure must still inject agent facts, got %q", block)
+	}
+	if degrade == nil || !strings.Contains(degrade.Error(), "shared recall failed") {
+		t.Errorf("shared failure must surface a degrade error, got %v", degrade)
+	}
+
+	okShared := &hookRecallStub{agentErr: fmt.Errorf("agent boom"), sharedFacts: []string{"shared fact"}}
+	block, degrade = hookRecallBlock(okShared, "a", "q", 3, 3)
+	if block == "" || !strings.Contains(block, "shared fact") {
+		t.Errorf("agent failure must still inject shared facts, got %q", block)
+	}
+	if degrade == nil || !strings.Contains(degrade.Error(), "agent recall failed") {
+		t.Errorf("agent failure must surface a degrade error, got %v", degrade)
+	}
+
+	bothDown := &hookRecallStub{agentErr: fmt.Errorf("agent boom"), sharedErr: fmt.Errorf("shared boom")}
+	if block, degrade := hookRecallBlock(bothDown, "a", "q", 3, 3); block != "" || degrade == nil {
+		t.Errorf("both namespaces failing must be a hard error, got block=%q degrade=%v", block, degrade)
+	}
+
+	// The only populated namespace failing is also a hard error, even though
+	// the other call succeeded with an empty result.
+	emptyAgent := &hookRecallStub{agentFacts: nil, sharedErr: fmt.Errorf("shared boom")}
+	if block, degrade := hookRecallBlock(emptyAgent, "a", "q", 3, 3); block != "" || degrade == nil {
+		t.Errorf("shared failure with no agent facts must be a hard error, got block=%q degrade=%v", block, degrade)
+	}
+}
+
+// TestHookRun_DegradeReceiptInLog: a degraded injection still goes out, and
+// the failure leaves its error receipt in hooks.log — the session never sees
+// the half-broken store, the log does.
+func TestHookRun_DegradeReceiptInLog(t *testing.T) {
+	dir := withHooksEnv(t)
+	seedHookStoreFacts(t, "The rate limit is 60 requests per minute")
+
+	oldRecall := hookRecallBlock
+	hookRecallBlock = func(store cliStore, agent, query string, agentTopK, sharedTopK int) (string, error) {
+		facts, err := store.Recall(context.Background(), agent, query, agentTopK)
+		if err != nil {
+			return "", err
+		}
+		return renderMemoryBlock(facts, nil), fmt.Errorf("shared recall failed, injecting agent facts only: broken on purpose")
+	}
+	t.Cleanup(func() { hookRecallBlock = oldRecall })
+
+	out, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "rate limit check"})
+	if err != nil {
+		t.Fatalf("degraded injection must not error the dispatch: %v", err)
+	}
+	if !strings.Contains(out, "rate limit") {
+		t.Errorf("degraded injection lost the agent facts: %q", out)
+	}
+
+	logData, err := os.ReadFile(filepath.Join(dir, "hooks.log"))
+	if err != nil {
+		t.Fatalf("hooks.log: %v", err)
+	}
+	if !strings.Contains(string(logData), `"outcome":"error"`) ||
+		!strings.Contains(string(logData), "injecting agent facts only") {
+		t.Errorf("hooks.log missing the degradation receipt: %s", logData)
+	}
+}
+
+// TestRenderMemoryBlock_Sections pins the block shape: agent facts first, the
+// shared section second, exact duplicates across namespaces rendered once,
+// multi-line facts folded, and an empty pair of lists rendering nothing.
+func TestRenderMemoryBlock_Sections(t *testing.T) {
+	cases := []struct {
+		name        string
+		agent, shrd []string
+		want        string
+	}{
+		{"agent only keeps the legacy shape", []string{"a fact"}, nil, "## Memory\n- a fact"},
+		{"shared only", nil, []string{"a convention"}, "## Shared memory (project-wide)\n- a convention"},
+		{
+			"both sections, agent first",
+			[]string{"own history"},
+			[]string{"project convention"},
+			"## Memory\n- own history\n\n## Shared memory (project-wide)\n- project convention",
+		},
+		{
+			"exact duplicate renders once, under Memory",
+			[]string{"same text"},
+			[]string{"same text"},
+			"## Memory\n- same text",
+		},
+		{"multi-line folded", []string{"line one\nline two"}, nil, "## Memory\n- line one line two"},
+		{"both empty is nothing", nil, nil, ""},
+	}
+	for _, c := range cases {
+		if got := renderMemoryBlock(c.agent, c.shrd); got != c.want {
+			t.Errorf("%s: renderMemoryBlock = %q, want %q", c.name, got, c.want)
+		}
 	}
 }

--- a/cmd/graymatter/cmd_status.go
+++ b/cmd/graymatter/cmd_status.go
@@ -175,16 +175,17 @@ func renderStatus(out io.Writer, view statusView) error {
 		fmt.Fprintln(out, "           no harness runs recorded (MCP sessions are not measured)")
 	}
 
-	minTop8, maxTop8, maxDump := 1<<30, 0, 0
+	// The session-start hook injects the agent's top facts plus the shared
+	// namespace's top conventions (the hooks' own budgets,
+	// hookSessionStartAgentTopK / hookSessionStartSharedTopK), so estimate
+	// that block rather than a generic top-8. __shared__ is never a hook
+	// agent — no cwd maps to it — so it contributes the shared part of every
+	// agent's estimate instead of a row of its own.
+	sharedTk := estimateTopN(view.Facts[memory.SharedAgentID], hookSessionStartSharedTopK)
+	minBlock, maxBlock, maxDump := 1<<30, 0, 0
+	agentsCounted := 0
 	for _, a := range ov.Agents {
 		facts := view.Facts[a.Agent]
-		tk := estimateTop8Tokens(facts)
-		if tk < minTop8 {
-			minTop8 = tk
-		}
-		if tk > maxTop8 {
-			maxTop8 = tk
-		}
 		live := make([]string, 0, len(facts))
 		for _, f := range facts {
 			if f.SupersededBy == "" {
@@ -194,10 +195,26 @@ func renderStatus(out io.Writer, view statusView) error {
 		if dump := tokens.Approx(strings.Join(live, "\n")); dump > maxDump {
 			maxDump = dump
 		}
+		if a.Agent == memory.SharedAgentID {
+			continue
+		}
+		tk := estimateTopN(facts, hookSessionStartAgentTopK) + sharedTk
+		agentsCounted++
+		if tk < minBlock {
+			minBlock = tk
+		}
+		if tk > maxBlock {
+			maxBlock = tk
+		}
 	}
-	if ov.TotalLiveFacts > 0 {
-		fmt.Fprintf(out, "INJECTION  est. top-8 recall cost now: ~%d–%d tk/agent vs full dump ~%d\n",
-			minTop8, maxTop8, maxDump)
+	if agentsCounted == 0 && sharedTk > 0 {
+		// A store holding only shared facts: every hook session injects the
+		// shared block alone.
+		minBlock, maxBlock, agentsCounted = sharedTk, sharedTk, 1
+	}
+	if ov.TotalLiveFacts > 0 && agentsCounted > 0 {
+		fmt.Fprintf(out, "INJECTION  est. session-start block (top-%d agent + top-%d shared): ~%d–%d tk/agent vs full dump ~%d\n",
+			hookSessionStartAgentTopK, hookSessionStartSharedTopK, minBlock, maxBlock, maxDump)
 		fmt.Fprintf(out, "           estimates ~%.2f tok/word; the server cannot see your chat history.\n",
 			tokens.PerWord)
 	}

--- a/cmd/graymatter/cmd_status_test.go
+++ b/cmd/graymatter/cmd_status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -188,6 +189,58 @@ func TestDirectStoreOverview_MatchesGroundTruth(t *testing.T) {
 	}
 	if ov.TotalTombstones != 1 {
 		t.Errorf("tombstones = %d, want 1", ov.TotalTombstones)
+	}
+}
+
+// TestStatus_InjectionEstimateReflectsHookBudgets: the INJECTION line quotes
+// the session-start hook's real block — the agent's top-5 plus the shared
+// namespace's top-3 — not a generic top-8, and __shared__ itself is never
+// counted as a hook agent row.
+func TestStatus_InjectionEstimateReflectsHookBudgets(t *testing.T) {
+	agentFacts := []memory.Fact{
+		{ID: "w1", AgentID: "writer", Text: "one two three four five six"},
+	}
+	sharedFacts := []memory.Fact{
+		{ID: "s1", AgentID: memory.SharedAgentID, Text: "shared convention one two three"},
+		{ID: "s2", AgentID: memory.SharedAgentID, Text: "shared convention four five six"},
+	}
+	view := statusView{
+		Mode: "in-process",
+		Overview: &daemon.StoreOverviewResponse{
+			TotalAgents:    2,
+			TotalLiveFacts: 3,
+			Agents: []daemon.AgentSummary{
+				{Agent: "writer", LiveFacts: 1},
+				{Agent: memory.SharedAgentID, LiveFacts: 2},
+			},
+		},
+		KG:    &daemon.KGStateResponse{},
+		Facts: map[string][]memory.Fact{"writer": agentFacts, memory.SharedAgentID: sharedFacts},
+	}
+
+	var out bytes.Buffer
+	if err := renderStatus(&out, view); err != nil {
+		t.Fatalf("renderStatus: %v", err)
+	}
+	got := out.String()
+
+	wantBlock := estimateTopN(agentFacts, hookSessionStartAgentTopK) + estimateTopN(sharedFacts, hookSessionStartSharedTopK)
+	wantLine := fmt.Sprintf("INJECTION  est. session-start block (top-%d agent + top-%d shared): ~%d–%d tk/agent",
+		hookSessionStartAgentTopK, hookSessionStartSharedTopK, wantBlock, wantBlock)
+	if !strings.Contains(got, wantLine) {
+		t.Errorf("INJECTION line must quote the hook's real block (%s):\n%s", wantLine, got)
+	}
+
+	// The old generic top-8 shape must not come back: top-8 of the agent
+	// alone (no shared part) is a different number for this store.
+	onlyAgentTop8 := estimateTopN(agentFacts, 8)
+	if onlyAgentTop8 != wantBlock {
+		// Guard the guard: with these facts the two estimates differ, so the
+		// assertion below is meaningful.
+		if strings.Contains(got, fmt.Sprintf("~%d–%d tk/agent", onlyAgentTop8, onlyAgentTop8)) &&
+			!strings.Contains(got, wantLine) {
+			t.Errorf("INJECTION line fell back to a plain top-8 estimate:\n%s", got)
+		}
 	}
 }
 

--- a/cmd/graymatter/hooks_daemon_e2e_test.go
+++ b/cmd/graymatter/hooks_daemon_e2e_test.go
@@ -100,6 +100,11 @@ func TestHooksDaemonE2E_FullLifecycle(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
+		// The shared namespace must ride the same injection path through the
+		// daemon: one project-wide convention seeded before any hook fires.
+		if err := mem.RememberShared(ctx, "production deploys freeze on fridays; wait until monday"); err != nil {
+			t.Fatal(err)
+		}
 		if err := mem.Remember(ctx, agent, "ancient fact waiting to be pruned"); err != nil {
 			t.Fatal(err)
 		}
@@ -135,10 +140,13 @@ func TestHooksDaemonE2E_FullLifecycle(t *testing.T) {
 		t.Fatalf("hooks install: exit=%d out=%s", code, out)
 	}
 
-	// 2. session-start injects
+	// 2. session-start injects the agent's facts AND the shared convention
 	out, code := runE2E(t, bin, proj, hookStdin(proj, ""), "hooks", "run", "session-start")
 	if code != 0 || !strings.Contains(out, "## Memory") || !strings.Contains(out, "release checklist") {
 		t.Fatalf("session-start: exit=%d out=%q", code, out)
+	}
+	if !strings.Contains(out, "## Shared memory (project-wide)") || !strings.Contains(out, "freeze on fridays") {
+		t.Errorf("session-start lost the shared namespace: %q", out)
 	}
 
 	// 3. user-prompt recall injects
@@ -151,6 +159,17 @@ func TestHooksDaemonE2E_FullLifecycle(t *testing.T) {
 	out, code = runE2E(t, bin, proj, hookStdin(proj, "remember: the offcall rota lives in ops/rota.md"), "hooks", "run", "user-prompt")
 	if code != 0 || !strings.Contains(out, "Saved to memory") {
 		t.Fatalf("user-prompt remember: exit=%d out=%q", code, out)
+	}
+
+	// 4b. user-prompt remember shared: saves into the shared namespace, and
+	// the fact is readable back over the daemon wire.
+	out, code = runE2E(t, bin, proj, hookStdin(proj, "remember shared: the weekly demo is thursdays at 15:00 utc"), "hooks", "run", "user-prompt")
+	if code != 0 || !strings.Contains(out, "Saved to shared memory") {
+		t.Fatalf("user-prompt remember shared: exit=%d out=%q", code, out)
+	}
+	out, code = runE2E(t, bin, proj, "", "--dir", storeDir, "recall", "proj-e2e", "weekly demo", "--shared")
+	if code != 0 || !strings.Contains(out, "weekly demo is thursdays") {
+		t.Errorf("remember shared: fact not readable via recall --shared (exit=%d): %q", code, out)
 	}
 
 	// 5. pre-compact checkpoints silently

--- a/cmd/graymatter/hooks_run.go
+++ b/cmd/graymatter/hooks_run.go
@@ -54,6 +54,12 @@ const (
 	// hooksRememberPrefix turns a prompt into a deterministic instant-save,
 	// no model in the loop.
 	hooksRememberPrefix = "remember:"
+
+	// hooksRememberSharedPrefix is the same instant-save aimed at the
+	// __shared__ namespace every agent reads: "remember shared: <text>".
+	// Checked before hooksRememberPrefix, which it does not collide with
+	// ("remember " carries a space where "remember:" carries a colon).
+	hooksRememberSharedPrefix = "remember shared:"
 )
 
 // timeNow is the process clock, a seam so latency paths are testable.
@@ -65,6 +71,21 @@ const (
 	hookUserPromptBudget = 150 * time.Millisecond
 	hookSessionEndBudget = 500 * time.Millisecond
 	hookPreCompactBudget = 200 * time.Millisecond
+)
+
+// Injection budgets per event and namespace. The two namespaces get separate
+// budgets, not one merged top-k: project conventions are old by nature, and
+// on session-start — where an empty query leaves recency as the only ranked
+// signal — a merged ranking would let them displace the agent's freshest
+// facts. Shared gets its own ceiling instead, so it can never cannibalize the
+// agent's history. Session-start totals top-8, the injection size
+// `graymatter status` quotes an estimate for.
+const (
+	hookSessionStartAgentTopK  = 5
+	hookSessionStartSharedTopK = 3
+
+	hookUserPromptAgentTopK  = 3
+	hookUserPromptSharedTopK = 3
 )
 
 func hooksRunCmd() *cobra.Command {
@@ -205,38 +226,59 @@ func deriveAgentID(dir string) string {
 
 // --- event handlers ------------------------------------------------------------
 
-// hookSessionStart recalls the agent's top facts and renders them for
-// injection. Query "" makes recency the only ranked signal (there are no
-// query terms to match), which is exactly "start where the last session
-// ended": the freshest live facts, deterministic order.
+// hookSessionStart recalls the agent's top facts plus the __shared__ project
+// conventions and renders them for injection. Query "" makes recency the only
+// ranked signal (there are no query terms to match), which is exactly "start
+// where the last session ended": the freshest live facts, deterministic order.
 func hookSessionStart(agent string, payload hookEventPayload) (string, error) {
+	start := timeNow()
 	store, err := openStore()
 	if err != nil {
 		return "", fmt.Errorf("open store: %w", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	facts, err := store.Recall(context.Background(), agent, "", 5)
-	if err != nil {
-		return "", fmt.Errorf("recall: %w", err)
-	}
-	if len(facts) == 0 {
+	block, degrade := hookRecallBlock(store, agent, "", hookSessionStartAgentTopK, hookSessionStartSharedTopK)
+	if block == "" {
+		if degrade != nil {
+			return "", degrade
+		}
 		return "", nil // never noise: an empty memory injects nothing
 	}
-	return renderMemoryBlock(facts), nil
+	if degrade != nil {
+		hookLog(payload, "session-start", timeNow().Sub(start), "error", degrade.Error())
+	}
+	return block, nil
 }
 
 // hookUserPrompt either performs a deterministic remember (prompt starts with
-// "remember:") or a short recall. Consecutive turns with identical recall
-// output are suppressed via the state file: the context is already there.
+// "remember:" or "remember shared:") or a short recall from both namespaces.
+// Consecutive turns with identical recall output are suppressed via the state
+// file: the context is already there.
 func hookUserPrompt(agent string, payload hookEventPayload) (string, error) {
 	prompt := strings.TrimSpace(payload.Prompt)
 	if prompt == "" {
 		return "", nil
 	}
 
-	// Instant-save path: "remember: <text>".
-	if rest, ok := hooksRememberRest(prompt); ok {
+	// Instant-save to the project-wide namespace: "remember shared: <text>".
+	if rest, ok := hookPromptRest(prompt, hooksRememberSharedPrefix); ok {
+		if rest == "" {
+			return "", fmt.Errorf("remember shared: with no text")
+		}
+		store, err := openStore()
+		if err != nil {
+			return "", fmt.Errorf("open store: %w", err)
+		}
+		defer func() { _ = store.Close() }()
+		if err := store.PutShared(context.Background(), rest); err != nil {
+			return "", fmt.Errorf("remember shared: %w", err)
+		}
+		return fmt.Sprintf("Saved to shared memory: %s", rest), nil
+	}
+
+	// Instant-save to the cwd agent: "remember: <text>".
+	if rest, ok := hookPromptRest(prompt, hooksRememberPrefix); ok {
 		if rest == "" {
 			return "", fmt.Errorf("remember: with no text")
 		}
@@ -251,20 +293,23 @@ func hookUserPrompt(agent string, payload hookEventPayload) (string, error) {
 		return fmt.Sprintf("Saved to memory (%s): %s", agent, rest), nil
 	}
 
+	start := timeNow()
 	store, err := openStore()
 	if err != nil {
 		return "", fmt.Errorf("open store: %w", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	facts, err := store.Recall(context.Background(), agent, prompt, 3)
-	if err != nil {
-		return "", fmt.Errorf("recall: %w", err)
-	}
-	if len(facts) == 0 {
+	block, degrade := hookRecallBlock(store, agent, prompt, hookUserPromptAgentTopK, hookUserPromptSharedTopK)
+	if block == "" {
+		if degrade != nil {
+			return "", degrade
+		}
 		return "", nil
 	}
-	block := renderMemoryBlock(facts)
+	if degrade != nil {
+		hookLog(payload, "user-prompt", timeNow().Sub(start), "error", degrade.Error())
+	}
 	if hookStateSeenBlock(agent, block) {
 		return "", nil // identical context already injected on a recent turn
 	}
@@ -272,16 +317,51 @@ func hookUserPrompt(agent string, payload hookEventPayload) (string, error) {
 	return block, nil
 }
 
-// hooksRememberRest strips the remember: prefix case-insensitively. Returns
-// the remaining text and whether the prefix was present.
-func hooksRememberRest(prompt string) (string, bool) {
-	if len(prompt) < len(hooksRememberPrefix) {
+// hookPromptRest strips a prefix case-insensitively, returning the remaining
+// text and whether the prefix was present.
+func hookPromptRest(prompt, prefix string) (string, bool) {
+	if len(prompt) < len(prefix) {
 		return "", false
 	}
-	if !strings.EqualFold(prompt[:len(hooksRememberPrefix)], hooksRememberPrefix) {
+	if !strings.EqualFold(prompt[:len(prefix)], prefix) {
 		return "", false
 	}
-	return strings.TrimSpace(prompt[len(hooksRememberPrefix):]), true
+	return strings.TrimSpace(prompt[len(prefix):]), true
+}
+
+// hookRecallBlock recalls one injection's worth of context: the agent's own
+// facts plus the __shared__ namespace, each under its own budget. A var seam
+// (timeNow precedent) so the degradation paths are testable without a store
+// that fails selectively.
+//
+// Degradation contract: one namespace failing never costs the other's facts —
+// the block comes back carrying whichever side still answered, along with a
+// non-nil degrade error the caller turns into an error receipt in hooks.log
+// while injecting the block anyway. Only when nothing injectable survived
+// (both namespaces failed, or the only populated one did) is the error a hard
+// failure that aborts the injection.
+var hookRecallBlock = func(store cliStore, agent, query string, agentTopK, sharedTopK int) (string, error) {
+	ctx := context.Background()
+	agentFacts, agentErr := store.Recall(ctx, agent, query, agentTopK)
+	sharedFacts, sharedErr := store.RecallShared(ctx, query, sharedTopK)
+
+	switch {
+	case agentErr != nil && sharedErr != nil:
+		return "", fmt.Errorf("recall agent: %v; recall shared: %v", agentErr, sharedErr)
+	case agentErr != nil:
+		block := renderMemoryBlock(nil, sharedFacts)
+		if block == "" {
+			return "", fmt.Errorf("recall agent: %w", agentErr)
+		}
+		return block, fmt.Errorf("agent recall failed, injecting shared facts only: %w", agentErr)
+	case sharedErr != nil:
+		block := renderMemoryBlock(agentFacts, nil)
+		if block == "" {
+			return "", fmt.Errorf("recall shared: %w", sharedErr)
+		}
+		return block, fmt.Errorf("shared recall failed, injecting agent facts only: %w", sharedErr)
+	}
+	return renderMemoryBlock(agentFacts, sharedFacts), nil
 }
 
 // hookCheckpoint is the pre-compact runner: one deterministic checkpoint, no
@@ -358,15 +438,37 @@ func sessionCheckpointFor(agent string, payload hookEventPayload, event string) 
 
 // renderMemoryBlock renders the injected context. Plain text (Claude Code
 // accepts plain text or JSON; plain keeps the block human-readable in the
-// transcript too). Facts longer than one line are folded — the block must stay
-// skimmable inside a prompt.
-func renderMemoryBlock(facts []string) string {
+// transcript too). Two labeled sections — the agent's own facts, then the
+// project-wide __shared__ conventions — because a model consuming the block
+// must be able to tell its own history from standing project rules. Facts
+// longer than one line are folded, and a text stored in both namespaces
+// renders once under Memory: the block must stay skimmable inside a prompt.
+func renderMemoryBlock(agentFacts, sharedFacts []string) string {
 	var sb strings.Builder
-	sb.WriteString("## Memory\n")
-	for _, f := range facts {
-		line := strings.ReplaceAll(strings.TrimSpace(f), "\n", " ")
-		sb.WriteString("- " + line + "\n")
+	seen := make(map[string]bool, len(agentFacts)+len(sharedFacts))
+	render := func(header string, facts []string) {
+		lines := make([]string, 0, len(facts))
+		for _, f := range facts {
+			line := strings.ReplaceAll(strings.TrimSpace(f), "\n", " ")
+			if line == "" || seen[line] {
+				continue
+			}
+			seen[line] = true
+			lines = append(lines, line)
+		}
+		if len(lines) == 0 {
+			return
+		}
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(header + "\n")
+		for _, line := range lines {
+			sb.WriteString("- " + line + "\n")
+		}
 	}
+	render("## Memory", agentFacts)
+	render("## Shared memory (project-wide)", sharedFacts)
 	return strings.TrimRight(sb.String(), "\n")
 }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -455,7 +455,7 @@ Other useful subcommands:
 |---------|---------|
 | `graymatter init` | Wire MCP into Claude Code, Cursor, Codex, OpenCode, Antigravity (see [README.md](../README.md)); `--kg` persists graph auto-population, `--hooks` installs Claude Code memory hooks |
 | `graymatter demo` | Seed a scratch multi-agent store, run consolidation, open the TUI — one command, no keys |
-| `graymatter hooks install` / `uninstall` / `doctor` | Manage Claude Code automatic memory hooks (per-turn injection, `remember:` instant-save, /compact survival); every hook failure degrades silently |
+| `graymatter hooks install` / `uninstall` / `doctor` | Manage Claude Code automatic memory hooks (per-turn injection of agent facts + `__shared__` conventions, `remember:` / `remember shared:` instant-save, /compact survival); every hook failure degrades silently |
 | `graymatter recall <agent> "<query>" --explain` | Receipts per fact: per-signal RRF ranks, fused score, weight, age, provenance (`fact_id`, `written_at`) — same JSON shape as the MCP `explain` payload |
 | `graymatter consolidate <agent_id>` | Run one consolidation cycle through the daemon's policy |
 | `graymatter kg render --out graph.html` | Self-contained force-graph page (offline, tooltips carry fact-ID receipts); `--out graph.dot` for Graphviz |


### PR DESCRIPTION
## Summary

Fixes the P0 from the 28-Aug hardening round: neither `hookSessionStart` nor the `hookUserPrompt` recall ever read the `__shared__` namespace. `AGENTS.md` directs every agent to archive project-wide conventions there, so the documented path led to a hole that failed silently — no error, no warning, empty stdout, the exact failure mode that reads as "memory is broken".

## What changed

- **Both injection runners recall both namespaces** (`hooks_run.go`), each under its own budget: session-start top-5 agent + top-3 shared, per-turn top-3 + top-3. Separate budgets, not a merged top-k (report §7.1 recommendation): on session-start recency is the only ranked signal, so a merged ranking would let old conventions displace the agent's freshest facts. Session-start totals top-8, the injection size `status` quotes.
- **Labeled sections** (§7.2): agent facts render under `## Memory`, shared conventions under `## Shared memory (project-wide)`. A text stored in both namespaces renders once, under Memory. Agent-only stores render the legacy single-section block byte-compatibly.
- **Write-side asymmetry closed** (§3 facet 3): `remember shared: <text>` is a new deterministic instant-save into `__shared__`; until now nothing typed in a prompt could reach it. `remember:` behavior is unchanged.
- **Degradation contract per namespace** (§6): one recall failing never costs the other's facts. The degraded injection still goes out; the failure leaves an error receipt in `hooks.log`. Both namespaces failing (or the only populated one) remains a hard error that follows the exit-0/silent contract.
- **Throttle intact**: the identical-block hash covers the whole rendered block, so merged blocks suppress on unchanged turns and re-inject when a shared fact changes. No state-key versioning needed — the format change produces a new hash, costing at most one redundant injection after upgrade.
- **`graymatter status` INJECTION line** now estimates the block the hooks actually inject (top-5 agent + top-3 shared, via an `estimateTopN` refactor shared with `bench --store`, whose top-8 semantics are unchanged) and no longer counts `__shared__` as a hook agent row.

## Design decisions (report §7)

| Decision | Call |
|---|---|
| Budget split | Separate budgets; agent budgets unchanged (5 / 3), shared gets 3 / 3 |
| Labeling | Two labeled sections; conventions must be distinguishable from own history |
| Shared write syntax | `remember shared: <text>` (case-insensitive), checked before `remember:`; the two prefixes do not collide |
| Pin ordering | Unchanged — pins protect facts from decay/pruning/summarisation; boosting pin rank is a store-ranking change out of scope for this fix |

## Verification (all empirical)

- **Original repro, run against the fixed binary**: both report payloads (§1.1 session-start, §1.2 user-prompt) now return the `__shared__` convention; the pure shared-only store injects it through both events; `remember shared:` round-trips via `recall --shared`.
- **New tests** (report §8 plan, `cmd_hooks_test.go` extended, nothing replaced): session-start shared-only / agent-only (legacy shape) / both; user-prompt same three against matching queries; merged-block throttle (suppressed when identical, re-injects when shared changes); `remember shared` happy + case-insensitive + empty-rest error + agent-namespace-leak check; degradation unit tests on a stub store; degraded-injection receipt in `hooks.log` through the real dispatch; block-render shape pins.
- **Daemon e2e** (`hooks_daemon_e2e_test.go`): the shared convention rides session-start, and `remember shared:` lands in `__shared__` readable over the daemon wire.
- **Full suites green**: root module `go test ./...` (incl. `pkg/memory`, `pkg/memory/rpc`, `benchmarks/*`) and the CLI module `go test ./...` — every package. `go vet` clean; no new gofmt drift vs `main`.
- **Hook-latency gate with the second recall inside** (`benchmarks/hook_latency`, 10k facts, 12 measured process runs/event): recall delta +113 ms (budget ≤ 200 ms), session-end delta +3 ms (≤ 200 ms), scaling 1.10x of linear (max 2.5x) — all hook gates hold.
- **`hooks doctor` green on a healthy project**; `doctor` reports nothing new.
- **`graymatter status`** against a store with shared facts quotes the new block shape.

## Docs

`AGENTS.md` / `docs/AGENTS.md` become true as-is (report §9); README's hooks table and `docs/AGENTS.md`'s command table gain the shared-injection and `remember shared:` mentions. CHANGELOG entry added under `Fixed` in the house style.
