### PR TITLE
fix(benchmarks): pin the hook latency gate to the keyword embedder

### DIFF
--- a/benchmarks/hook_latency/main.go
+++ b/benchmarks/hook_latency/main.go
@@ -192,6 +192,7 @@ func run(stdout io.Writer) error {
 		}
 	}
 
+	fmt.Fprintln(stdout, "Embedder: keyword (no LLM, no network, no API key)")
 	fmt.Fprintf(stdout, "store: %d facts · %d warm-up + %d measured process runs per event\n\n",
 		seedFacts, warmupSamples, measuredRuns)
 
@@ -260,6 +261,8 @@ func measureRecallScaling(dir string) (float64, error) {
 	open := func(dataDir string, n int) (*graymatter.Memory, error) {
 		cfg := graymatter.DefaultConfig()
 		cfg.DataDir = dataDir
+		// Keep this latency gate local and reproducible, independent of ambient credentials.
+		cfg.EmbeddingMode = graymatter.EmbeddingKeyword
 		cfg.VectorReconcileInterval = 0
 		cfg.AsyncConsolidate = false
 		mem, err := graymatter.NewWithConfig(cfg)
@@ -332,6 +335,14 @@ func topicsFor(i int) string {
 func execHook(binary, workDir, storeDir, event, payload string) (string, error) {
 	cmd := exec.Command(binary, "--dir", storeDir, "hooks", "run", event)
 	cmd.Dir = workDir
+	// Hook samples auto-start a daemon, and session-end spawns consolidation.
+	// Keep that entire measured path local, reproducible, and network-free.
+	cmd.Env = append(cmd.Environ(),
+		"ANTHROPIC_API_KEY=",
+		"OPENAI_API_KEY=",
+		"VOYAGE_API_KEY=",
+		"GRAYMATTER_OLLAMA_URL=disabled://hook-latency-benchmark",
+	)
 	cmd.Stdin = strings.NewReader(payload)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -503,6 +514,8 @@ func buildBinary(dir string) (string, func(), error) {
 func seedStore(dir string) error {
 	cfg := graymatter.DefaultConfig()
 	cfg.DataDir = dir
+	// Keep corpus seeding local and reproducible, independent of ambient credentials.
+	cfg.EmbeddingMode = graymatter.EmbeddingKeyword
 	cfg.VectorReconcileInterval = 0 // no background churn during measurement
 	cfg.AsyncConsolidate = false
 	mem, err := graymatter.NewWithConfig(cfg)

--- a/benchmarks/hook_latency/main_test.go
+++ b/benchmarks/hook_latency/main_test.go
@@ -32,6 +32,9 @@ func TestHookLatencyBudgets(t *testing.T) {
 	// The report must name every gated event — a gate that silently stops
 	// measuring one of them is worse than a failing one.
 	out := buf.String()
+	if !strings.Contains(out, "Embedder: keyword (no LLM, no network, no API key)") {
+		t.Error("report missing the explicit keyword embedder")
+	}
 	for _, event := range []string{"user-prompt", "pre-compact", "session-end"} {
 		if !strings.Contains(out, event) {
 			t.Errorf("report missing the %s row", event)


### PR DESCRIPTION
`benchmarks/hook_latency` did not pin its embedder. It fell through to the
library default, which selects OpenAI when `OPENAI_API_KEY` is present in the
environment — so the gate that is supposed to measure local hook latency was
measuring a remote provider instead.

## Measured

Same machine, same tree, changing only the environment:

| Condition | Result |
|---|---|
| With `OPENAI_API_KEY` | `FAIL` — timeout at **1,500 s**, hung in `net/http` HTTP/2 |
| Without it | `ok` — 39 s |

The benchmark seeds `seedFacts = 10000` plus `smallFacts = 500`, so each run
sent roughly 10,500 facts to a paid API. Three consequences, in order:

1. `go test ./...` at the repo root billed a third party and moved fact text
   off the machine, for any contributor with the key set. Nothing announced it.
2. The published latency number stopped being reproducible: whoever holds a key
   measured network round-trips, whoever does not measured local work.
3. CI never saw it. There is no key on the runner, so the job passes there in
   1m19s — the defect was visible only to whoever ran the suite locally.

The sibling benchmark `benchmarks/retrieval_quality` already pins
`embedding.ModeKeyword` on purpose and prints the embedder it used. This brings
`hook_latency` in line with it.

## What changed

Three touch points, because the benchmark measures across a process boundary:

- **In-process stores** — `seedStore` and `measureRecallScaling` pin
  `EmbeddingKeyword`. This covers corpus seeding and the scaling probe.
- **The spawned binary** — `execHook` runs the real CLI, which starts a daemon
  and, on `session-end`, spawns consolidation. Those children inherit the
  environment, so pinning in-process alone would have left the *measured* path
  on the network. The child environment now clears the three provider keys and
  points `GRAYMATTER_OLLAMA_URL` at an unroutable scheme, which
  `ollamaReachable` rejects immediately rather than waiting out its 500 ms
  probe.
- **The report** names the embedder, and a test asserts that line is present. A
  gate that does not state what it measured with is what produced this in the
  first place.

With `OPENAI_API_KEY` set in the environment, the package now passes in ~36 s.

No production code, no flags, no changes to `pkg/embedding`, and no changes to
`seedFacts`, `smallFacts`, or any published budget.

## Related, not touched here

The same root cause — ambient provider credentials reaching code that presents
itself as local and deterministic — appears in three other places. They are
documented separately and deliberately left alone:

- **`graymatter bench --hooks`** (`internal/benchsyn/hook_latency.go:284, 388`).
  This one is a shipped command rather than a test, so it reaches users of the
  binary, and it warrants its own change.
- `benchmarks/agent_lifecycle` and one other manual benchmark, which spawn
  `graymatter mcp serve` with the inherited environment.
