### PR TITLE
test(harness): make the kill guard sleeper independent of PATH

### DIFF
--- a/cmd/graymatter/internal/harness/kill_guard_test.go
+++ b/cmd/graymatter/internal/harness/kill_guard_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,17 +41,20 @@ func saveRunning(t *testing.T, db *bolt.DB, id string, pid int) {
 	}
 }
 
+func TestKillGuardSleeperProcess(t *testing.T) {
+	if os.Getenv("GRAYMATTER_TEST_SLEEP_HELPER") != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
+}
+
 // startSleeper launches a real, harmless child process and returns its PID.
 // It is the stand-in for "some other process on this machine".
 func startSleeper(t *testing.T) int {
 	t.Helper()
 
-	var c *exec.Cmd
-	if runtime.GOOS == "windows" {
-		c = exec.Command("cmd.exe", "/c", "ping -n 30 127.0.0.1 > NUL")
-	} else {
-		c = exec.Command("sleep", "30")
-	}
+	c := exec.Command(os.Args[0], "-test.run=^TestKillGuardSleeperProcess$")
+	c.Env = append(c.Environ(), "GRAYMATTER_TEST_SLEEP_HELPER=1")
 	if err := c.Start(); err != nil {
 		t.Skipf("cannot start a helper process: %v", err)
 	}


### PR DESCRIPTION
The kill-guard tests spawn a real child process to stand in for "some other
process on this machine". On Windows that child was
`cmd.exe /c ping -n 30 127.0.0.1 > NUL`; on POSIX, `sleep 30`. Both resolve
their program through `PATH`.

On a host where `PATH` arrives truncated or empty for the child — a long
inherited environment is the known case — `ping` never runs, the child exits
immediately with `exit status 1`, and the assertions report symptoms that have
nothing to do with what they test:

- `TestKillSessionDB_RefusesMismatchedPIDFile` → *"the unrelated process was
  terminated anyway"*, because `processAlive` finds a process that died on its
  own.
- `TestKillSessionDB_KillsRealSessions` → `TerminateProcess: Access is denied`,
  because the PID no longer exists.

The guard itself is correct, and CI has always shown that: both Windows cells
pass, since `ping` resolves on the runner. The failure was only ever visible to
whoever ran the suite locally on an affected host — where it reads as a
process-termination bug in `recovery.go`, which is a costly place to send
someone chasing a defect that is not there. (See the correction appended to
#84, where exactly that misreading was published and retracted.)

## What changed

`startSleeper` now uses Go's standard test-helper-process pattern: it re-execs
the test binary itself with `-test.run` pointed at a helper that sleeps, gated
behind an environment variable so it is inert in a normal run. No `cmd.exe`, no
`ping`, no `sleep`, no `PATH` lookup, and the `runtime.GOOS` branch disappears.

## Verification

The whole family passes with `PATH` **unset entirely** — the test binary
compiled first, then run with no `PATH` at all:

```
--- PASS: TestKillSessionDB_RefusesPIDsWithoutAPIDFile
--- PASS: TestKillSessionDB_RefusesMismatchedPIDFile
--- PASS: TestKillSessionDB_RefusesToKillItself
--- PASS: TestKillSessionDB_KillsRealSessions
```

`-race` on the package is green, both modules build, `gofmt` is clean.

Test-only: no production code, no changed assertions, no changed timeouts, and
no CHANGELOG entry, since nothing user-facing moves.
