### PR TITLE
fix(run): persist the session identity a background run announces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - **Hooks and MCP no longer duplicate matching startup recall, and `init --global` now says exactly what it scopes** ([#81](https://github.com/angelnicolasc/graymatter/issues/81)). A non-empty Claude Code hook block names the namespace it actually queried; before the first reply, same-ID non-empty sections replace matching MCP startup searches. A different ID reruns both project and `__shared__` so cross-namespace dedup cannot hide shared facts, while missing sections safely fall back. Focused/batch searches, writes, corrections, aliases, and checkpoints remain available. `init --global` still initializes the current project and additionally installs home-scoped agent instructions — it does not globalize project-scoped MCP configs (Codex's config is already home-scoped).
+- **Background agent runs now persist the exact session ID, PID, and log path announced by the parent process.** `sessions list`, `sessions logs`, and `sessions kill` therefore address the same detached run instead of an unreachable duplicate session record.
 
 ### Notes
 

--- a/cmd/graymatter/cmd_run.go
+++ b/cmd/graymatter/cmd_run.go
@@ -17,12 +17,12 @@ import (
 
 func runCmd() *cobra.Command {
 	var (
-		background     bool
-		resumeID       string
-		maxRetries     int
-		inputs         []string
+		background      bool
+		resumeID        string
+		maxRetries      int
+		inputs          []string
 		backgroundChild bool
-		sessionIDFlag  string
+		sessionIDFlag   string
 	)
 
 	cmd := &cobra.Command{
@@ -68,6 +68,11 @@ Examples:
 				Stdout:     cmd.OutOrStdout(),
 				Stderr:     cmd.ErrOrStderr(),
 				Store:      store,
+			}
+			if backgroundChild {
+				cfg.SessionID = sessionIDFlag
+				cfg.PID = os.Getpid()
+				cfg.LogFile = harness.LogFilePath(dataDir, sessionIDFlag)
 			}
 			result, err := harness.Run(context.Background(), cfg)
 			if err != nil {

--- a/cmd/graymatter/cmd_run_background_test.go
+++ b/cmd/graymatter/cmd_run_background_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/harness"
+)
+
+const backgroundTestAgent = `---
+name: background-test-agent
+model: claude-opus-4-6
+---
+
+## System Prompt
+You are a test agent.
+
+## Task
+Wait for the test server.
+`
+
+func runBackgroundCLI(bin, dir string, env, args []string) (string, error) {
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func printedBackgroundSessionID(output string) string {
+	const (
+		prefix = "Session "
+		suffix = " started in background."
+	)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) && strings.HasSuffix(line, suffix) {
+			return strings.TrimSuffix(strings.TrimPrefix(line, prefix), suffix)
+		}
+	}
+	return ""
+}
+
+func backgroundOutputField(output, prefix string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		}
+	}
+	return ""
+}
+
+func TestRunBackgroundPersistsPrintedSessionAndSupportsControl(t *testing.T) {
+	bin := buildE2EBinary(t)
+	projectDir := t.TempDir()
+	storeDir := filepath.Join(projectDir, ".graymatter")
+	agentFile := filepath.Join(projectDir, "agent.md")
+	if err := os.WriteFile(agentFile, []byte(backgroundTestAgent), 0o600); err != nil {
+		t.Fatalf("write agent: %v", err)
+	}
+
+	requestBlocked := make(chan struct{})
+	requestDone := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var requestCount atomic.Int32
+	var blockedOnce, doneOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount.Add(1) == 1 {
+			http.Error(w, "intentional first-attempt failure", http.StatusBadRequest)
+			return
+		}
+		blockedOnce.Do(func() { close(requestBlocked) })
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		controller := http.NewResponseController(w)
+		ticker := time.NewTicker(25 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				doneOnce.Do(func() { close(requestDone) })
+				return
+			case <-releaseRequest:
+				return
+			case <-ticker.C:
+				_, writeErr := w.Write([]byte(" "))
+				if writeErr == nil {
+					writeErr = controller.Flush()
+				}
+				if writeErr != nil {
+					doneOnce.Do(func() { close(requestDone) })
+					return
+				}
+			}
+		}
+	}))
+
+	env := []string{
+		"ANTHROPIC_API_KEY=background-e2e",
+		"ANTHROPIC_AUTH_TOKEN=",
+		"ANTHROPIC_BASE_URL=" + server.URL,
+		"OPENAI_API_KEY=",
+		"VOYAGE_API_KEY=",
+		"GRAYMATTER_OLLAMA_URL=disabled://background-session-e2e",
+		"GRAYMATTER_NO_DAEMON=",
+		"HTTP_PROXY=",
+		"HTTPS_PROXY=",
+		"ALL_PROXY=",
+		"http_proxy=",
+		"https_proxy=",
+		"all_proxy=",
+		"NO_PROXY=127.0.0.1,localhost",
+		"PATH=",
+	}
+	printedID := ""
+	backgroundPID := 0
+	t.Cleanup(func() {
+		if printedID != "" {
+			_, _ = runBackgroundCLI(bin, projectDir, env,
+				[]string{"--dir", storeDir, "sessions", "kill", printedID})
+		}
+		select {
+		case <-requestDone:
+		default:
+			if backgroundPID > 0 {
+				if process, err := os.FindProcess(backgroundPID); err == nil {
+					_ = process.Kill()
+				}
+			}
+		}
+		close(releaseRequest)
+		server.Close()
+		daemonPID := daemon.ReadPIDFile(storeDir)
+		_, _ = runBackgroundCLI(bin, projectDir, env,
+			[]string{"--dir", storeDir, "daemon", "stop"})
+		deadline := time.Now().Add(5 * time.Second)
+		for daemon.ReadPIDFile(storeDir) != 0 && time.Now().Before(deadline) {
+			time.Sleep(25 * time.Millisecond)
+		}
+		if daemon.ReadPIDFile(storeDir) != 0 && daemonPID > 0 {
+			if process, err := os.FindProcess(daemonPID); err == nil {
+				_ = process.Kill()
+			}
+		}
+	})
+
+	out, err := runBackgroundCLI(bin, projectDir, env,
+		[]string{"--dir", storeDir, "run", agentFile, "--background", "--max-retries", "2"})
+	if err != nil {
+		t.Fatalf("run --background: %v\n%s", err, out)
+	}
+	printedID = printedBackgroundSessionID(out)
+	if printedID == "" {
+		t.Fatalf("background output has no session ID:\n%s", out)
+	}
+	backgroundPID, err = strconv.Atoi(backgroundOutputField(out, "PID:"))
+	if err != nil || backgroundPID <= 0 {
+		t.Fatalf("background output has no valid PID:\n%s", out)
+	}
+	printedLog := backgroundOutputField(out, "Log:")
+	if printedLog == "" {
+		t.Fatalf("background output has no log path:\n%s", out)
+	}
+
+	select {
+	case <-requestBlocked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("background child did not reach the blocking second attempt")
+	}
+
+	listOut, err := runBackgroundCLI(bin, projectDir, env,
+		[]string{"--dir", storeDir, "--json", "sessions", "list"})
+	if err != nil {
+		t.Fatalf("sessions list: %v\n%s", err, listOut)
+	}
+	var sessions []harness.HarnessSession
+	if err := json.Unmarshal([]byte(listOut), &sessions); err != nil {
+		t.Fatalf("decode sessions list: %v\n%s", err, listOut)
+	}
+	var persisted *harness.HarnessSession
+	for i := range sessions {
+		if sessions[i].ID == printedID {
+			persisted = &sessions[i]
+			break
+		}
+	}
+	if persisted == nil {
+		t.Fatalf("printed session %q was not persisted: %+v", printedID, sessions)
+	}
+	if persisted.PID <= 0 {
+		t.Fatalf("background session has no PID: %+v", *persisted)
+	}
+	if persisted.PID != backgroundPID {
+		t.Fatalf("persisted PID = %d, printed PID = %d", persisted.PID, backgroundPID)
+	}
+	expectedLog := harness.LogFilePath(storeDir, printedID)
+	if filepath.Clean(printedLog) != filepath.Clean(expectedLog) {
+		t.Fatalf("printed log file = %q, want %q", printedLog, expectedLog)
+	}
+	if filepath.Clean(persisted.LogFile) != filepath.Clean(expectedLog) {
+		t.Fatalf("log file = %q, want %q", persisted.LogFile, expectedLog)
+	}
+	if pid, err := harness.ReadPIDFile(harness.PIDFilePath(storeDir, printedID)); err != nil {
+		t.Fatalf("read PID file: %v", err)
+	} else if pid != persisted.PID {
+		t.Fatalf("PID file = %d, persisted PID = %d", pid, persisted.PID)
+	}
+
+	logsOut, err := runBackgroundCLI(bin, projectDir, env,
+		[]string{"--dir", storeDir, "sessions", "logs", printedID})
+	if err != nil {
+		t.Fatalf("sessions logs: %v\n%s", err, logsOut)
+	}
+	if !strings.Contains(logsOut, "attempt 1/2 failed") {
+		t.Fatalf("sessions logs omitted child diagnostics:\n%s", logsOut)
+	}
+	if killOut, err := runBackgroundCLI(bin, projectDir, env,
+		[]string{"--dir", storeDir, "sessions", "kill", printedID}); err != nil {
+		t.Fatalf("sessions kill: %v\n%s", err, killOut)
+	}
+
+	select {
+	case <-requestDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sessions kill returned but the background process stayed connected")
+	}
+
+	listOut, err = runBackgroundCLI(bin, projectDir, env,
+		[]string{"--dir", storeDir, "--json", "sessions", "list"})
+	if err != nil {
+		t.Fatalf("sessions list after kill: %v\n%s", err, listOut)
+	}
+	sessions = nil
+	if err := json.Unmarshal([]byte(listOut), &sessions); err != nil {
+		t.Fatalf("decode sessions after kill: %v\n%s", err, listOut)
+	}
+	for _, session := range sessions {
+		if session.ID == printedID && session.Status == "killed" {
+			return
+		}
+	}
+	t.Fatalf("session %q was not marked killed: %+v", printedID, sessions)
+}

--- a/cmd/graymatter/internal/harness/runner.go
+++ b/cmd/graymatter/internal/harness/runner.go
@@ -49,6 +49,12 @@ type RunConfig struct {
 	// DataDir is the GrayMatter data directory. Default: ".graymatter"
 	DataDir string
 
+	// SessionID, PID, and LogFile identify a parent-spawned background run.
+	// SessionID defaults to a new ULID when omitted.
+	SessionID string
+	PID       int
+	LogFile   string
+
 	// MaxRetries is the maximum number of LLM call attempts. Default: 3
 	MaxRetries int
 
@@ -125,8 +131,11 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 		store = ls
 	}
 
-	// Allocate a new session ID for this run.
-	sessionID := ulid.Make().String()
+	// Allocate a new session ID unless the background parent supplied one.
+	sessionID := cfg.SessionID
+	if sessionID == "" {
+		sessionID = ulid.Make().String()
+	}
 
 	// Load prior checkpoint message history when resuming.
 	var priorMessages []session.Message
@@ -145,6 +154,8 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 		AgentFile: cfg.AgentFile,
 		StartedAt: time.Now().UTC(),
 		Status:    "running",
+		PID:       cfg.PID,
+		LogFile:   cfg.LogFile,
 		Inputs:    cfg.Inputs,
 	}
 	if err := store.SessionSave(hs); err != nil {


### PR DESCRIPTION
`graymatter run --background` printed a session ID that was never persisted. The
record it did write carried neither a PID nor a log path, which are precisely
the two fields `sessions kill` and `sessions logs` require. Every background run
was therefore unreachable by the only tooling that exists to manage it.

Deterministic, on every platform, for 100% of background runs.

## Where the information was lost

The parent process was never the problem. `spawnBackground` fixes the session
ID, creates `logs/<sid>.log` and `run/<sid>.pid`, passes `--background-child`
and `--session-id=<sid>` to the child, writes the PID file, and prints all three
values to the user.

The child dropped them because it had nowhere to put them:

- `cmd_run.go` received the ID in `sessionIDFlag`, but consumed it only on the
  parent branch.
- `harness.RunConfig` had no field for a session ID, a PID, or a log path, so
  the child could not have forwarded them even if it tried.
- `runner.go` therefore minted a second, unconditional ULID — a different
  identity from the one the user was looking at.
- The persisted `HarnessSession` omitted `PID` and `LogFile`, although the
  struct has carried both fields all along.

`recovery.go` then rejected the record on `PID == 0` and `LogFile == ""`. Those
guards are correct and are left untouched: they are what surfaced this, not what
caused it.

## What changed

`RunConfig` gains `SessionID`, `PID`, and `LogFile`. The child populates them —
`os.Getpid()` for the PID, since the child *is* the process whose PID the parent
recorded — `runner.go` honours a supplied ID and falls back to a new ULID
otherwise, and the persisted session carries the PID and log path.

Foreground runs are unaffected: with no ID supplied, the ULID path is exactly
what it was.

No new user-visible flags (`--session-id` and `--background-child` already
existed, hidden), no change to the persisted JSON schema (both fields predate
this change), and no change to `spawnBackground` or the recovery guards.

## Verification

Background runs had no test coverage at all, which is why this survived. A new
end-to-end test now closes the loop, and it asserts against **the ID the command
prints** rather than any internal return value — the divergence between those
two is the bug:

- parses the session ID, PID, and log path out of the command's own stdout;
- asserts a persisted record exists under that printed ID;
- asserts the persisted PID and log path match the printed ones;
- asserts the PID file on disk agrees;
- kills the run through the printed ID and checks it reaches `killed`.

Green under `-race`, alongside the full `internal/harness` package.
