### PR TITLE
test(daemon): share one integration binary and stop asserting on its cleanup

### DIFF
--- a/cmd/graymatter/internal/daemon/daemon_integration_test.go
+++ b/cmd/graymatter/internal/daemon/daemon_integration_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -13,20 +14,49 @@ import (
 	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
 )
 
-// buildBinary compiles the graymatter binary once per test run and returns
-// its path. Spawn-on-connect re-invokes this binary as `daemon run`.
+var (
+	testBinaryOnce sync.Once
+	testBinaryDir  string
+	testBinaryPath string
+	testBinaryErr  error
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	// Shutdown acknowledges before the daemon necessarily exits, so Windows
+	// may still hold the executable here. This does not remove that race: it
+	// defers cleanup until after all package tests and makes it best-effort
+	// instead of a mandatory t.TempDir cleanup assertion.
+	if testBinaryDir != "" {
+		_ = os.RemoveAll(testBinaryDir)
+	}
+	os.Exit(code)
+}
+
+// buildBinary lazily compiles one graymatter binary for the package. Keeping
+// it outside t.TempDir prevents a transient Windows image lock from failing
+// an otherwise successful test during that test's mandatory cleanup.
 func buildBinary(t *testing.T) string {
 	t.Helper()
-	out := filepath.Join(t.TempDir(), "graymatter")
-	if runtime.GOOS == "windows" {
-		out += ".exe"
+	testBinaryOnce.Do(func() {
+		testBinaryDir, testBinaryErr = os.MkdirTemp("", "graymatter-daemon-test-")
+		if testBinaryErr != nil {
+			return
+		}
+		testBinaryPath = filepath.Join(testBinaryDir, "graymatter")
+		if runtime.GOOS == "windows" {
+			testBinaryPath += ".exe"
+		}
+		cmd := exec.Command("go", "build", "-o", testBinaryPath,
+			"github.com/angelnicolasc/graymatter/cmd/graymatter")
+		if combined, err := cmd.CombinedOutput(); err != nil {
+			testBinaryErr = fmt.Errorf("go build graymatter: %w\n%s", err, combined)
+		}
+	})
+	if testBinaryErr != nil {
+		t.Fatal(testBinaryErr)
 	}
-	cmd := exec.Command("go", "build", "-o", out,
-		"github.com/angelnicolasc/graymatter/cmd/graymatter")
-	if combined, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("go build graymatter: %v\n%s", err, combined)
-	}
-	return out
+	return testBinaryPath
 }
 
 // withBuiltDaemon points spawn-on-connect at a freshly built binary for the


### PR DESCRIPTION
`TestConcurrentClients_ThroughDaemon` failed a Windows CI cell on #87 with a
cleanup error, not an assertion:

```
--- FAIL: TestConcurrentClients_ThroughDaemon (32.59s)
    testing.go:1464: TempDir RemoveAll cleanup:
      unlinkat …\001\graymatter.exe: Access is denied.
```

Every assertion in that test passed. The failure came afterwards, from Go
turning a `t.TempDir()` cleanup error into a test failure.

## Why it happens

`buildBinary` compiled `graymatter.exe` **into `t.TempDir()`**, and the tests
spawn daemons from it. The test ends with `lead.Shutdown()`, which
(`client.go:274`) is a synchronous RPC that returns when the daemon
*acknowledges* the request — not when the process exits. Microseconds later the
TempDir cleanup tries to delete an image Windows still holds. On POSIX
unlinking a running executable is fine; on Windows it is not.

Hence the intermittency: the same commit passed on `windows-latest/go1.25` and
failed on `go1.26.7`.

## What changed

One binary per package, built lazily behind a `sync.Once` into a directory from
`os.MkdirTemp`, removed best-effort in `TestMain` after `m.Run()`.

The build stays lazy rather than moving into `TestMain`'s body on purpose: all
seven binary-dependent tests `t.Skip` in `-short` *before* reaching it, so
`go test -short ./internal/daemon` compiles nothing today, and an unconditional
build would have silently taken that away. Verified by directory count, not by
timing: a `-short` run creates zero build directories.

This does not make the daemon exit faster. It removes the assertion that
depended on it — a leftover temp file is something the OS reclaims, not a red
build. The code comment says exactly that rather than claiming the race is gone.

Secondary effect: the binary was being built six times per package run, once per
`withBuiltDaemon` call site. Now once.

Test-only: no production files, no changed assertions, no CHANGELOG.
