### PR TITLE
ci: give the core library suite the headroom its measurements need

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,16 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # 600s, not the 300s the other suites use: pkg/memory under -race is the
+      # slowest gated suite on a Windows runner, measuring 119-173s across green
+      # runs (162s on run 33846765301). That is under 2x headroom, and a loaded
+      # runner has twice crossed it with nothing wrong - run 33842978778 (PR #90)
+      # and run 33899489378 (main at 5e79f7b), both windows-latest/go1.25, both
+      # timing out at exactly 300.1s with the package still progressing. The
+      # remaining 300s suites keep theirs: they measure 4-37s, an 8-75x margin.
       - name: Test core library with coverage
         shell: bash
-        run: go test -race -count=1 -timeout=300s -coverprofile=coverage-core.out -covermode=atomic ./pkg/memory/...
+        run: go test -race -count=1 -timeout=600s -coverprofile=coverage-core.out -covermode=atomic ./pkg/memory/...
 
       - name: Test CLI module with coverage
         working-directory: cmd/graymatter


### PR DESCRIPTION
The `pkg/memory` step has timed out twice on `windows-latest/go1.25` with
nothing wrong, most recently on `main` itself:

- run 33842978778 — PR #90, a branch touching no file under `pkg/`
- run 33899489378 — `main` at 5e79f7b, the merge of #91, likewise touching none

Both failed identically: `panic: test timed out after 5m0s`, `FAIL … 300.158s`,
and the alarm naming a test that had been running for 8 seconds. Nothing hung —
the package simply did not finish inside the ceiling.

## The measurement

Per-step durations on a green `windows-latest/go1.25` run (33846765301):

| Step | Measured | Ceiling | Headroom |
|---|---:|---:|---:|
| **Test core library with coverage** | **162 s** | 300 s | **1.85x** |
| Test CLI module with coverage | 37 s | 300 s | 8.1x |
| Test root package | 4 s | 300 s | 75x |
| Test CLI entrypoint package | 37 s | 300 s | 8.1x |
| Test benchmark packages | 528 s | 1200 s | 2.3x |

Across green runs `pkg/memory` measures 119–173 s. It is the slowest gated
suite in the matrix, it already varies 45% between healthy runs, and a shared
runner having a bad minute is enough to double it.

## The change

One step. `pkg/memory` moves to 600s, which is 3.7x its median and 2x the
ceiling that has actually been breached — the same discipline the benchmark
step already carries, and for the same documented reason.

The other three 300s suites keep theirs. They measure 4–37 seconds and have
never timed out; widening a limit that is doing no harm would only make a real
hang take longer to surface.

No test, no production code, and no gate is weakened: a genuine hang still fails,
just after 10 minutes instead of 5.
