### PR TITLE
fix(benchmarks): pin the last two manual benchmarks to the keyword embedder

### DIFF
--- a/benchmarks/agent_lifecycle/main.go
+++ b/benchmarks/agent_lifecycle/main.go
@@ -158,6 +158,12 @@ type ioWriteCloser interface {
 func startSession(binary, workdir string) (*session, error) {
 	cmd := exec.Command(binary, "mcp", "serve")
 	cmd.Dir = workdir // the server opens <cwd>/.graymatter — pin it so the run's store is isolated from whatever the parent directory happens to contain
+	cmd.Env = append(cmd.Environ(),
+		"ANTHROPIC_API_KEY=",
+		"OPENAI_API_KEY=",
+		"VOYAGE_API_KEY=",
+		"GRAYMATTER_OLLAMA_URL=disabled://agent-lifecycle-benchmark",
+	)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err
@@ -566,6 +572,7 @@ func reportString(binary, dir string, m *metrics, fullHistoryTokens int, reducti
 
 	w("# Agent lifecycle simulation — 100 real sessions\n\n")
 	w("Protocol: one fresh `graymatter mcp serve` process per session (JSON-RPC over stdio); the process dies at every session end — durability across restarts is under test, not simulated. Corpus is realistic and adversarial: distractor families sharing vocabulary, a supersede pair, paraphrase probe, shared namespace. Deterministic seed.\n\n")
+	w("Embedder: keyword (no LLM, no network, no API key)\n\n")
 	w("| Metric | Claim under test | Measured | Verdict |\n|---|---|---|\n")
 
 	hitRate := 100 * float64(m.probeHits) / float64(max(1, m.probeTotal))

--- a/benchmarks/decay_probe/main.go
+++ b/benchmarks/decay_probe/main.go
@@ -22,6 +22,7 @@ func main() {
 	cfg.DecayHalfLife = 2 * time.Second // 30 days compressed to 2 seconds
 	cfg.AsyncConsolidate = false        // drive consolidation by hand
 	cfg.ConsolidateThreshold = 1000     // never auto-trigger
+	cfg.EmbeddingMode = graymatter.EmbeddingKeyword
 
 	mem, err := graymatter.NewWithConfig(cfg)
 	if err != nil {
@@ -29,6 +30,7 @@ func main() {
 		os.Exit(1)
 	}
 	ctx := context.Background()
+	fmt.Println("Embedder: keyword (no LLM, no network, no API key)")
 
 	const agent = "decay-agent"
 	for _, f := range []string{"untouched A", "untouched B", "untouched C", "untouched D", "untouched E", "untouched F", "untouched G", "untouched H", "untouched I", "untouched J"} {


### PR DESCRIPTION
Closes the family #85 and #88 opened. Two benchmarks presented as deterministic
simulations did not pin their embedder, so with credentials in the environment —
or with a local Ollama listening, which needs no credential at all — they left
the keyword path, changed their own latency and ranking, and sent synthetic
corpus to a third party.

Counting **both** APIs this repository uses to pin the embedder
(`embedding.ModeKeyword` and `graymatter.EmbeddingKeyword`), these were the last
two unpinned of six:

| Benchmark | Before |
|---|---|
| `agent_lifecycle` | unpinned |
| `decay_probe` | unpinned |
| `hook_latency` | pinned (#85) |
| `retrieval_quality`, `revision_currency`, `token_count` | pinned |

They needed different fixes, not the same one twice.

`agent_lifecycle` spawns processes: one fresh `mcp serve` per session, a hundred
of them. Its author had already isolated the *store* with `cmd.Dir` and said so
in a comment — the *environment* was still inherited. It now runs its children
with the three provider keys cleared and Ollama auto-detection aimed at an
unroutable scheme.

`decay_probe` opens its store in process, so it pins `EmbeddingKeyword` on the
config instead.

Both now name the embedder in their output, like the four that were already
correct. A benchmark that does not say what it measured with is what produced
this series.

No CHANGELOG: internal tooling, no user-facing surface, same as #85.
