### PR TITLE
fix(benchmarks): stop the hook daemon before deleting the binary it needs

### DIFF
--- a/benchmarks/hook_latency/main.go
+++ b/benchmarks/hook_latency/main.go
@@ -87,10 +87,6 @@ type sample struct {
 	wall     time.Duration // process start to exit
 }
 
-// binaryPath is the built benchmark binary, set once run() has it; the
-// daemon-stop cleanup reads it.
-var binaryPath string
-
 func main() {
 	if err := run(os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "hook_latency: %v\n", err)
@@ -111,15 +107,22 @@ func run(stdout io.Writer) error {
 		return fmt.Errorf("work dir: %w", err)
 	}
 
-	// The samples run against the store daemon, which spawns from the built
-	// binary and outlives them. Stop it so the temp root is releasable
-	// (Windows locks executing files). Best-effort.
+	// Keep the dependent cleanup order explicit: stop the daemon while the
+	// built binary still exists, then remove the binary and the temp root.
+	// Every step is best-effort, including paths that fail before the build.
+	var binaryPath string
+	var cleanupBinary func()
 	defer func() {
-		stop := exec.Command(binaryPath, "--dir", storeDir, "daemon", "stop")
-		stop.Stdout = io.Discard
-		stop.Stderr = io.Discard
-		_ = stop.Run()
-		time.Sleep(500 * time.Millisecond)
+		if binaryPath != "" {
+			stop := exec.Command(binaryPath, "--dir", storeDir, "daemon", "stop")
+			stop.Stdout = io.Discard
+			stop.Stderr = io.Discard
+			_ = stop.Run()
+			time.Sleep(500 * time.Millisecond)
+		}
+		if cleanupBinary != nil {
+			cleanupBinary()
+		}
 		_ = os.RemoveAll(root)
 	}()
 
@@ -140,10 +143,8 @@ func run(stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	defer cleanup()
-	// The daemon-stop cleanup (deferred above) needs the built binary's path;
-	// it is only known now, after the build.
 	binaryPath = binary
+	cleanupBinary = cleanup
 
 	runHook := func(event, payload string) (sample, string) {
 		start := time.Now()

--- a/cmd/graymatter/internal/benchsyn/hook_latency.go
+++ b/cmd/graymatter/internal/benchsyn/hook_latency.go
@@ -141,10 +141,9 @@ func RunHookLatency(p HookLatencyParams, stdout io.Writer) (HookLatencyReport, e
 	}
 
 	defer func() {
-		// The samples run against the store daemon, which spawns from the
-		// binary under test and outlives them. Stop it so the temp root —
-		// and the binary on Windows, which locks executing files — is
-		// releasable. Best-effort: no daemon is also fine.
+		// Ask the known daemon to stop before best-effort root cleanup. Detached
+		// session-end work can still revive it after this request; this does not
+		// remove that race, and cleanup failure is not a benchmark failure.
 		stop := exec.Command(p.Binary, "--dir", storeDir, "daemon", "stop")
 		isolateHookBenchmarkProcess(stop)
 		stop.Stdout = io.Discard

--- a/cmd/graymatter/internal/benchsyn/hook_latency_test.go
+++ b/cmd/graymatter/internal/benchsyn/hook_latency_test.go
@@ -21,8 +21,15 @@ func TestRunHookLatency_ScaledPipeline(t *testing.T) {
 		t.Skip("spawns real hook processes; skipped in -short")
 	}
 
-	// The runner executes a graymatter binary; build the current tree once.
-	bin := filepath.Join(t.TempDir(), "graymatter-under-test.exe")
+	// Detached session-end work may still hold the executable after the runner
+	// returns. This does not remove that race: an owned temp directory makes
+	// cleanup best-effort instead of a t.TempDir assertion.
+	binDir, err := os.MkdirTemp("", "graymatter-bench-hooks-binary-")
+	if err != nil {
+		t.Fatalf("create binary temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(binDir) }()
+	bin := filepath.Join(binDir, "graymatter-under-test.exe")
 	out, err := exec.Command("go", "build", "-o", bin, "github.com/angelnicolasc/graymatter/cmd/graymatter").CombinedOutput()
 	if err != nil {
 		t.Fatalf("build test binary: %v: %s", err, out)


### PR DESCRIPTION
Two symptoms of one cause: cleanup racing a process that still holds the
temporary binary.

## The defers ran in the wrong order

`benchmarks/hook_latency` registered the daemon-stop cleanup first and
`defer cleanup()` — which deletes the built binary — second. Defers run LIFO, so
the binary was removed *before* the stop tried to execute it. The stop failed
silently, since it is `_ = stop.Run()`, and on POSIX the daemon stayed up until
its two-minute idle exit.

The comment above `defer cleanup()` shows the author had noticed that the stop
depends on `binaryPath` and solved that by assigning it after the build. The
dependency on *execution order* went unnoticed.

Both are now one defer with the sequence written out — stop, then binary, then
root — with guards so a failure before the build cannot panic. The
package-level `binaryPath` variable is gone; the closure captures locals.

## Detached work outlived the runner on Windows

`internal/benchsyn`'s test built its binary into `t.TempDir()`, whose cleanup
Go treats as a mandatory assertion. `session-end` spawns detached consolidation
that can revive the daemon after the single stop, so on Windows the image was
still locked when the directory was removed.

The binary now lives in an `os.MkdirTemp` directory removed best-effort, the
same shape #89 used for `internal/daemon`.

## What this does not do

It does not eliminate the race, and the comments say so rather than claiming
otherwise. Detached session-end work can still start a daemon after the stop
request; what changes is that a leftover temporary file is no longer a failed
benchmark.

Guaranteeing zero surviving processes would require tracking those children,
coordinating with the daemon, or repeating the stop — none of which belong in a
benchmark's cleanup, and all of which would change the production behaviour the
benchmark exists to measure. The residue is bounded: consolidators finish on
their own and the daemon idle-exits after two minutes. The files were the part
that persisted, and those are handled.

## Verification

`internal/benchsyn` green. The manual benchmark runs to `all hook gates hold`,
and a Windows run left the `graymatter` process count unchanged before and
after.

No measurement, corpus, budget, CI configuration or daemon behaviour changed.
