### PR TITLE
fix(sessions): terminate the verified handle on Windows instead of the PID

### DIFF
--- a/cmd/graymatter/internal/harness/kill_unix.go
+++ b/cmd/graymatter/internal/harness/kill_unix.go
@@ -8,6 +8,22 @@ import (
 	"syscall"
 )
 
+type pidKillTarget int
+
+func openKillTarget(pid int) (processKillTarget, error) {
+	return pidKillTarget(pid), nil
+}
+
+func (t pidKillTarget) startTime() (int64, error) {
+	return processStartTime(int(t))
+}
+
+func (t pidKillTarget) terminate() error {
+	return killPID(int(t))
+}
+
+func (pidKillTarget) close() {}
+
 // killPID sends SIGTERM to the process with the given PID.
 // Returns an error if the process is not found or the signal fails.
 func killPID(pid int) error {

--- a/cmd/graymatter/internal/harness/kill_windows.go
+++ b/cmd/graymatter/internal/harness/kill_windows.go
@@ -4,22 +4,63 @@ package harness
 
 import (
 	"fmt"
-	"os"
+
+	"golang.org/x/sys/windows"
 )
 
-// killPID terminates the process with the given PID via os.Process.Kill().
-// On Windows this calls TerminateProcess under the hood.
-// Returns an error if the process is not found or termination fails.
-func killPID(pid int) error {
-	if pid <= 0 {
-		return fmt.Errorf("invalid PID %d", pid)
-	}
-	p, err := os.FindProcess(pid)
+type windowsProcessAPI struct {
+	openProcess      func(uint32, bool, uint32) (windows.Handle, error)
+	getProcessTimes  getProcessTimesFunc
+	terminateProcess func(windows.Handle, uint32) error
+	closeHandle      func(windows.Handle) error
+}
+
+var nativeWindowsProcessAPI = windowsProcessAPI{
+	openProcess:      windows.OpenProcess,
+	getProcessTimes:  windows.GetProcessTimes,
+	terminateProcess: windows.TerminateProcess,
+	closeHandle:      windows.CloseHandle,
+}
+
+type windowsKillTarget struct {
+	pid    int
+	handle windows.Handle
+	api    windowsProcessAPI
+}
+
+func openKillTarget(pid int) (processKillTarget, error) {
+	return openWindowsKillTarget(pid, nativeWindowsProcessAPI)
+}
+
+func openWindowsKillTarget(pid int, api windowsProcessAPI) (processKillTarget, error) {
+	processID, err := windowsProcessID(pid)
 	if err != nil {
-		return fmt.Errorf("find process %d: %w", pid, err)
+		return nil, err
 	}
-	if err := p.Kill(); err != nil {
-		return fmt.Errorf("kill process %d: %w", pid, err)
+	h, err := api.openProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE,
+		false,
+		processID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open process %d: %w", pid, err)
+	}
+	return &windowsKillTarget{pid: pid, handle: h, api: api}, nil
+}
+
+func (t *windowsKillTarget) startTime() (int64, error) {
+	return processStartTimeFromHandle(t.pid, t.handle, t.api.getProcessTimes)
+}
+
+func (t *windowsKillTarget) terminate() error {
+	// Match os.Process.Kill's Windows exit code while keeping the HANDLE that
+	// supplied the verified creation time.
+	if err := t.api.terminateProcess(t.handle, 1); err != nil {
+		return fmt.Errorf("kill process %d: %w", t.pid, err)
 	}
 	return nil
+}
+
+func (t *windowsKillTarget) close() {
+	_ = t.api.closeHandle(t.handle)
 }

--- a/cmd/graymatter/internal/harness/kill_windows_test.go
+++ b/cmd/graymatter/internal/harness/kill_windows_test.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+package harness
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsKillTargetTerminatesVerifiedHandleWithoutReopeningPID(t *testing.T) {
+	const wantStart = 123456789
+	pid := startSleeper(t)
+	var (
+		openCalls        int
+		closeCalls       int
+		openedHandle     windows.Handle
+		handleClosed     bool
+		verifiedHandle   windows.Handle
+		terminatedHandle windows.Handle
+	)
+	t.Cleanup(func() {
+		if openedHandle != 0 && !handleClosed {
+			_ = windows.CloseHandle(openedHandle)
+		}
+	})
+	api := windowsProcessAPI{
+		openProcess: func(access uint32, inherit bool, gotPID uint32) (windows.Handle, error) {
+			openCalls++
+			if access != windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE {
+				t.Errorf("OpenProcess access = %#x, want query|terminate", access)
+			}
+			if inherit {
+				t.Error("OpenProcess requested an inheritable handle")
+			}
+			if gotPID != uint32(pid) {
+				t.Errorf("OpenProcess PID = %d, want %d", gotPID, pid)
+			}
+			h, err := windows.OpenProcess(access, inherit, gotPID)
+			openedHandle = h
+			return h, err
+		},
+		getProcessTimes: func(h windows.Handle, created, _, _, _ *windows.Filetime) error {
+			verifiedHandle = h
+			created.LowDateTime = wantStart
+			return nil
+		},
+		terminateProcess: func(h windows.Handle, exitCode uint32) error {
+			terminatedHandle = h
+			if exitCode != 1 {
+				t.Errorf("TerminateProcess exit code = %d, want 1", exitCode)
+			}
+			return nil
+		},
+		closeHandle: func(h windows.Handle) error {
+			closeCalls++
+			if h != openedHandle {
+				t.Errorf("CloseHandle handle = %#x, want %#x", h, openedHandle)
+				return nil
+			}
+			err := windows.CloseHandle(h)
+			handleClosed = err == nil
+			return err
+		},
+	}
+
+	target, err := openWindowsKillTarget(pid, api)
+	if err != nil {
+		t.Fatalf("open kill target: %v", err)
+	}
+	started, err := target.startTime()
+	if err != nil {
+		t.Fatalf("verify process start time: %v", err)
+	}
+	if started != wantStart {
+		t.Fatalf("start time = %d, want %d", started, wantStart)
+	}
+	if err := target.terminate(); err != nil {
+		t.Fatalf("terminate target: %v", err)
+	}
+	target.close()
+
+	if openCalls != 1 {
+		t.Fatalf("OpenProcess calls = %d, want exactly 1", openCalls)
+	}
+	if verifiedHandle != openedHandle {
+		t.Errorf("GetProcessTimes handle = %#x, want %#x", verifiedHandle, openedHandle)
+	}
+	if terminatedHandle != verifiedHandle {
+		t.Errorf("TerminateProcess handle = %#x, verified handle = %#x", terminatedHandle, verifiedHandle)
+	}
+	if closeCalls != 1 {
+		t.Errorf("CloseHandle calls = %d, want 1", closeCalls)
+	}
+	if !handleClosed {
+		t.Error("verified process handle was not closed")
+	}
+}

--- a/cmd/graymatter/internal/harness/process_start_windows.go
+++ b/cmd/graymatter/internal/harness/process_start_windows.go
@@ -10,20 +10,23 @@ import (
 )
 
 func processStartTime(pid int) (int64, error) {
-	if pid <= 0 {
-		return 0, fmt.Errorf("invalid PID %d", pid)
+	processID, err := windowsProcessID(pid)
+	if err != nil {
+		return 0, err
 	}
-	if uint64(pid) > math.MaxUint32 {
-		return 0, fmt.Errorf("PID %d exceeds the Windows process ID range", pid)
-	}
-	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, processID)
 	if err != nil {
 		return 0, fmt.Errorf("open process %d: %w", pid, err)
 	}
 	defer func() { _ = windows.CloseHandle(h) }()
+	return processStartTimeFromHandle(pid, h, windows.GetProcessTimes)
+}
 
+type getProcessTimesFunc func(windows.Handle, *windows.Filetime, *windows.Filetime, *windows.Filetime, *windows.Filetime) error
+
+func processStartTimeFromHandle(pid int, h windows.Handle, getTimes getProcessTimesFunc) (int64, error) {
 	var created, exited, kernel, user windows.Filetime
-	if err := windows.GetProcessTimes(h, &created, &exited, &kernel, &user); err != nil {
+	if err := getTimes(h, &created, &exited, &kernel, &user); err != nil {
 		return 0, fmt.Errorf("get process %d times: %w", pid, err)
 	}
 	raw := uint64(created.HighDateTime)<<32 | uint64(created.LowDateTime)
@@ -35,4 +38,14 @@ func processStartTime(pid int) (int64, error) {
 		return 0, fmt.Errorf("process %d has invalid start time %d", pid, started)
 	}
 	return started, nil
+}
+
+func windowsProcessID(pid int) (uint32, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid PID %d", pid)
+	}
+	if uint64(pid) > math.MaxUint32 {
+		return 0, fmt.Errorf("PID %d exceeds the Windows process ID range", pid)
+	}
+	return uint32(pid), nil
 }

--- a/cmd/graymatter/internal/harness/recovery.go
+++ b/cmd/graymatter/internal/harness/recovery.go
@@ -71,11 +71,13 @@ func KillSessionDB(db *bolt.DB, sessionID string) error {
 	if hs.PID == 0 {
 		return fmt.Errorf("session %q has no PID — it was not started in background mode", sessionID)
 	}
-	if err := confirmOurProcess(db, sessionID, hs.PID, hs.PIDStart); err != nil {
+	target, err := confirmOurProcess(db, sessionID, hs.PID, hs.PIDStart)
+	if err != nil {
 		return err
 	}
+	defer target.close()
 
-	if err := killPID(hs.PID); err != nil {
+	if err := target.terminate(); err != nil {
 		return fmt.Errorf("kill session %q (pid %d): %w", sessionID, hs.PID, err)
 	}
 
@@ -84,6 +86,12 @@ func KillSessionDB(db *bolt.DB, sessionID string) error {
 	hs.Status = "killed"
 	hs.FinishedAt = &now
 	return saveHarnessSession(db, *hs)
+}
+
+type processKillTarget interface {
+	startTime() (int64, error)
+	terminate() error
+	close()
 }
 
 // confirmOurProcess checks that pid is one graymatter actually spawned for
@@ -95,22 +103,27 @@ func KillSessionDB(db *bolt.DB, sessionID string) error {
 // "running", call SessionKill, and the daemon terminates that process on your
 // behalf. The PID file narrows the primitive to processes this tool started.
 // The start identity also rejects stale records after the OS recycles a PID.
+// On Windows, the start check and termination share one process HANDLE, so PID
+// reuse cannot change the target between them. Unix keeps the established
+// check-then-signal-by-PID behavior; that sequence is not atomic, and its much
+// smaller reuse window remains accepted until a field need justifies platform-
+// specific handle support there.
 //
 // It is not a defence against a process already running as the same user: that
 // process can write both the record and the file. It is a defence against the
 // RPC surface being a kill primitive on its own, which is a different thing.
-func confirmOurProcess(db *bolt.DB, sessionID string, pid int, recordedStart int64) error {
+func confirmOurProcess(db *bolt.DB, sessionID string, pid int, recordedStart int64) (processKillTarget, error) {
 	if pid == os.Getpid() {
-		return fmt.Errorf("session %q names this process (pid %d); refusing to kill it", sessionID, pid)
+		return nil, fmt.Errorf("session %q names this process (pid %d); refusing to kill it", sessionID, pid)
 	}
 	if recordedStart == 0 {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"session %q predates process-identity hardening and has no process start time; "+
 				"refusing to kill pid %d: stop it manually only after verifying its identity",
 			sessionID, pid)
 	}
 	if recordedStart < 0 {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"session %q could not record a process start time; refusing to kill pid %d: "+
 				"stop it manually only after verifying its identity",
 			sessionID, pid)
@@ -122,28 +135,36 @@ func confirmOurProcess(db *bolt.DB, sessionID string, pid int, recordedStart int
 
 	onDisk, err := ReadPIDFile(pidPath)
 	if err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"session %q: no PID file at %s, so pid %d is recorded only in the database; "+
 				"refusing to kill a process graymatter cannot confirm it started: %w",
 			sessionID, pidPath, pid, err)
 	}
 	if onDisk != pid {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"session %q: the database says pid %d but %s says %d; refusing to kill either",
 			sessionID, pid, pidPath, onDisk)
 	}
-	liveStart, err := processStartTime(pid)
+	target, err := openKillTarget(pid)
 	if err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
+			"session %q: cannot open pid %d for verified termination; refusing to kill it: %w",
+			sessionID, pid, err)
+	}
+	liveStart, err := target.startTime()
+	if err != nil {
+		target.close()
+		return nil, fmt.Errorf(
 			"session %q: cannot verify the start time of pid %d; refusing to kill it: %w",
 			sessionID, pid, err)
 	}
 	if liveStart != recordedStart {
-		return fmt.Errorf(
+		target.close()
+		return nil, fmt.Errorf(
 			"session %q: pid %d was recycled (recorded start time %d, live start time %d); refusing to kill it",
 			sessionID, pid, recordedStart, liveStart)
 	}
-	return nil
+	return target, nil
 }
 
 // SaveSessionDB persists a HarnessSession record against an already-open db


### PR DESCRIPTION
#90 closed the persistent case: a stale `running` record whose PID the OS had
reassigned hours later can no longer kill anything, because the recorded start
identity does not match.

What remained was the instant: `confirmOurProcess` looked up the identity of
whatever held the PID, returned, and `killPID` then acted on **the number
again**. If the verified process exited between those two steps and the system
reassigned its PID, the signal reached the new occupant. Check-then-use, not
atomic.

## Windows closes it

A Windows `HANDLE` is bound to the process object, not to the number. The
target is now opened once, with `PROCESS_QUERY_LIMITED_INFORMATION |
PROCESS_TERMINATE`; the creation time that proves identity is read **from that
handle**, and `TerminateProcess` is called **on the same handle**. A recycled
PID cannot change what gets terminated, because the number is never consulted
again. The handle is closed exactly once, on every path.

`TerminateProcess` is given exit code 1, matching what `os.Process.Kill` has
always produced on Windows.

## Unix is unchanged, deliberately

Closing this on Linux would need `pidfd_open` with a kernel minimum to decide
about, and macOS has no stable equivalent — there the honest ceiling is
narrowing the window, not closing it. Rather than ship asymmetric platform code
for a window that needs a process to die and its PID to be reassigned inside a
single call, Unix keeps exactly the #90 behaviour, and the guard's comment now
records that this sequence is not atomic and why that is accepted.

The comment already covered two threat models — the RPC surface as a kill
primitive, and PID reuse across time. It now covers the third.

A partial fix, documented as partial, is the point here. Nothing was relaxed on
the platforms not covered.

## Verification

All seven original kill guards pass unchanged, plus a new test asserting the
Windows target terminates the verified handle without reopening by PID — the
API is injected so this is exercised without real processes. `-race` green on
`internal/harness`. The background E2E from #90 passes with none of its
assertions modified. Cross-compilation green for darwin/amd64, darwin/arm64 and
linux/amd64.

No schema change, no new dependency, and #90's guard is threaded through the new
interface rather than altered.
