### PR TITLE
fix(hooks): persist the hook as command + args instead of a shell string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
+
 - **`run --resume <session-id>` now resumes the checkpoint belonging to that exact session.** The flag previously treated every non-empty value as `latest` and silently loaded the newest checkpoint for the agent, even when the requested ID was historical or nonexistent. Concrete IDs are now resolved through the session registry, unknown IDs fail with the requested session named, and `latest` retains its existing newest-checkpoint behavior.
 
 - **Installed Claude Code hooks now invoke the runnable `hooks run` path, and global hooks no longer create stores in unrelated working directories** ([#83](https://github.com/angelnicolasc/graymatter/issues/83)). Global commands persist a silent `--no-create` guard while project installs retain first-use creation; `doctor` identifies older global installs, and reinstalling replaces legacy malformed commands.

--- a/cmd/graymatter/cmd_hooks.go
+++ b/cmd/graymatter/cmd_hooks.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// Markers distinguish current commands from legacy malformed entries.
-	hooksCommandMarker       = "--graymatter-managed-hook"
-	hooksRunCommandMarker    = " hooks run "
-	hooksNoCreateArg         = "--no-create"
+	hooksCommandMarker    = "--graymatter-managed-hook"
+	hooksRunCommandMarker = " hooks run "
+	hooksNoCreateArg      = "--no-create"
 
 	// hooksEventSessionStart is one of the four events this package manages.
 	// Claude Code fires SessionStart with source startup|resume|clear|compact;
@@ -83,7 +83,7 @@ func hooksInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install [--scope project|global] [--all]",
 		Short: "Write GrayMatter's hooks into Claude Code settings.json",
-		Long: `Upserts GrayMatter's hook groups into Claude Code's settings.json.
+		Long: `Upserts GrayMatter's hook groups using exec form (Claude Code 2.1.139 or later).
 
 Merge, never overwrite: hooks that are not GrayMatter's (formatters,
 guardrails, anything else) are preserved. If GrayMatter's own entries
@@ -169,9 +169,8 @@ func hooksUninstallCmd() *cobra.Command {
 	return cmd
 }
 
-// resolveOwnBinary returns this executable as an absolute slash-normalised
-// path — the form the hook commands record, so the hook resolves no matter
-// which cwd Claude Code fires it from.
+// resolveOwnBinary returns this executable as an absolute native path — the
+// exact value exec-form hooks record, so it resolves from any working directory.
 func resolveOwnBinary() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
@@ -389,16 +388,10 @@ func rewriteHookEvent(existing any, want []any, install bool, expectedExe ...str
 		nextArr = append(nextArr, foreign...)
 		nextArr = append(nextArr, want...)
 		next = nextArr
-		if before, err1 := json.Marshal(oursBefore); err1 == nil {
-			if after, err2 := json.Marshal(want); err2 == nil {
-				drift = string(before) != string(after)
-			} else {
-				drift = true
-			}
-		} else {
-			drift = true
+		if len(oursBefore) > 0 {
+			drift = !hookGroupsEquivalent(oursBefore, want)
 		}
-		mutated = drift || len(oursBefore) != len(want)
+		mutated = !hookArraysEqual(oursBefore, want)
 		if !mutated {
 			// Same length and not drifted: could still differ in content order
 			// relative to foreign groups; a deep compare settles it.
@@ -426,6 +419,54 @@ func hookArraysEqual(a, b []any) bool {
 	return string(ab) == string(bb)
 }
 
+// hookGroupsEquivalent treats the two previous shell-command formats as the
+// canonical exec form for drift purposes. Reinstall still rewrites them, but a
+// format migration alone is not a hand edit. Every other field is compared.
+func hookGroupsEquivalent(existing, want []any) bool {
+	data, err := json.Marshal(existing)
+	if err != nil {
+		return false
+	}
+	var normalized []any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return false
+	}
+	for i := range normalized {
+		if i >= len(want) {
+			break
+		}
+		normalizeLegacyHookGroup(normalized[i], want[i])
+	}
+	return hookArraysEqual(normalized, want)
+}
+
+func normalizeLegacyHookGroup(existing, want any) {
+	eg, ok := existing.(map[string]any)
+	if !ok {
+		return
+	}
+	wg, ok := want.(map[string]any)
+	if !ok {
+		return
+	}
+	existingHooks, _ := eg["hooks"].([]any)
+	wantedHooks, _ := wg["hooks"].([]any)
+	for i := range existingHooks {
+		if i >= len(wantedHooks) {
+			break
+		}
+		oldHook, ok := existingHooks[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		newHook, ok := wantedHooks[i].(map[string]any)
+		if ok && legacyHookMatches(oldHook, newHook) {
+			oldHook["command"] = newHook["command"]
+			oldHook["args"] = newHook["args"]
+		}
+	}
+}
+
 // hookGroupIsOurs reports whether a matcher group belongs to GrayMatter.
 func hookGroupIsOurs(group any, expectedExe ...string) bool {
 	ours, _ := hookGroupGuardStatus(group, expectedExe...)
@@ -444,9 +485,9 @@ func hookGroupGuardStatus(group any, expectedExe ...string) (ours, guarded bool)
 		if !ok {
 			continue
 		}
-		if c, _ := hook["command"].(string); hookCommandIsOurs(c, expectedExe...) {
+		if hookEntryIsOurs(hook, expectedExe...) {
 			ours = true
-			guarded = guarded && hookCommandHasArg(c, hooksNoCreateArg)
+			guarded = guarded && hookEntryHasArg(hook, hooksNoCreateArg)
 		}
 	}
 	return ours, guarded
@@ -458,15 +499,19 @@ func hookEventNames() []string {
 }
 
 // hookGroupsFor builds the canonical matcher groups for one event and the
-// given executable. The recorded command carries the CLI event name (the
-// snake_case arg `hooks run` takes), not the settings event key.
+// given executable. The args carry the CLI event name (the snake_case value
+// `hooks run` takes), not the settings event key.
 func hookGroupsFor(exe, event string, scopes ...hookScope) []any {
 	scope := scopeProject
 	if len(scopes) > 0 {
 		scope = scopes[0]
 	}
 	group := func(matcher string, timeout int) map[string]any {
-		hook := map[string]any{"type": "command", "command": hookCommand(exe, hookRunArg(event), scope)}
+		args := []string{"hooks", "run", hookRunArg(event), hooksCommandMarker}
+		if scope == scopeGlobal {
+			args = append(args, hooksNoCreateArg)
+		}
+		hook := map[string]any{"type": "command", "command": exe, "args": args}
 		if timeout > 0 {
 			hook["timeout"] = timeout
 		}
@@ -509,9 +554,8 @@ func hookRunArg(event string) string {
 	return event
 }
 
-// hookCommand renders the command line Claude Code will execute. The binary
-// path is quoted when needed: hooks run through a shell, and installs under
-// paths with spaces are routine on every platform.
+// hookCommand renders the previous shell form. It remains solely so legacy
+// installations can be exercised against the compatibility parser.
 func hookCommand(exe, event string, scopes ...hookScope) string {
 	scope := scopeProject
 	if len(scopes) > 0 {
@@ -642,10 +686,10 @@ func runHooksDoctorChecks(path, exeAbs string, scope hookScope) []hookCheck {
 				if !ok {
 					continue
 				}
-				if c, _ := hook["command"].(string); hookCommandIsOurs(c, exeAbs) {
+				if hookEntryIsOurs(hook, exeAbs) {
 					found = true
 					if exePath == "" {
-						exePath = hookBinaryPath(c)
+						exePath = hookEntryBinaryPath(hook)
 					}
 				}
 			}
@@ -773,6 +817,127 @@ func globalHookGuardStatus(root map[string]any) (installed, guarded bool) {
 	return installed, guarded
 }
 
+func hookEntryArgs(hook map[string]any) ([]string, bool) {
+	raw, present := hook["args"]
+	if !present {
+		return nil, false
+	}
+	switch values := raw.(type) {
+	case []string:
+		return append([]string(nil), values...), true
+	case []any:
+		args := make([]string, len(values))
+		for i, value := range values {
+			arg, ok := value.(string)
+			if !ok {
+				return nil, false
+			}
+			args[i] = arg
+		}
+		return args, true
+	default:
+		return nil, false
+	}
+}
+
+func hookEntryHasArg(hook map[string]any, want string) bool {
+	if _, structured := hook["args"]; structured {
+		args, ok := hookEntryArgs(hook)
+		if !ok {
+			return false
+		}
+		for _, arg := range args {
+			if arg == want {
+				return true
+			}
+		}
+		return false
+	}
+	command, _ := hook["command"].(string)
+	return hookCommandHasArg(command, want)
+}
+
+func hookEntryIsOurs(hook map[string]any, expectedExe ...string) bool {
+	command, ok := hook["command"].(string)
+	if !ok {
+		return false
+	}
+	if _, structured := hook["args"]; !structured {
+		return hookCommandIsOurs(command, expectedExe...)
+	}
+	args, ok := hookEntryArgs(hook)
+	if !ok {
+		return false
+	}
+	if len(args) < 3 || args[0] != "hooks" || args[1] != "run" {
+		return false
+	}
+	if stringSliceContains(args, hooksCommandMarker) {
+		return true
+	}
+	if len(expectedExe) > 0 && filepath.Clean(command) == filepath.Clean(expectedExe[0]) {
+		return true
+	}
+	return strings.TrimSuffix(strings.ToLower(filepath.Base(command)), ".exe") == "graymatter"
+}
+
+func hookEntryBinaryPath(hook map[string]any) string {
+	command, _ := hook["command"].(string)
+	if _, structured := hook["args"]; structured {
+		return command
+	}
+	return hookBinaryPath(command)
+}
+
+func legacyHookMatches(existing, want map[string]any) bool {
+	if _, structured := existing["args"]; structured {
+		return false
+	}
+	command, ok := existing["command"].(string)
+	if !ok {
+		return false
+	}
+	wantCommand, ok := want["command"].(string)
+	if !ok || filepath.Clean(hookBinaryPath(command)) != filepath.Clean(wantCommand) {
+		return false
+	}
+	wantArgs, ok := hookEntryArgs(want)
+	if !ok || len(wantArgs) < 4 {
+		return false
+	}
+	idx := strings.LastIndex(command, hooksRunCommandMarker)
+	if idx < 0 {
+		return false
+	}
+	tail := strings.Fields(command[idx+len(hooksRunCommandMarker):])
+	prefix := strings.TrimSpace(command[:idx])
+	if strings.HasSuffix(prefix, " graymatter") {
+		return len(tail) == 1 && tail[0] == wantArgs[2]
+	}
+	return stringSlicesEqual(tail, wantArgs[2:])
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func hookCommandHasArg(command, want string) bool {
 	idx := strings.LastIndex(command, hooksRunCommandMarker)
 	if idx < 0 {
@@ -804,7 +969,11 @@ func hookBinaryPath(command string) string {
 	}
 	p := strings.TrimSpace(command[:idx])
 	p = strings.TrimSpace(strings.TrimSuffix(p, " graymatter"))
-	p = strings.Trim(p, `"'`)
+	if unquoted, err := strconv.Unquote(p); err == nil {
+		p = unquoted
+	} else {
+		p = strings.Trim(p, `"'`)
+	}
 	return filepath.FromSlash(p)
 }
 

--- a/cmd/graymatter/cmd_hooks_hardening_test.go
+++ b/cmd/graymatter/cmd_hooks_hardening_test.go
@@ -269,11 +269,22 @@ func FuzzRewriteHookEvent(f *testing.F) {
 		if err != nil {
 			t.Fatalf("merged event array is not serialisable: %v", err)
 		}
-		if !strings.Contains(string(blob), "graymatter hooks run user-prompt") {
+		if !strings.Contains(string(blob), `"args":["hooks","run","user-prompt","--graymatter-managed-hook"]`) {
 			t.Fatalf("install lost our group: %s", blob)
 		}
 		_ = drift
 	})
+}
+
+func TestHooksOwnership_RejectsMalformedStructuredArgs(t *testing.T) {
+	for _, tc := range []struct{ command string; args any }{{"/opt/gm/graymatter", nil}, {"/opt/gm/graymatter", "hooks run user-prompt"}, {"/opt/gm/graymatter", []any{"hooks", 7, "user-prompt"}}, {"echo", []any{hooksCommandMarker}}} {
+		group := map[string]any{"hooks": []any{map[string]any{
+			"type": "command", "command": tc.command, "args": tc.args,
+		}}}
+		if hookGroupIsOurs(group, "/opt/gm/graymatter") {
+			t.Errorf("malformed entry %+v was claimed as a managed hook", tc)
+		}
+	}
 }
 
 // A foreign command that only mentions the legacy marker is never ours.

--- a/cmd/graymatter/cmd_hooks_test.go
+++ b/cmd/graymatter/cmd_hooks_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
@@ -62,6 +64,8 @@ func hookGroups(t *testing.T, root map[string]any, event string) []map[string]an
 
 func groupCommands(t *testing.T, group map[string]any) []string {
 	t.Helper()
+	// Compatibility view for older assertions; persisted exec-form tests read
+	// command and args separately and never execute this reconstruction.
 	list, _ := group["hooks"].([]any)
 	out := make([]string, 0, len(list))
 	for _, h := range list {
@@ -73,6 +77,9 @@ func groupCommands(t *testing.T, group map[string]any) []string {
 			t.Errorf("hook type = %v, want command", hook["type"])
 		}
 		c, _ := hook["command"].(string)
+		if args, ok := hookEntryArgs(hook); ok {
+			c += " " + strings.Join(args, " ")
+		}
 		out = append(out, c)
 	}
 	return out
@@ -81,7 +88,7 @@ func groupCommands(t *testing.T, group map[string]any) []string {
 // TestHooksInstall_WritesCanonicalContract pins the emitted settings shape:
 // four events, SessionStart split across a startup|resume|fork group and a
 // compact group, the user-prompt hook carrying a 10s timeout, and every
-// command an absolute path carrying the documented invocation.
+// command an exact executable path and args carrying the invocation tokens.
 func TestHooksInstall_WritesCanonicalContract(t *testing.T) {
 	withHooksEnv(t)
 	dir := t.TempDir()
@@ -121,18 +128,25 @@ func TestHooksInstall_WritesCanonicalContract(t *testing.T) {
 
 	for _, event := range hookEventNames() {
 		for _, g := range hookGroups(t, root, event) {
-			for _, c := range groupCommands(t, g) {
-				if !strings.Contains(c, hooksCommandMarker) {
-					t.Errorf("%s command %q lacks the marker", event, c)
+			for _, raw := range g["hooks"].([]any) {
+				hook := raw.(map[string]any)
+				if command, _ := hook["command"].(string); command != exe {
+					t.Errorf("%s command = %q, want exact path %q", event, command, exe)
 				}
-				if !strings.Contains(c, hooksRunCommandMarker+hookRunArg(event)+" "+hooksCommandMarker) {
-					t.Errorf("command %q must invoke the run event %q", c, hookRunArg(event))
-				}
-				if !filepath.IsAbs(hookBinaryPath(c)) {
-					t.Errorf("command %q must record an absolute binary path", c)
+				args, ok := hookEntryArgs(hook)
+				want := []string{"hooks", "run", hookRunArg(event), hooksCommandMarker}
+				if !ok || !stringSlicesEqual(args, want) {
+					t.Errorf("%s args = %q, want %q", event, args, want)
 				}
 			}
 		}
+	}
+	global := hookGroupsFor(exe, hooksEventPreCompact, scopeGlobal)[0].(map[string]any)
+	hook := global["hooks"].([]any)[0].(map[string]any)
+	args, ok := hookEntryArgs(hook)
+	want := []string{"hooks", "run", "pre-compact", hooksCommandMarker, hooksNoCreateArg}
+	if hook["command"] != exe || !ok || !stringSlicesEqual(args, want) {
+		t.Errorf("global exec form = command %v args %q, want %q + %q", hook["command"], args, exe, want)
 	}
 }
 
@@ -364,10 +378,10 @@ func TestHooksSettings_NonObjectHooksLeftUntouched(t *testing.T) {
 	}
 }
 
-// TestHookCommand_Quoting: binaries under paths with spaces must record a
-// quoted command, and hookBinaryPath must round-trip it.
-func TestHookCommand_Quoting(t *testing.T) {
-	withSpaces := `/c/Program Files/hooks run/graymatter`
+// TestHookCommand_LegacyParsing keeps the two shell-form readers available for
+// reinstall and uninstall of settings written by previous releases.
+func TestHookCommand_LegacyParsing(t *testing.T) {
+	withSpaces := `/c/Program Files/hook's run/graymatter`
 	cmd := hookCommand(withSpaces, "user-prompt")
 	if !strings.HasPrefix(cmd, `"`) {
 		t.Errorf("command %q must quote a path containing spaces", cmd)
@@ -380,6 +394,126 @@ func TestHookCommand_Quoting(t *testing.T) {
 	plain := hookCommand("/usr/local/bin/graymatter", "session-start")
 	if strings.HasPrefix(plain, `"`) {
 		t.Errorf("command %q need not be quoted", plain)
+	}
+}
+
+func TestHooksInstall_ExecFormRunsLiteralBinaryPath(t *testing.T) {
+	for _, name := range []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "VOYAGE_API_KEY"} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("GRAYMATTER_OLLAMA_URL", "disabled://hook-command-test")
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "hook path $ (literal)")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(binDir, "graymatter.exe")
+	build := exec.Command("go", "build", "-o", bin, "github.com/angelnicolasc/graymatter/cmd/graymatter")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build hook binary: %v\n%s", err, out)
+	}
+
+	project := filepath.Join(root, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	storeDir := filepath.Join(project, ".graymatter")
+	t.Cleanup(func() {
+		stop := exec.Command(bin, "--dir", storeDir, "daemon", "stop")
+		stop.Dir = project
+		_ = stop.Run()
+		time.Sleep(300 * time.Millisecond)
+	})
+
+	settings := filepath.Join(project, ".claude", "settings.json")
+	install := exec.Command(bin, "hooks", "install")
+	install.Dir = project
+	if out, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("install hooks from literal path: %v\n%s", err, out)
+	}
+	groups := hookGroups(t, readSettings(t, settings), hooksEventUserPrompt)
+	hook := groups[0]["hooks"].([]any)[0].(map[string]any)
+	command, _ := hook["command"].(string)
+	args, ok := hookEntryArgs(hook)
+	if command != bin || !ok {
+		t.Fatalf("persisted exec form = command %q args %q", command, args)
+	}
+	payload, _ := json.Marshal(map[string]string{
+		"cwd": project, "prompt": "remember: exec form preserved the literal path",
+	})
+	run := exec.Command(command, args...)
+	run.Dir, run.Stdin = project, strings.NewReader(string(payload))
+	out, err := run.CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "Saved to memory") {
+		t.Fatalf("execute persisted command+args: %v\n%s", err, out)
+	}
+}
+
+func TestHooksInstall_MigratesPreviousCommandFormsWithoutDrift(t *testing.T) {
+	exe := filepath.Join(t.TempDir(), "graymatter.exe")
+	cases := []struct {
+		name    string
+		scope   hookScope
+		command string
+	}{
+		{"string project", scopeProject, hookCommand(exe, "user-prompt")},
+		{"string global", scopeGlobal, hookCommand(exe, "user-prompt", scopeGlobal)},
+		{"pre-marker project", scopeProject, filepath.ToSlash(exe) + " graymatter hooks run user-prompt"},
+		{"pre-marker global", scopeGlobal, filepath.ToSlash(exe) + " graymatter hooks run user-prompt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			legacy := map[string]any{"hooks": map[string]any{
+				hooksEventUserPrompt: []any{map[string]any{"hooks": []any{
+					map[string]any{"type": "command", "command": tc.command, "timeout": userPromptHookTimeout},
+				}}},
+			}}
+			write := func(value map[string]any) {
+				t.Helper()
+				data, _ := json.MarshalIndent(value, "", "  ")
+				if err := os.WriteFile(path, data, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write(legacy)
+			if drift, err := hookSettingsDrift(path, exe, tc.scope); err != nil || drift {
+				t.Fatalf("previous generation reported drift=%v err=%v", drift, err)
+			}
+			res, err := upsertHookSettings(path, exe, true, tc.scope)
+			if err != nil || !res.Changed || res.Drifted {
+				t.Fatalf("migration result=%+v err=%v", res, err)
+			}
+			group := hookGroups(t, readSettings(t, path), hooksEventUserPrompt)[0]
+			hook := group["hooks"].([]any)[0].(map[string]any)
+			if hook["command"] != exe {
+				t.Fatalf("migrated command = %v, want %q", hook["command"], exe)
+			}
+			wantArgs := []string{"hooks", "run", "user-prompt", hooksCommandMarker}
+			if tc.scope == scopeGlobal {
+				wantArgs = append(wantArgs, hooksNoCreateArg)
+			}
+			if args, ok := hookEntryArgs(hook); !ok || !stringSlicesEqual(args, wantArgs) {
+				t.Fatalf("migrated args = %q", args)
+			}
+
+			write(legacy)
+			res, err = upsertHookSettings(path, exe, false, tc.scope)
+			if err != nil || !res.Changed {
+				t.Fatalf("uninstall previous generation result=%+v err=%v", res, err)
+			}
+			if _, exists := readSettings(t, path)["hooks"]; exists {
+				t.Fatal("uninstall left the previous-generation hook installed")
+			}
+
+			edited := legacy["hooks"].(map[string]any)[hooksEventUserPrompt].([]any)[0].(map[string]any)
+			edited["hooks"].([]any)[0].(map[string]any)["timeout"] = 60
+			write(legacy)
+			if drift, err := hookSettingsDrift(path, exe, tc.scope); err != nil || !drift {
+				t.Fatalf("real edit reported drift=%v err=%v", drift, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#92 removed a spurious `graymatter` argument that made the persisted hook
unparseable by cobra. What it did not change is that the command was still **one
string handed to a shell**, and that string was built like this:

```go
if strings.ContainsAny(exe, " '\"") {
    return strconv.Quote(exe) + trailer
}
```

Two defects in those lines.

**The quoting breaks PowerShell.** A quoted path at the start of a command is a
*string expression* there — without the `&` operator it invokes nothing. A normal
Windows install lives in a path with spaces, so the hook failed whenever Claude
Code fell back to PowerShell. Reproduced on 5.1 and 7: `UnexpectedToken`.

**`strconv.Quote` is not shell escaping.** It emits a *Go* literal. Under `sh` or
Git Bash, `$` and backticks still expand. And the guard only looked for spaces
and quotes, so a path containing `;`, `&`, `$`, backticks or parentheses was
serialised with no quoting at all.

Because hooks degrade silently by contract, none of this surfaced as an error.
It surfaced as no memory.

## The fix is the client's own feature

Claude Code 2.1.139 added exactly this:

> Added hook `args: string[]` field (exec form) that spawns the command directly
> without a shell, so path placeholders never need quoting

Hooks are now persisted as `{"type": "command", "command": <exe>, "args": [...]}`.
No shell, so there is no quoting to get right — per platform or per
metacharacter. The exec form requires 2.1.139 or later, released in May; the
`install` help states the requirement.

## Migration is the bulk of the change

Ownership and drift detection read command text: `hookCommandIsOurs`,
`hookCommandHasArg`, `hookBinaryPath`. They now understand the structured entry
through `hookEntryIsOurs` / `hookEntryArgs` / `hookEntryHasArg`, **without
losing** either previous shape:

- the pre-#92 malformed form, `<exe> graymatter hooks run <event>`
- the #92 string form, `<exe> hooks run <event> --graymatter-managed-hook`

Both are still recognised as ours, migrated by a reinstall, removed by an
uninstall, and — importantly — a previous-generation install is not reported as
a hand edit. `hookCommand` is kept solely to render the legacy shape for that
comparison.

## Verification

End-to-end through the command actually persisted into `settings.json`, from
paths containing spaces and metacharacters, plus coverage for legacy parsing,
malformed structured args, scope drift and the legacy warning. The full hook
suite, the daemon lifecycle E2E, `vet` and both module builds are green.
