### PR TITLE
fix(hooks): make --all cover both scopes and keep doctor read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
+
 - **`run --resume <session-id>` now resumes the checkpoint belonging to that exact session.** The flag previously treated every non-empty value as `latest` and silently loaded the newest checkpoint for the agent, even when the requested ID was historical or nonexistent. Concrete IDs are now resolved through the session registry, unknown IDs fail with the requested session named, and `latest` retains its existing newest-checkpoint behavior.
 
 - **Installed Claude Code hooks now invoke the runnable `hooks run` path, and global hooks no longer create stores in unrelated working directories** ([#83](https://github.com/angelnicolasc/graymatter/issues/83)). Global commands persist a silent `--no-create` guard while project installs retain first-use creation; `doctor` identifies older global installs, and reinstalling replaces legacy malformed commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
 
+- **Hook scope management and diagnostics now match their public contract.** `hooks uninstall --all` and `hooks doctor --all` cover project and global settings, while the unsafe `hooks install --all` form is rejected to prevent duplicate hook execution. `hooks doctor` reports an uninitialised store without creating it, including when settings are missing or malformed.
+
 - **`run --resume <session-id>` now resumes the checkpoint belonging to that exact session.** The flag previously treated every non-empty value as `latest` and silently loaded the newest checkpoint for the agent, even when the requested ID was historical or nonexistent. Concrete IDs are now resolved through the session registry, unknown IDs fail with the requested session named, and `latest` retains its existing newest-checkpoint behavior.
 
 - **Installed Claude Code hooks now invoke the runnable `hooks run` path, and global hooks no longer create stores in unrelated working directories** ([#83](https://github.com/angelnicolasc/graymatter/issues/83)). Global commands persist a silent `--no-create` guard while project installs retain first-use creation; `doctor` identifies older global installs, and reinstalling replaces legacy malformed commands.

--- a/cmd/graymatter/cmd_hooks.go
+++ b/cmd/graymatter/cmd_hooks.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// Markers distinguish current commands from legacy malformed entries.
-	hooksCommandMarker       = "--graymatter-managed-hook"
-	hooksRunCommandMarker    = " hooks run "
-	hooksNoCreateArg         = "--no-create"
+	hooksCommandMarker    = "--graymatter-managed-hook"
+	hooksRunCommandMarker = " hooks run "
+	hooksNoCreateArg      = "--no-create"
 
 	// hooksEventSessionStart is one of the four events this package manages.
 	// Claude Code fires SessionStart with source startup|resume|clear|compact;
@@ -83,7 +83,7 @@ func hooksInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install [--scope project|global] [--all]",
 		Short: "Write GrayMatter's hooks into Claude Code settings.json",
-		Long: `Upserts GrayMatter's hook groups into Claude Code's settings.json.
+		Long: `Upserts GrayMatter's hook groups using exec form (Claude Code 2.1.139 or later).
 
 Merge, never overwrite: hooks that are not GrayMatter's (formatters,
 guardrails, anything else) are preserved. If GrayMatter's own entries
@@ -169,9 +169,8 @@ func hooksUninstallCmd() *cobra.Command {
 	return cmd
 }
 
-// resolveOwnBinary returns this executable as an absolute slash-normalised
-// path — the form the hook commands record, so the hook resolves no matter
-// which cwd Claude Code fires it from.
+// resolveOwnBinary returns this executable as an absolute native path — the
+// exact value exec-form hooks record, so it resolves from any working directory.
 func resolveOwnBinary() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
@@ -389,16 +388,10 @@ func rewriteHookEvent(existing any, want []any, install bool, expectedExe ...str
 		nextArr = append(nextArr, foreign...)
 		nextArr = append(nextArr, want...)
 		next = nextArr
-		if before, err1 := json.Marshal(oursBefore); err1 == nil {
-			if after, err2 := json.Marshal(want); err2 == nil {
-				drift = string(before) != string(after)
-			} else {
-				drift = true
-			}
-		} else {
-			drift = true
+		if len(oursBefore) > 0 {
+			drift = !hookGroupsEquivalent(oursBefore, want)
 		}
-		mutated = drift || len(oursBefore) != len(want)
+		mutated = !hookArraysEqual(oursBefore, want)
 		if !mutated {
 			// Same length and not drifted: could still differ in content order
 			// relative to foreign groups; a deep compare settles it.
@@ -426,6 +419,54 @@ func hookArraysEqual(a, b []any) bool {
 	return string(ab) == string(bb)
 }
 
+// hookGroupsEquivalent treats the two previous shell-command formats as the
+// canonical exec form for drift purposes. Reinstall still rewrites them, but a
+// format migration alone is not a hand edit. Every other field is compared.
+func hookGroupsEquivalent(existing, want []any) bool {
+	data, err := json.Marshal(existing)
+	if err != nil {
+		return false
+	}
+	var normalized []any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return false
+	}
+	for i := range normalized {
+		if i >= len(want) {
+			break
+		}
+		normalizeLegacyHookGroup(normalized[i], want[i])
+	}
+	return hookArraysEqual(normalized, want)
+}
+
+func normalizeLegacyHookGroup(existing, want any) {
+	eg, ok := existing.(map[string]any)
+	if !ok {
+		return
+	}
+	wg, ok := want.(map[string]any)
+	if !ok {
+		return
+	}
+	existingHooks, _ := eg["hooks"].([]any)
+	wantedHooks, _ := wg["hooks"].([]any)
+	for i := range existingHooks {
+		if i >= len(wantedHooks) {
+			break
+		}
+		oldHook, ok := existingHooks[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		newHook, ok := wantedHooks[i].(map[string]any)
+		if ok && legacyHookMatches(oldHook, newHook) {
+			oldHook["command"] = newHook["command"]
+			oldHook["args"] = newHook["args"]
+		}
+	}
+}
+
 // hookGroupIsOurs reports whether a matcher group belongs to GrayMatter.
 func hookGroupIsOurs(group any, expectedExe ...string) bool {
 	ours, _ := hookGroupGuardStatus(group, expectedExe...)
@@ -444,9 +485,9 @@ func hookGroupGuardStatus(group any, expectedExe ...string) (ours, guarded bool)
 		if !ok {
 			continue
 		}
-		if c, _ := hook["command"].(string); hookCommandIsOurs(c, expectedExe...) {
+		if hookEntryIsOurs(hook, expectedExe...) {
 			ours = true
-			guarded = guarded && hookCommandHasArg(c, hooksNoCreateArg)
+			guarded = guarded && hookEntryHasArg(hook, hooksNoCreateArg)
 		}
 	}
 	return ours, guarded
@@ -458,15 +499,19 @@ func hookEventNames() []string {
 }
 
 // hookGroupsFor builds the canonical matcher groups for one event and the
-// given executable. The recorded command carries the CLI event name (the
-// snake_case arg `hooks run` takes), not the settings event key.
+// given executable. The args carry the CLI event name (the snake_case value
+// `hooks run` takes), not the settings event key.
 func hookGroupsFor(exe, event string, scopes ...hookScope) []any {
 	scope := scopeProject
 	if len(scopes) > 0 {
 		scope = scopes[0]
 	}
 	group := func(matcher string, timeout int) map[string]any {
-		hook := map[string]any{"type": "command", "command": hookCommand(exe, hookRunArg(event), scope)}
+		args := []string{"hooks", "run", hookRunArg(event), hooksCommandMarker}
+		if scope == scopeGlobal {
+			args = append(args, hooksNoCreateArg)
+		}
+		hook := map[string]any{"type": "command", "command": exe, "args": args}
 		if timeout > 0 {
 			hook["timeout"] = timeout
 		}
@@ -509,9 +554,8 @@ func hookRunArg(event string) string {
 	return event
 }
 
-// hookCommand renders the command line Claude Code will execute. The binary
-// path is quoted when needed: hooks run through a shell, and installs under
-// paths with spaces are routine on every platform.
+// hookCommand renders the previous shell form. It remains solely so legacy
+// installations can be exercised against the compatibility parser.
 func hookCommand(exe, event string, scopes ...hookScope) string {
 	scope := scopeProject
 	if len(scopes) > 0 {
@@ -642,10 +686,10 @@ func runHooksDoctorChecks(path, exeAbs string, scope hookScope) []hookCheck {
 				if !ok {
 					continue
 				}
-				if c, _ := hook["command"].(string); hookCommandIsOurs(c, exeAbs) {
+				if hookEntryIsOurs(hook, exeAbs) {
 					found = true
 					if exePath == "" {
-						exePath = hookBinaryPath(c)
+						exePath = hookEntryBinaryPath(hook)
 					}
 				}
 			}
@@ -773,6 +817,127 @@ func globalHookGuardStatus(root map[string]any) (installed, guarded bool) {
 	return installed, guarded
 }
 
+func hookEntryArgs(hook map[string]any) ([]string, bool) {
+	raw, present := hook["args"]
+	if !present {
+		return nil, false
+	}
+	switch values := raw.(type) {
+	case []string:
+		return append([]string(nil), values...), true
+	case []any:
+		args := make([]string, len(values))
+		for i, value := range values {
+			arg, ok := value.(string)
+			if !ok {
+				return nil, false
+			}
+			args[i] = arg
+		}
+		return args, true
+	default:
+		return nil, false
+	}
+}
+
+func hookEntryHasArg(hook map[string]any, want string) bool {
+	if _, structured := hook["args"]; structured {
+		args, ok := hookEntryArgs(hook)
+		if !ok {
+			return false
+		}
+		for _, arg := range args {
+			if arg == want {
+				return true
+			}
+		}
+		return false
+	}
+	command, _ := hook["command"].(string)
+	return hookCommandHasArg(command, want)
+}
+
+func hookEntryIsOurs(hook map[string]any, expectedExe ...string) bool {
+	command, ok := hook["command"].(string)
+	if !ok {
+		return false
+	}
+	if _, structured := hook["args"]; !structured {
+		return hookCommandIsOurs(command, expectedExe...)
+	}
+	args, ok := hookEntryArgs(hook)
+	if !ok {
+		return false
+	}
+	if len(args) < 3 || args[0] != "hooks" || args[1] != "run" {
+		return false
+	}
+	if stringSliceContains(args, hooksCommandMarker) {
+		return true
+	}
+	if len(expectedExe) > 0 && filepath.Clean(command) == filepath.Clean(expectedExe[0]) {
+		return true
+	}
+	return strings.TrimSuffix(strings.ToLower(filepath.Base(command)), ".exe") == "graymatter"
+}
+
+func hookEntryBinaryPath(hook map[string]any) string {
+	command, _ := hook["command"].(string)
+	if _, structured := hook["args"]; structured {
+		return command
+	}
+	return hookBinaryPath(command)
+}
+
+func legacyHookMatches(existing, want map[string]any) bool {
+	if _, structured := existing["args"]; structured {
+		return false
+	}
+	command, ok := existing["command"].(string)
+	if !ok {
+		return false
+	}
+	wantCommand, ok := want["command"].(string)
+	if !ok || filepath.Clean(hookBinaryPath(command)) != filepath.Clean(wantCommand) {
+		return false
+	}
+	wantArgs, ok := hookEntryArgs(want)
+	if !ok || len(wantArgs) < 4 {
+		return false
+	}
+	idx := strings.LastIndex(command, hooksRunCommandMarker)
+	if idx < 0 {
+		return false
+	}
+	tail := strings.Fields(command[idx+len(hooksRunCommandMarker):])
+	prefix := strings.TrimSpace(command[:idx])
+	if strings.HasSuffix(prefix, " graymatter") {
+		return len(tail) == 1 && tail[0] == wantArgs[2]
+	}
+	return stringSlicesEqual(tail, wantArgs[2:])
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func hookCommandHasArg(command, want string) bool {
 	idx := strings.LastIndex(command, hooksRunCommandMarker)
 	if idx < 0 {
@@ -804,7 +969,11 @@ func hookBinaryPath(command string) string {
 	}
 	p := strings.TrimSpace(command[:idx])
 	p = strings.TrimSpace(strings.TrimSuffix(p, " graymatter"))
-	p = strings.Trim(p, `"'`)
+	if unquoted, err := strconv.Unquote(p); err == nil {
+		p = unquoted
+	} else {
+		p = strings.Trim(p, `"'`)
+	}
 	return filepath.FromSlash(p)
 }
 

--- a/cmd/graymatter/cmd_hooks.go
+++ b/cmd/graymatter/cmd_hooks.go
@@ -92,9 +92,9 @@ the previous file as .bak.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {
-				global = true
+				return fmt.Errorf("hooks install --all is not supported; install one scope explicitly to avoid duplicate hook execution")
 			}
-			scopes, err := parseHookScopes(scope, global)
+			scopes, err := parseHookScopes(scope, global, false)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ the previous file as .bak.`,
 		},
 	}
 	cmd.Flags().StringVar(&scope, "scope", "project", "where to write: project (.claude/settings.json) or global (~/.claude/settings.json)")
-	cmd.Flags().BoolVar(&all, "all", false, "install into both project and global scope")
+	cmd.Flags().BoolVar(&all, "all", false, "unsupported: install one scope at a time to avoid duplicate hook execution")
 	cmd.Flags().BoolVar(&global, "global", false, "alias of --scope global")
 	_ = cmd.Flags().MarkHidden("global")
 	return cmd
@@ -135,10 +135,7 @@ func hooksUninstallCmd() *cobra.Command {
 		Short: "Remove GrayMatter's hooks from Claude Code settings.json",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if all {
-				global = true
-			}
-			scopes, err := parseHookScopes(scope, global)
+			scopes, err := parseHookScopes(scope, global, all)
 			if err != nil {
 				return err
 			}
@@ -192,7 +189,13 @@ const (
 	scopeGlobal  hookScope = "global"
 )
 
-func parseHookScopes(scope string, global bool) ([]hookScope, error) {
+func parseHookScopes(scope string, global, all bool) ([]hookScope, error) {
+	if all {
+		if scope != "" && scope != string(scopeProject) && scope != string(scopeGlobal) {
+			return nil, fmt.Errorf("unknown scope %q (want project or global)", scope)
+		}
+		return []hookScope{scopeProject, scopeGlobal}, nil
+	}
 	if global {
 		if scope != "" && scope != string(scopeProject) && scope != string(scopeGlobal) {
 			return nil, fmt.Errorf("conflicting --scope %q and --global", scope)
@@ -592,10 +595,7 @@ func hooksDoctorCmd() *cobra.Command {
 Exits non-zero when any check fails, so scripts and CI can gate on it.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if all {
-				global = true
-			}
-			scopes, err := parseHookScopes(scope, global)
+			scopes, err := parseHookScopes(scope, global, all)
 			if err != nil {
 				return err
 			}

--- a/cmd/graymatter/cmd_hooks.go
+++ b/cmd/graymatter/cmd_hooks.go
@@ -747,6 +747,11 @@ func runHooksDoctorChecks(path, exeAbs string, scope hookScope) []hookCheck {
 // store cannot answer within it, per-turn injection is the wrong shape and
 // the doctor says so.
 func hooksStoreCheck() hookCheck {
+	if !hookStoreInitialized(dataDir) {
+		return hookCheck{
+			Name: "store", Status: "info", Detail: "store not initialised (no gray.db or MEMORY.md found)",
+		}
+	}
 	start := timeNow()
 	store, err := openStore()
 	if err != nil {

--- a/cmd/graymatter/cmd_hooks_hardening_test.go
+++ b/cmd/graymatter/cmd_hooks_hardening_test.go
@@ -269,11 +269,22 @@ func FuzzRewriteHookEvent(f *testing.F) {
 		if err != nil {
 			t.Fatalf("merged event array is not serialisable: %v", err)
 		}
-		if !strings.Contains(string(blob), "graymatter hooks run user-prompt") {
+		if !strings.Contains(string(blob), `"args":["hooks","run","user-prompt","--graymatter-managed-hook"]`) {
 			t.Fatalf("install lost our group: %s", blob)
 		}
 		_ = drift
 	})
+}
+
+func TestHooksOwnership_RejectsMalformedStructuredArgs(t *testing.T) {
+	for _, tc := range []struct{ command string; args any }{{"/opt/gm/graymatter", nil}, {"/opt/gm/graymatter", "hooks run user-prompt"}, {"/opt/gm/graymatter", []any{"hooks", 7, "user-prompt"}}, {"echo", []any{hooksCommandMarker}}} {
+		group := map[string]any{"hooks": []any{map[string]any{
+			"type": "command", "command": tc.command, "args": tc.args,
+		}}}
+		if hookGroupIsOurs(group, "/opt/gm/graymatter") {
+			t.Errorf("malformed entry %+v was claimed as a managed hook", tc)
+		}
+	}
 }
 
 // A foreign command that only mentions the legacy marker is never ours.

--- a/cmd/graymatter/cmd_hooks_test.go
+++ b/cmd/graymatter/cmd_hooks_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
@@ -62,6 +64,8 @@ func hookGroups(t *testing.T, root map[string]any, event string) []map[string]an
 
 func groupCommands(t *testing.T, group map[string]any) []string {
 	t.Helper()
+	// Compatibility view for older assertions; persisted exec-form tests read
+	// command and args separately and never execute this reconstruction.
 	list, _ := group["hooks"].([]any)
 	out := make([]string, 0, len(list))
 	for _, h := range list {
@@ -73,6 +77,9 @@ func groupCommands(t *testing.T, group map[string]any) []string {
 			t.Errorf("hook type = %v, want command", hook["type"])
 		}
 		c, _ := hook["command"].(string)
+		if args, ok := hookEntryArgs(hook); ok {
+			c += " " + strings.Join(args, " ")
+		}
 		out = append(out, c)
 	}
 	return out
@@ -81,7 +88,7 @@ func groupCommands(t *testing.T, group map[string]any) []string {
 // TestHooksInstall_WritesCanonicalContract pins the emitted settings shape:
 // four events, SessionStart split across a startup|resume|fork group and a
 // compact group, the user-prompt hook carrying a 10s timeout, and every
-// command an absolute path carrying the documented invocation.
+// command an exact executable path and args carrying the invocation tokens.
 func TestHooksInstall_WritesCanonicalContract(t *testing.T) {
 	withHooksEnv(t)
 	dir := t.TempDir()
@@ -121,18 +128,25 @@ func TestHooksInstall_WritesCanonicalContract(t *testing.T) {
 
 	for _, event := range hookEventNames() {
 		for _, g := range hookGroups(t, root, event) {
-			for _, c := range groupCommands(t, g) {
-				if !strings.Contains(c, hooksCommandMarker) {
-					t.Errorf("%s command %q lacks the marker", event, c)
+			for _, raw := range g["hooks"].([]any) {
+				hook := raw.(map[string]any)
+				if command, _ := hook["command"].(string); command != exe {
+					t.Errorf("%s command = %q, want exact path %q", event, command, exe)
 				}
-				if !strings.Contains(c, hooksRunCommandMarker+hookRunArg(event)+" "+hooksCommandMarker) {
-					t.Errorf("command %q must invoke the run event %q", c, hookRunArg(event))
-				}
-				if !filepath.IsAbs(hookBinaryPath(c)) {
-					t.Errorf("command %q must record an absolute binary path", c)
+				args, ok := hookEntryArgs(hook)
+				want := []string{"hooks", "run", hookRunArg(event), hooksCommandMarker}
+				if !ok || !stringSlicesEqual(args, want) {
+					t.Errorf("%s args = %q, want %q", event, args, want)
 				}
 			}
 		}
+	}
+	global := hookGroupsFor(exe, hooksEventPreCompact, scopeGlobal)[0].(map[string]any)
+	hook := global["hooks"].([]any)[0].(map[string]any)
+	args, ok := hookEntryArgs(hook)
+	want := []string{"hooks", "run", "pre-compact", hooksCommandMarker, hooksNoCreateArg}
+	if hook["command"] != exe || !ok || !stringSlicesEqual(args, want) {
+		t.Errorf("global exec form = command %v args %q, want %q + %q", hook["command"], args, exe, want)
 	}
 }
 
@@ -364,10 +378,10 @@ func TestHooksSettings_NonObjectHooksLeftUntouched(t *testing.T) {
 	}
 }
 
-// TestHookCommand_Quoting: binaries under paths with spaces must record a
-// quoted command, and hookBinaryPath must round-trip it.
-func TestHookCommand_Quoting(t *testing.T) {
-	withSpaces := `/c/Program Files/hooks run/graymatter`
+// TestHookCommand_LegacyParsing keeps the two shell-form readers available for
+// reinstall and uninstall of settings written by previous releases.
+func TestHookCommand_LegacyParsing(t *testing.T) {
+	withSpaces := `/c/Program Files/hook's run/graymatter`
 	cmd := hookCommand(withSpaces, "user-prompt")
 	if !strings.HasPrefix(cmd, `"`) {
 		t.Errorf("command %q must quote a path containing spaces", cmd)
@@ -380,6 +394,126 @@ func TestHookCommand_Quoting(t *testing.T) {
 	plain := hookCommand("/usr/local/bin/graymatter", "session-start")
 	if strings.HasPrefix(plain, `"`) {
 		t.Errorf("command %q need not be quoted", plain)
+	}
+}
+
+func TestHooksInstall_ExecFormRunsLiteralBinaryPath(t *testing.T) {
+	for _, name := range []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "VOYAGE_API_KEY"} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("GRAYMATTER_OLLAMA_URL", "disabled://hook-command-test")
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "hook path $ (literal)")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(binDir, "graymatter.exe")
+	build := exec.Command("go", "build", "-o", bin, "github.com/angelnicolasc/graymatter/cmd/graymatter")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build hook binary: %v\n%s", err, out)
+	}
+
+	project := filepath.Join(root, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	storeDir := filepath.Join(project, ".graymatter")
+	t.Cleanup(func() {
+		stop := exec.Command(bin, "--dir", storeDir, "daemon", "stop")
+		stop.Dir = project
+		_ = stop.Run()
+		time.Sleep(300 * time.Millisecond)
+	})
+
+	settings := filepath.Join(project, ".claude", "settings.json")
+	install := exec.Command(bin, "hooks", "install")
+	install.Dir = project
+	if out, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("install hooks from literal path: %v\n%s", err, out)
+	}
+	groups := hookGroups(t, readSettings(t, settings), hooksEventUserPrompt)
+	hook := groups[0]["hooks"].([]any)[0].(map[string]any)
+	command, _ := hook["command"].(string)
+	args, ok := hookEntryArgs(hook)
+	if command != bin || !ok {
+		t.Fatalf("persisted exec form = command %q args %q", command, args)
+	}
+	payload, _ := json.Marshal(map[string]string{
+		"cwd": project, "prompt": "remember: exec form preserved the literal path",
+	})
+	run := exec.Command(command, args...)
+	run.Dir, run.Stdin = project, strings.NewReader(string(payload))
+	out, err := run.CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "Saved to memory") {
+		t.Fatalf("execute persisted command+args: %v\n%s", err, out)
+	}
+}
+
+func TestHooksInstall_MigratesPreviousCommandFormsWithoutDrift(t *testing.T) {
+	exe := filepath.Join(t.TempDir(), "graymatter.exe")
+	cases := []struct {
+		name    string
+		scope   hookScope
+		command string
+	}{
+		{"string project", scopeProject, hookCommand(exe, "user-prompt")},
+		{"string global", scopeGlobal, hookCommand(exe, "user-prompt", scopeGlobal)},
+		{"pre-marker project", scopeProject, filepath.ToSlash(exe) + " graymatter hooks run user-prompt"},
+		{"pre-marker global", scopeGlobal, filepath.ToSlash(exe) + " graymatter hooks run user-prompt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			legacy := map[string]any{"hooks": map[string]any{
+				hooksEventUserPrompt: []any{map[string]any{"hooks": []any{
+					map[string]any{"type": "command", "command": tc.command, "timeout": userPromptHookTimeout},
+				}}},
+			}}
+			write := func(value map[string]any) {
+				t.Helper()
+				data, _ := json.MarshalIndent(value, "", "  ")
+				if err := os.WriteFile(path, data, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write(legacy)
+			if drift, err := hookSettingsDrift(path, exe, tc.scope); err != nil || drift {
+				t.Fatalf("previous generation reported drift=%v err=%v", drift, err)
+			}
+			res, err := upsertHookSettings(path, exe, true, tc.scope)
+			if err != nil || !res.Changed || res.Drifted {
+				t.Fatalf("migration result=%+v err=%v", res, err)
+			}
+			group := hookGroups(t, readSettings(t, path), hooksEventUserPrompt)[0]
+			hook := group["hooks"].([]any)[0].(map[string]any)
+			if hook["command"] != exe {
+				t.Fatalf("migrated command = %v, want %q", hook["command"], exe)
+			}
+			wantArgs := []string{"hooks", "run", "user-prompt", hooksCommandMarker}
+			if tc.scope == scopeGlobal {
+				wantArgs = append(wantArgs, hooksNoCreateArg)
+			}
+			if args, ok := hookEntryArgs(hook); !ok || !stringSlicesEqual(args, wantArgs) {
+				t.Fatalf("migrated args = %q", args)
+			}
+
+			write(legacy)
+			res, err = upsertHookSettings(path, exe, false, tc.scope)
+			if err != nil || !res.Changed {
+				t.Fatalf("uninstall previous generation result=%+v err=%v", res, err)
+			}
+			if _, exists := readSettings(t, path)["hooks"]; exists {
+				t.Fatal("uninstall left the previous-generation hook installed")
+			}
+
+			edited := legacy["hooks"].(map[string]any)[hooksEventUserPrompt].([]any)[0].(map[string]any)
+			edited["hooks"].([]any)[0].(map[string]any)["timeout"] = 60
+			write(legacy)
+			if drift, err := hookSettingsDrift(path, exe, tc.scope); err != nil || !drift {
+				t.Fatalf("real edit reported drift=%v err=%v", drift, err)
+			}
+		})
 	}
 }
 

--- a/cmd/graymatter/cmd_hooks_test.go
+++ b/cmd/graymatter/cmd_hooks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -83,6 +84,79 @@ func groupCommands(t *testing.T, group map[string]any) []string {
 		out = append(out, c)
 	}
 	return out
+}
+
+func TestHooksUninstallAll_RemovesBothScopes(t *testing.T) {
+	withHooksEnv(t)
+	project, home := t.TempDir(), t.TempDir()
+	t.Chdir(project)
+	testHomeOverride = home
+	t.Cleanup(func() { testHomeOverride = "" })
+
+	exe := filepath.Join(t.TempDir(), "graymatter")
+	paths := []string{
+		filepath.Join(project, ".claude", "settings.json"),
+		filepath.Join(home, ".claude", "settings.json"),
+	}
+	for i, path := range paths {
+		scope := []hookScope{scopeProject, scopeGlobal}[i]
+		if _, err := upsertHookSettings(path, exe, true, scope); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := hooksUninstallCmd()
+	cmd.SetArgs([]string{"--all"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hooks uninstall --all: %v", err)
+	}
+	for _, path := range paths {
+		if hooks, ok := readSettings(t, path)["hooks"]; ok {
+			t.Errorf("%s still has hooks after --all: %#v", path, hooks)
+		}
+	}
+}
+
+func TestHooksDoctorAll_ReportsBothScopes(t *testing.T) {
+	withHooksEnv(t)
+	project, home := t.TempDir(), t.TempDir()
+	t.Chdir(project)
+	testHomeOverride = home
+	t.Cleanup(func() { testHomeOverride = "" })
+	exe, err := resolveOwnBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for scope, path := range map[hookScope]string{
+		scopeProject: filepath.Join(project, ".claude", "settings.json"),
+		scopeGlobal:  filepath.Join(home, ".claude", "settings.json"),
+	} {
+		if _, err := upsertHookSettings(path, exe, true, scope); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var out bytes.Buffer
+	cmd := hooksDoctorCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--all"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hooks doctor --all: %v", err)
+	}
+	got := out.String()
+	for _, path := range []string{filepath.Join(".claude", "settings.json"), filepath.Join(home, ".claude", "settings.json")} {
+		if !strings.Contains(got, path) {
+			t.Errorf("doctor --all omitted %s:\n%s", path, got)
+		}
+	}
+}
+
+func TestHooksInstallAll_RemainsRejected(t *testing.T) {
+	cmd := hooksInstallCmd()
+	cmd.SetArgs([]string{"--all"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("hooks install --all error = %v, want explicit rejection", err)
+	}
 }
 
 // TestHooksInstall_WritesCanonicalContract pins the emitted settings shape:

--- a/cmd/graymatter/cmd_hooks_test.go
+++ b/cmd/graymatter/cmd_hooks_test.go
@@ -159,6 +159,52 @@ func TestHooksInstallAll_RemainsRejected(t *testing.T) {
 	}
 }
 
+func TestHooksDoctor_MissingStoreDoesNotCreateState(t *testing.T) {
+	bin := buildE2EBinary(t)
+	for _, tc := range []struct {
+		name     string
+		wantCode int
+	}{
+		{name: "valid settings", wantCode: 0},
+		{name: "missing settings", wantCode: 1},
+		{name: "corrupt settings", wantCode: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			work := t.TempDir()
+			settings := filepath.Join(work, ".claude", "settings.json")
+			switch tc.name {
+			case "valid settings":
+				if out, code := runE2E(t, bin, work, "", "hooks", "install"); code != 0 {
+					t.Fatalf("hooks install: exit=%d out=%s", code, out)
+				}
+			case "corrupt settings":
+				if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(settings, []byte("{broken"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			before, err := os.ReadDir(work)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, code := runE2E(t, bin, work, "", "hooks", "doctor")
+			after, err := os.ReadDir(work)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if code != tc.wantCode || !strings.Contains(out, "store not initialised") {
+				t.Fatalf("hooks doctor: exit=%d out=%q, want exit %d and uninitialised report", code, out, tc.wantCode)
+			}
+			if len(after) != len(before) {
+				t.Fatalf("doctor created state: before=%v after=%v", before, after)
+			}
+		})
+	}
+}
+
 // TestHooksInstall_WritesCanonicalContract pins the emitted settings shape:
 // four events, SessionStart split across a startup|resume|fork group and a
 // compact group, the user-prompt hook carrying a 10s timeout, and every


### PR DESCRIPTION
**Stacked on #98**, which should merge first; this branch carries its commit and
GitHub will narrow the diff once it lands. Two defects, one commit each.

## `--all` never touched project scope

`hooks install/uninstall/doctor --all` all promised both scopes. Each handler
implemented the flag by setting `global = true`, and `parseHookScopes` answered
with `[]hookScope{scopeGlobal}` alone. Project scope never entered the loop:
`uninstall --all` left the project hooks in place, and `doctor --all` could call
an installation healthy while looking at half of it.

`all` is now its own parameter rather than collapsing into `global`, and returns
both scopes.

`install --all` is the exception and is now **rejected explicitly**. Claude Code
can load project and user handlers in parallel, so installing both scopes means
running every hook twice. Silently installing one of the two was the wrong way
to avoid that; refusing with a reason is the right one, and the flag's help says
so.

## The diagnostic created what it came to inspect

`hooks doctor` always appended `hooksStoreCheck()`, which calls `openStore()`
with the process-wide `--dir` — defaulting to `.graymatter` relative to the
working directory. Running the diagnostic from an uninitialised folder created
the store, the daemon files and the log there: exactly what #92 stopped the
automatic hooks from doing. It happened even when `settings.json` was missing or
unparseable, the cases with the least reason to touch anything.

The probe now reports `store not initialised` instead of creating one. A check
that tells you something is absent is more useful than one that erases the
question by answering it.

## Verification

Both scopes covered on removal and diagnosis, `install --all` refused, and a
`doctor` run in an uninitialised directory leaves it empty — including with
absent and corrupt settings files. Full hook suite, `vet` and both module builds
green.
