### PR TITLE
fix(benchmarks): correct the lifecycle recall rate, gate its exit code, and clean up both manual benchmarks

### DIFF
--- a/benchmarks/agent_lifecycle/main.go
+++ b/benchmarks/agent_lifecycle/main.go
@@ -461,9 +461,10 @@ func main() {
 		m.tokensRecall += countTokens(text)
 		m.queriesCounted++
 		if strings.Contains(text, pq.fact) {
-			m.probeHits++
 			if pq.fact == paraphrase.fact {
 				m.paraphraseHit = true
+			} else {
+				m.probeHits++
 			}
 		}
 		checkDead(text, m)

--- a/benchmarks/agent_lifecycle/main.go
+++ b/benchmarks/agent_lifecycle/main.go
@@ -289,6 +289,23 @@ func run() int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+	storeDir := filepath.Join(dir, ".graymatter")
+	var activeSession *session
+	defer func() {
+		if activeSession != nil {
+			activeSession.kill()
+		}
+		// Ask the known daemon to stop before best-effort removal. Detached work
+		// can still revive it after this request; this narrows, not removes, the race.
+		stop := exec.Command(*binary, "--dir", storeDir, "daemon", "stop")
+		_ = stop.Run()
+		time.Sleep(500 * time.Millisecond)
+		if !*keep {
+			if err := os.RemoveAll(dir); err != nil {
+				fmt.Fprintf(os.Stderr, "cleanup %s: %v\n", dir, err)
+			}
+		}
+	}()
 
 	rng := rand.New(rand.NewSource(42)) // deterministic corpus
 	m := &metrics{liveFactsSeen: map[string]bool{}}
@@ -302,6 +319,7 @@ func run() int {
 			fmt.Fprintf(os.Stderr, "session %d: start failed: %v\n", sess, err)
 			return 1
 		}
+		activeSession = s
 
 		// resume continuity: every session after the first must recover state
 		if sess > 1 {
@@ -422,6 +440,7 @@ func run() int {
 		}
 
 		s.kill() // the process dies: this is the cross-session durability claim
+		activeSession = nil
 	}
 
 	// ---- final verification session: the probes fire here ----
@@ -430,7 +449,7 @@ func run() int {
 		fmt.Fprintln(os.Stderr, "final session: start failed:", err)
 		return 1
 	}
-	defer s.kill()
+	activeSession = s
 
 	probeQueries := []struct {
 		query string
@@ -519,9 +538,7 @@ func run() int {
 	if *out != "" {
 		writeReport(*out, m, fullHistoryTokens, reduction, elapsed)
 	}
-	if !*keep {
-		os.RemoveAll(dir)
-	} else {
+	if *keep {
 		fmt.Printf("store kept at: %s\n", dir)
 	}
 	if !passed {

--- a/benchmarks/agent_lifecycle/main.go
+++ b/benchmarks/agent_lifecycle/main.go
@@ -263,6 +263,10 @@ type metrics struct {
 }
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	binary := flag.String("binary", "", "path to the compiled graymatter binary")
 	out := flag.String("out", "", "optional path for the markdown report")
 	keep := flag.Bool("keep", false, "keep the store directory after the run (forensics)")
@@ -275,7 +279,7 @@ func main() {
 			build.Stderr = os.Stderr
 			if err := build.Run(); err != nil {
 				fmt.Fprintln(os.Stderr, "build failed:", err)
-				os.Exit(1)
+				return 1
 			}
 		}
 	}
@@ -283,7 +287,7 @@ func main() {
 	dir, err := os.MkdirTemp("", "gm-lifecycle")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return 1
 	}
 
 	rng := rand.New(rand.NewSource(42)) // deterministic corpus
@@ -296,7 +300,7 @@ func main() {
 		s, err := startSession(*binary, dir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "session %d: start failed: %v\n", sess, err)
-			os.Exit(1)
+			return 1
 		}
 
 		// resume continuity: every session after the first must recover state
@@ -332,7 +336,7 @@ func main() {
 			if _, err := s.call("memory_add", map[string]any{
 				"agent_id": emptyAgentName, "text": probes[idx].fact,
 			}); err != nil {
-				fail(sess, "plant probe", err)
+				return fail(sess, "plant probe", err)
 			}
 			storedTexts[probes[idx].fact] = true
 			m.totalFacts++
@@ -341,7 +345,7 @@ func main() {
 			if _, err := s.call("memory_add", map[string]any{
 				"agent_id": emptyAgentName, "text": supersededV1,
 			}); err != nil {
-				fail(sess, "plant v1", err)
+				return fail(sess, "plant v1", err)
 			}
 			storedTexts[supersededV1] = true
 			m.totalFacts++
@@ -350,7 +354,7 @@ func main() {
 			if _, err := s.call("memory_add", map[string]any{
 				"agent_id": emptyAgentName, "text": paraphrase.fact,
 			}); err != nil {
-				fail(sess, "plant paraphrase", err)
+				return fail(sess, "plant paraphrase", err)
 			}
 			storedTexts[paraphrase.fact] = true
 			m.totalFacts++
@@ -365,7 +369,7 @@ func main() {
 				if _, err := s.call("memory_add", map[string]any{
 					"agent_id": "__shared__", "text": sh,
 				}); err != nil {
-					fail(sess, "plant shared", err)
+					return fail(sess, "plant shared", err)
 				}
 				storedTexts[sh] = true
 				m.totalFacts++
@@ -377,7 +381,7 @@ func main() {
 			if _, err := s.call("memory_add", map[string]any{
 				"agent_id": emptyAgentName, "text": f,
 			}); err != nil {
-				fail(sess, "add", err)
+				return fail(sess, "add", err)
 			}
 			storedTexts[f] = true
 			m.totalFacts++
@@ -392,7 +396,7 @@ func main() {
 				"text":   replacementV2,
 				"target": supersededV1,
 			}); err != nil {
-				fail(sess, "supersede", err)
+				return fail(sess, "supersede", err)
 			}
 			storedTexts[replacementV2] = true
 			m.totalFacts++
@@ -402,7 +406,7 @@ func main() {
 		if _, err := s.call("checkpoint_save", map[string]any{
 			"agent_id": emptyAgentName, "state": checkpointState(sess),
 		}); err != nil {
-			fail(sess, "checkpoint_save", err)
+			return fail(sess, "checkpoint_save", err)
 		}
 
 		// window narrowing for the tombstone finding: probe v1 immediately
@@ -424,7 +428,7 @@ func main() {
 	s, err := startSession(*binary, dir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "final session: start failed:", err)
-		os.Exit(1)
+		return 1
 	}
 	defer s.kill()
 
@@ -455,7 +459,7 @@ func main() {
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "probe query failed: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		text := firstText(res)
 		m.tokensRecall += countTokens(text)
@@ -511,7 +515,7 @@ func main() {
 		reduction = 1 - avgRecall/float64(fullHistoryTokens)
 	}
 
-	printReport(*binary, dir, m, fullHistoryTokens, reduction, elapsed)
+	passed := printReport(*binary, dir, m, fullHistoryTokens, reduction, elapsed)
 	if *out != "" {
 		writeReport(*out, m, fullHistoryTokens, reduction, elapsed)
 	}
@@ -520,6 +524,10 @@ func main() {
 	} else {
 		fmt.Printf("store kept at: %s\n", dir)
 	}
+	if !passed {
+		return 1
+	}
+	return 0
 }
 
 // checkDead counts a superseded fact as returned only when it appears as a
@@ -551,25 +559,29 @@ func countTokens(s string) int {
 	return int(float64(wordCount(s)) * tokenPerWord)
 }
 
-func fail(sess int, what string, err error) {
+func fail(sess int, what string, err error) int {
 	fmt.Fprintf(os.Stderr, "session %d: %s failed: %v\n", sess, what, err)
-	os.Exit(1)
+	return 1
 }
 
-func printReport(binary, dir string, m *metrics, fullHistoryTokens int, reduction float64, elapsed time.Duration) {
-	fmt.Print(reportString(binary, dir, m, fullHistoryTokens, reduction, elapsed))
+func printReport(binary, dir string, m *metrics, fullHistoryTokens int, reduction float64, elapsed time.Duration) bool {
+	report, passed := reportString(binary, dir, m, fullHistoryTokens, reduction, elapsed)
+	fmt.Print(report)
 	fmt.Printf("\nMarkdown report: pass -out <path>\n")
+	return passed
 }
 
 func writeReport(path string, m *metrics, fullHistoryTokens int, reduction float64, elapsed time.Duration) {
-	if err := os.WriteFile(path, []byte(reportString("", "", m, fullHistoryTokens, reduction, elapsed)), 0o644); err != nil {
+	report, _ := reportString("", "", m, fullHistoryTokens, reduction, elapsed)
+	if err := os.WriteFile(path, []byte(report), 0o644); err != nil {
 		fmt.Fprintln(os.Stderr, "write report:", err)
 	}
 }
 
-func reportString(binary, dir string, m *metrics, fullHistoryTokens int, reduction float64, elapsed time.Duration) string {
+func reportString(binary, dir string, m *metrics, fullHistoryTokens int, reduction float64, elapsed time.Duration) (string, bool) {
 	var b strings.Builder
 	w := func(f string, a ...any) { fmt.Fprintf(&b, f, a...) }
+	passed := true
 
 	w("# Agent lifecycle simulation — 100 real sessions\n\n")
 	w("Protocol: one fresh `graymatter mcp serve` process per session (JSON-RPC over stdio); the process dies at every session end — durability across restarts is under test, not simulated. Corpus is realistic and adversarial: distractor families sharing vocabulary, a supersede pair, paraphrase probe, shared namespace. Deterministic seed.\n\n")
@@ -580,6 +592,7 @@ func reportString(binary, dir string, m *metrics, fullHistoryTokens int, reducti
 	verdict := "PASS"
 	if hitRate < 70 {
 		verdict = "FAIL"
+		passed = false
 	}
 	w("| Probe recall after ~96 sessions + %d process deaths | 83%% (band ≥70%%) | %.0f%% (%d/%d) | %s |\n",
 		sessions-4, hitRate, m.probeHits, m.probeTotal, verdict)
@@ -587,24 +600,28 @@ func reportString(binary, dir string, m *metrics, fullHistoryTokens int, reducti
 	deadVerdict := "PASS"
 	if m.deadReturned > 0 {
 		deadVerdict = "FAIL"
+		passed = false
 	}
 	w("| Superseded facts returned | 0%% | %d occurrences | %s |\n", m.deadReturned, deadVerdict)
 
 	redVerdict := "PASS"
 	if reduction < 0.85 {
 		redVerdict = "FAIL"
+		passed = false
 	}
 	w("| Token reduction vs full-history | ~90%% (band ≥85%%) | %.0f%% | %s |\n", reduction*100, redVerdict)
 
 	resumeVerdict := "PASS"
 	if m.resumeOK != m.resumeTried {
 		resumeVerdict = "FAIL"
+		passed = false
 	}
 	w("| Checkpoint resume across process death | every session | %d/%d | %s |\n", m.resumeOK, m.resumeTried, resumeVerdict)
 
 	sharedVerdict := "PASS"
 	if m.sharedOK < 3 {
 		sharedVerdict = "FAIL"
+		passed = false
 	}
 	w("| Shared namespace from a foreign agent_id | 3/3 conventions visible | %d/3 | %s |\n", m.sharedOK, sharedVerdict)
 
@@ -626,7 +643,7 @@ func reportString(binary, dir string, m *metrics, fullHistoryTokens int, reducti
 	if dir != "" {
 		w("| Store dir | %s (deleted after run) |\n", dir)
 	}
-	return b.String()
+	return b.String(), passed
 }
 
 func max(a, b int) int {

--- a/benchmarks/decay_probe/main.go
+++ b/benchmarks/decay_probe/main.go
@@ -16,9 +16,17 @@ import (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	cfg := graymatter.DefaultConfig()
 	cfg.DataDir, _ = os.MkdirTemp("", "gm-decay")
-	defer os.RemoveAll(cfg.DataDir)
+	defer func() {
+		if err := os.RemoveAll(cfg.DataDir); err != nil {
+			fmt.Fprintf(os.Stderr, "cleanup %s: %v\n", cfg.DataDir, err)
+		}
+	}()
 	cfg.DecayHalfLife = 2 * time.Second // 30 days compressed to 2 seconds
 	cfg.AsyncConsolidate = false        // drive consolidation by hand
 	cfg.ConsolidateThreshold = 1000     // never auto-trigger
@@ -27,8 +35,14 @@ func main() {
 	mem, err := graymatter.NewWithConfig(cfg)
 	if err != nil {
 		fmt.Println("open:", err)
-		os.Exit(1)
+		return 1
 	}
+	// Registered after directory cleanup so LIFO closes bbolt first on return.
+	defer func() {
+		if err := mem.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "close:", err)
+		}
+	}()
 	ctx := context.Background()
 	fmt.Println("Embedder: keyword (no LLM, no network, no API key)")
 
@@ -36,12 +50,12 @@ func main() {
 	for _, f := range []string{"untouched A", "untouched B", "untouched C", "untouched D", "untouched E", "untouched F", "untouched G", "untouched H", "untouched I", "untouched J"} {
 		if err := mem.Remember(ctx, agent, f); err != nil {
 			fmt.Println("remember:", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 	if err := mem.Remember(ctx, agent, "pinned institutional fact: production secrets live in the platform vault"); err != nil {
 		fmt.Println("remember pinned:", err)
-		os.Exit(1)
+		return 1
 	}
 	// pin it through the store handle (what memory_reflect action=pin does)
 	adv := mem.Advanced()
@@ -68,7 +82,7 @@ func main() {
 	time.Sleep(6 * time.Second)
 	if err := mem.Consolidate(ctx, agent); err != nil {
 		fmt.Println("consolidate 1:", err)
-		os.Exit(1)
+		return 1
 	}
 	facts, _ = adv.List(agent)
 	maxW := 0.0
@@ -88,7 +102,7 @@ func main() {
 	// the touch: recalling A resets its decay clock
 	if _, err := mem.Recall(ctx, agent, "untouched A"); err != nil {
 		fmt.Println("recall touch:", err)
-		os.Exit(1)
+		return 1
 	}
 
 	// The touch: recalling A resets ITS decay clock — and the clocks of the
@@ -100,7 +114,7 @@ func main() {
 	time.Sleep(8 * time.Second)
 	if err := mem.Consolidate(ctx, agent); err != nil {
 		fmt.Println("consolidate 2:", err)
-		os.Exit(1)
+		return 1
 	}
 
 	facts, _ = adv.List(agent)
@@ -125,9 +139,10 @@ func main() {
 
 	if failures > 0 {
 		fmt.Printf("\n%d checks FAILED\n", failures)
-		os.Exit(1)
+		return 1
 	}
 	fmt.Println("\nAll forgetting-curve checks passed.")
+	return 0
 }
 
 var _ = math.Exp


### PR DESCRIPTION
Four defects in the two manual benchmarks, one commit each. No production code is touched; neither benchmark runs in CI.

### 1. The recall rate could exceed 100%

`agent_lifecycle` incremented the hit counter on every final probe, the paraphrase included, while the denominator excluded that same probe. Numerator of five over a denominator of four: whenever the paraphrase hit, the report published `125% (5/4) | PASS`. The intent was already written down next to the denominator, so the numerator now honours it and the paraphrase stays reported-not-gated.

### 2. A FAIL verdict exited 0

The report computes five verdicts and none of them reached the exit code, so any automation calling this benchmark saw success unconditionally. All five now gate the exit status, along the same lines as the `bench --hooks --json` correction.

### 3. The lifecycle daemon outlived the run

Every session starts an MCP server, which auto-starts the daemon for the temporary store. Closing the MCP process does not wait for the idle-exit, and cleanup called `os.RemoveAll` without checking its error, so the run finished with a live daemon holding a directory it had just failed to delete. The daemon is now asked to stop first and the removal error is reported. The comment says plainly that this narrows the race rather than removing it.

### 4. `decay_probe` never closed its store

`os.RemoveAll` ran with bbolt still open and its error discarded, which on Windows left one `gm-decay*` store behind per execution — deterministic, not flaky. `mem.Close()` is now registered after the cleanup defer so LIFO closes the store first.

## Verification

- Recall reports `100% (4/4)` on a run where the paraphrase probe hit, which is the case that used to produce 125%.
- A real breach returns exit 1; all gates green returns 0.
- Three consecutive `decay_probe` runs leave zero `gm-decay*` directories.
- After a lifecycle run the store directory is gone and no daemon of that run survives, verified by listing processes.
- No band or threshold changes. Builds and vet green on both modules.

## One result worth stating

The token-reduction row reports 79% against its own >=85% band and therefore now exits 1. This is not a regression introduced here: the same FAIL was already visible in the printed report, next to an exit code of 0. What changed is that a machine can read it.

It is also not the published number. The ~90% figure in README comes from `benchmarks/token_count`, which is gated in CI and still prints 90% at 100 sessions. `agent_lifecycle` measures a different and harsher quantity: 223 facts, fifteen mixed queries including the adversarial paraphrase and superseded probes, against a ~1190-token baseline. No public claim moves. Neither benchmark runs in CI, so nothing turns red; a stock `go run ./benchmarks/agent_lifecycle` now exits 1 until that band and that measurement are reconciled.

No CHANGELOG entry: internal tooling, no user-facing surface changes.
