### PR TITLE
fix(bench): reject missing scaling measurements and correct the hook latency test contract

### DIFF
--- a/benchmarks/hook_latency/main_test.go
+++ b/benchmarks/hook_latency/main_test.go
@@ -7,16 +7,15 @@ import (
 	"time"
 )
 
-// TestHookLatencyBudgets is the CI gate: the hook budgets are machine-checked
-// against the real binary, exactly like every other published number. A
-// breach fails the benchmark package, which ci.yml runs as a blocking job
-// (go test ./benchmarks/...).
+// TestHookLatencyBudgets runs the real binary against the machine-relative
+// contract: the median user-prompt and session-end deltas from pre-compact
+// must stay within recallDeltaBudget and sessionEndDeltaBudget (200 ms each),
+// and normalized scaling must stay within recallScalingMaxNormalized (2.5x).
+// Pre-compact is the per-run baseline and has no absolute gate.
 //
-// Budgets (playbook, mirrored in cmd/graymatter/hooks_run.go):
-//
-//	user-prompt  p99 < 150 ms on a 10k-fact store
-//	session-end  max < 500 ms
-//	pre-compact  max < 200 ms
+// CI runs this timing measurement report-only with continue-on-error; it is
+// deliberately excluded from the blocking benchmark-package tests because
+// shared-runner timings are noisy.
 func TestHookLatencyBudgets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("hook latency gate needs process spawns; skipped in -short")

--- a/cmd/graymatter/internal/benchsyn/hook_latency.go
+++ b/cmd/graymatter/internal/benchsyn/hook_latency.go
@@ -248,7 +248,7 @@ func RunHookLatency(p HookLatencyParams, stdout io.Writer) (HookLatencyReport, e
 	if report.SessionEndDeltaMs > msDuration(HookSessionEndDeltaBudget) {
 		breaches++
 	}
-	if scalingNormalized > HookScalingMaxNormalized {
+	if !hookScalingRatioValid(scalingNormalized) {
 		breaches++
 	}
 	report.Pass = breaches == 0
@@ -349,11 +349,22 @@ func hookScalingRatio(seedFacts int) (float64, float64, error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	return normalizeHookScaling(smallBest, bigBest, seedFacts, smallFacts)
+}
+
+func normalizeHookScaling(smallBest, bigBest time.Duration, seedFacts, smallFacts int) (float64, float64, error) {
 	if smallBest <= 0 {
 		return 0, 0, fmt.Errorf("small recall measured %v", smallBest)
 	}
+	if bigBest <= 0 {
+		return 0, 0, fmt.Errorf("big recall measured %v", bigBest)
+	}
 	raw := float64(bigBest) / float64(smallBest)
 	return raw / (float64(seedFacts) / float64(smallFacts)), raw, nil
+}
+
+func hookScalingRatioValid(normalized float64) bool {
+	return normalized > 0 && normalized <= HookScalingMaxNormalized
 }
 
 func scalingTopic(i int) string {

--- a/cmd/graymatter/internal/benchsyn/hook_latency_test.go
+++ b/cmd/graymatter/internal/benchsyn/hook_latency_test.go
@@ -67,7 +67,7 @@ func TestRunHookLatency_ScaledPipeline(t *testing.T) {
 	if report.DeltaBudgetMs != msDuration(HookRecallDeltaBudget) {
 		t.Errorf("report delta budget = %v, want %v", report.DeltaBudgetMs, msDuration(HookRecallDeltaBudget))
 	}
-	if report.ScalingNormalized <= 0 || report.ScalingNormalized > HookScalingMaxNormalized {
+	if !hookScalingRatioValid(report.ScalingNormalized) {
 		t.Errorf("scaling normalized = %v, want (0, %.1f]", report.ScalingNormalized, HookScalingMaxNormalized)
 	}
 	// The injected-block guard: with corpus-matching queries the user-prompt
@@ -87,6 +87,42 @@ func TestRunHookLatency_ScaledPipeline(t *testing.T) {
 	if report.Rows[0].Event != "user-prompt" || report.Rows[2].Event != "session-end" {
 		t.Errorf("row order = %s..%s, want user-prompt first, session-end last",
 			report.Rows[0].Event, report.Rows[2].Event)
+	}
+}
+
+func TestNormalizeHookScalingRejectsMissingMeasurements(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		small, big time.Duration
+	}{
+		{name: "small", small: 0, big: time.Millisecond},
+		{name: "big", small: time.Millisecond, big: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := normalizeHookScaling(tc.small, tc.big, 100, 5); err == nil {
+				t.Fatal("zero-duration recall must be rejected as a missing measurement")
+			}
+		})
+	}
+}
+
+func TestHookScalingRatioValidRange(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		ratio float64
+		want  bool
+	}{
+		{name: "negative", ratio: -1, want: false},
+		{name: "zero", ratio: 0, want: false},
+		{name: "positive", ratio: 0.01, want: true},
+		{name: "maximum", ratio: HookScalingMaxNormalized, want: true},
+		{name: "above maximum", ratio: HookScalingMaxNormalized + 0.01, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hookScalingRatioValid(tc.ratio); got != tc.want {
+				t.Errorf("hookScalingRatioValid(%v) = %v, want %v", tc.ratio, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Two defects on the same hook-latency measurement, one commit each. Stacked on the manual-benchmark corrections.

### 1. A zero duration passed in the product and failed in the test

`hookScalingRatio` times three recalls per store and keeps the shortest. It validated the small store's figure and not the big one, so a zero duration for one of the fast recalls on the large store produced a normalized ratio of 0. The two layers then disagreed: the report only counted a ratio *above* the maximum as a breach, while `TestRunHookLatency_ScaledPipeline` required `(0, 2.5]`. The same sample, two verdicts, depending on how the clock fell.

The flake was the symptom. The defect was that the product and its test did not share a definition of a valid measurement. Both durations are now validated, a zero is reported as a missing measurement rather than an excellent ratio, and `hookScalingRatioValid` is the single predicate that the report and the test both use — the test now fails if the product ever loosens it.

### 2. The test contract described gates and a CI job that do not exist

The header on `TestHookLatencyBudgets` listed three absolute budgets that the implementation never evaluates, and claimed a breach breaks a blocking `go test ./benchmarks/...` job.

Neither is true. The implementation gates two *median* deltas against the per-run pre-compact baseline, plus a normalized scaling ratio; pre-compact is the baseline and carries no absolute gate. And the workflow deliberately excludes this measurement from the blocking benchmark step, running it in the bench job with `continue-on-error: true`, because timings on shared runners are noisy. The header now names the constants it depends on so the text and the values cannot drift apart again.

## Verification

- Both zero-duration cases are rejected, covered by a new table test.
- The shared predicate is covered across its range, including the boundary.
- `go test ./internal/benchsyn` green.
- `go test ./benchmarks/hook_latency/` green **with `OPENAI_API_KEY` set in the environment**, still reporting the keyword embedder with no network — the provider isolation holds.
- No budget or maximum changes; `HookLatencyReport` keeps its shape.

## Adjacent finding, deliberately not fixed here

`benchmarks/hook_latency/main.go` carries both of these defects itself: it validates only the small duration at `main.go:323-326` under the same `normalized > max` gate at `:244`, and its header calls the command "the CI gate" and says CI enforces the deltas. The scope of this change is the twin file's test comment, so the implementation file is left alone and tracked separately. It runs report-only, so nothing is blocked in the meantime.

No CHANGELOG entry: no user-facing surface changes.
