### PR TITLE
test(plugin): tamper before execution so the digest test is portable

### DIFF
--- a/cmd/graymatter/internal/plugin/integrity_test.go
+++ b/cmd/graymatter/internal/plugin/integrity_test.go
@@ -237,11 +237,8 @@ func TestCall_RefusesTamperedBinary(t *testing.T) {
 		SHA256: mustHash(t, binPath),
 	}
 
-	// Sanity: it runs while the bytes match.
-	if _, err := Call(context.Background(), manifest, "echo_hello", nil); err != nil {
-		t.Fatalf("Call before tampering: %v", err)
-	}
-
+	// TestCall_EchoPlugin covers the matching-binary path. Tamper before this
+	// binary is ever executed so replacing its bytes is portable across OSes.
 	if err := os.WriteFile(binPath, []byte("replaced"), 0o755); err != nil {
 		t.Fatalf("tamper: %v", err)
 	}


### PR DESCRIPTION
A fixture flake in a package that CI runs blocking. No production code is touched.

`TestCall_RefusesTamperedBinary` executed a compiled plugin and then rewrote its bytes in the same inode. On Linux that open for writing can fail with `ETXTBSY` while the kernel still considers the image in use — `Call` returning does not guarantee the child has finished tearing down — and the test then aborted before reaching the cryptographic check it exists to cover:

```
--- FAIL: TestCall_RefusesTamperedBinary (0.37s)
    integrity_test.go:246: tamper: open .../echo-plugin: text file busy
```

This matters more than the other timing flakes in this series because `internal/plugin` is in the blocking coverage step with `-race`, so it can turn any pull request red.

## Fix

The test does not need to rewrite that inode. It needs `Call` to find a binary whose bytes do not match the recorded digest, so the tampering now happens before the binary is ever executed. The matching-binary path is not lost: `TestCall_EchoPlugin` already covers a successful call with a correct digest and asserts the output.

The refusal assertion is unchanged — same call, same error check for the refusal message.

## Verification

- `go test -race -count=1 ./internal/plugin` green ten consecutive times on Linux, where the flake lives, and green on Windows.
- The test still asserts the cryptographic refusal of a tampered binary.
- The diff contains no production file.

No CHANGELOG entry: test hygiene.
