### PR TITLE
fix(memory): keep the revise replacement identity instead of inferring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **`Store.Revise` keeps its own replacement identity.** A write interleaved in the same namespace could make the library method return that unrelated fact's ID and point its victims at it; the method now uses the identity returned by its own committed replacement write.
+
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
 
 - **Hook scope management and diagnostics now match their public contract.** `hooks uninstall --all` and `hooks doctor --all` cover project and global settings, while the unsafe `hooks install --all` form is rejected to prevent duplicate hook execution. `hooks doctor` reports an uninitialised store without creating it, including when settings are missing or malformed.

--- a/pkg/memory/revise.go
+++ b/pkg/memory/revise.go
@@ -21,9 +21,8 @@ import (
 // curve (ADR-007); what changes is that Recall drops them before scoring, and
 // the live fact's receipt names them under Provenance.Supersedes.
 //
-// This is the single home for the semantics. The CLI's `graymatter revise`
-// and the revision benchmark both call it, so a store curated from a terminal
-// and one built by a benchmark cannot drift apart.
+// The revision benchmark calls this method directly. The CLI implements its
+// own daemon-capable revision path because Revise is not part of the RPC surface.
 func (s *Store) Revise(ctx context.Context, agentID, newText string, victims ...Fact) (string, error) {
 	if newText == "" {
 		return "", fmt.Errorf("revise: the replacement text is required")
@@ -32,15 +31,6 @@ func (s *Store) Revise(ctx context.Context, agentID, newText string, victims ...
 		if v.IsSuperseded() {
 			return "", fmt.Errorf("revise: %q is already superseded", v.Text)
 		}
-	}
-
-	before, err := s.List(agentID)
-	if err != nil {
-		return "", fmt.Errorf("revise: list facts: %w", err)
-	}
-	known := make(map[string]bool, len(before))
-	for _, f := range before {
-		known[f.ID] = true
 	}
 
 	// The replacement inherits the victim's kind: a revised alias stays an
@@ -52,29 +42,11 @@ func (s *Store) Revise(ctx context.Context, agentID, newText string, victims ...
 	if len(victims) > 0 {
 		kind = victims[0].Kind
 	}
-	if _, err := s.putReturningFactKind(ctx, agentID, newText, kind, ""); err != nil {
+	replacement, err := s.putReturningFactKind(ctx, agentID, newText, kind, "")
+	if err != nil {
 		return "", fmt.Errorf("revise: write the replacement: %w", err)
 	}
-
-	// Identify the replacement by identity rather than text, so a correction
-	// that repeats wording already in the store still resolves to the fact
-	// this call created.
-	after, err := s.List(agentID)
-	if err != nil {
-		return "", fmt.Errorf("revise: re-list facts: %w", err)
-	}
-	replacementID := ""
-	for _, f := range after {
-		if !known[f.ID] {
-			replacementID = f.ID
-			break
-		}
-	}
-	if replacementID == "" {
-		// The replacement cannot be named — record that something retired
-		// these facts rather than leaving them live and unexplained.
-		replacementID = SupersededByAgent
-	}
+	replacementID := replacement.ID
 
 	for _, v := range victims {
 		v.SupersededBy = replacementID

--- a/pkg/memory/supersede_test.go
+++ b/pkg/memory/supersede_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -26,6 +27,62 @@ const (
 	deadFact = "We use Lemon Squeezy for billing and payments"
 	liveFact = "We use Polar for billing and payments"
 )
+
+func TestRevise_ConcurrentPutKeepsReplacementIdentity(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	var tick atomic.Int64
+	s.now = func() time.Time { return time.Unix(tick.Add(1), 0).UTC() }
+	first, err := s.putReturningFact(ctx, "shared-writers", "deployments require Maria's approval")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := s.putReturningFact(ctx, "shared-writers", "Maria approves every production deploy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementCommitted := make(chan string)
+	releaseRevise := make(chan struct{})
+	var claimed atomic.Bool
+	s.cfg.OnPut = func(_, id string, _ time.Duration) {
+		if claimed.CompareAndSwap(false, true) {
+			replacementCommitted <- id
+			<-releaseRevise
+		}
+	}
+	type result struct {
+		id  string
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		id, err := s.Revise(ctx, "shared-writers", "Priya approves every production deploy", first, second)
+		done <- result{id, err}
+	}()
+	correctID := <-replacementCommitted // replacement is committed; Revise is held before its next step
+	unrelated, putErr := s.putReturningFact(ctx, "shared-writers", "incident channel is ops-sev")
+	close(releaseRevise)
+	if putErr != nil {
+		t.Fatal(putErr)
+	}
+	if unrelated.ID == correctID {
+		t.Fatal("interleaved write reused the replacement identity")
+	}
+	got := <-done
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if got.id != correctID {
+		t.Fatalf("Revise returned %q, want its committed replacement %q (unrelated %q)", got.id, correctID, unrelated.ID)
+	}
+	for _, victim := range []Fact{first, second} {
+		stored, ok := s.loadFact("shared-writers", victim.ID)
+		if !ok || stored.SupersededBy != correctID {
+			t.Errorf("victim %q: present=%v SupersededBy=%q, want %q", victim.ID, ok, stored.SupersededBy, correctID)
+		}
+	}
+}
 
 // TestRecall_ExcludesSupersededFact is the regression test for that scenario.
 func TestRecall_ExcludesSupersededFact(t *testing.T) {


### PR DESCRIPTION
`Store.Revise` wrote its replacement and then went looking for it, instead of keeping what the write handed back.

`putReturningFactKind` returns the `Fact` it just committed. `Revise` discarded it, re-listed the namespace, and took the first ID that was not in a snapshot taken before the write. `List` sorts newest first, so a write landing in the same namespace between the put and the second list carries a newer ULID, heads the list, and wins that scan — the returned ID and the `SupersededBy` of every victim in that revision then point at an unrelated fact.

bbolt serializes each transaction, but this was several of them; serializing each one does not make the sequence atomic.

The condition sounds exotic and is not. Daemon mode is the default topology: one process owns the store and the TUI, the MCP server, the CLI, `run` and the REST server all connect as clients. Two agents writing the same namespace, or a `session-end` consolidating while someone corrects a fact, is ordinary use.

Nothing was lost or leaked — no text disappears, no namespace crosses, no retired fact comes back. What was corrupted is traceability: the link, the receipts, and anything that walks that chain later.

## The fix

Keep the identity the write already returns. The snapshot diff is gone.

The `SupersededByAgent` fallback in `Revise` went with it, deliberately: it existed for "the replacement cannot be named", and with the ID coming from the committed write that branch is unreachable. Every return path of `putReturningFactKind` is either `Fact{}, err` or `f, nil`, and `f` always carries a generated ULID — so on success the ID is never empty. The constant itself is untouched and still serves `Retire` and the two recall paths, where it means what it says.

The write-before-retire ordering is unchanged. It is the contract, and the reason is on the method: a failure part-way through should leave the agent holding both values, not a retired fact and nothing in its place.

## Verification

The regression test forces the interleaving with an `OnPut` barrier, a deterministic clock and two victims. `OnPut` fires after the transaction commits, so the replacement is durable while `Revise` is held before its next step — a legitimate interleaving rather than a probabilistic race.

Against the unfixed tree the test fails with the returned ID byte-identical to the unrelated write's:

```
Revise returned "01M1QQYBX30X9C8G7VGW39T47X",
  want its committed replacement "01M1QQYBX29K99QYKXNEHBT92G"
  (unrelated "01M1QQYBX30X9C8G7VGW39T47X")
```

`go test -race -count=1 ./pkg/memory/...` green; builds and vet green on both modules.

## The doc comment was false, and structurally so

It claimed `Revise` was the single home for the semantics because the CLI and the benchmark both call it. The benchmark does. The CLI does not, and cannot: `Revise` is not in `cliStore` or the RPC surface, so a CLI talking to the daemon has no way to reach it. The comment now says what is actually true.

## Two twins stay out of scope

The same snapshot-diff inference lives in two more places, both left untouched here:

- `newFactID` in the MCP handler, behind `memory_reflect action=update`
- `newlyAddedID` in `cmd/graymatter/cmd_revise.go`

The MCP one carries the higher exposure of the three, since that tool is what agents actually call, while `Store.Revise` is reached only by the benchmark. Neither is a one-line change: both need a write that returns an ID across `cliStore` and `pkg/memory/rpc`, which is new surface on the daemon client and server. They share that enabling work and belong in one follow-up rather than being bolted onto a fix to the library method.

The CHANGELOG entry is scoped to `Store.Revise` for the same reason: claiming more would not be true yet.
