### PR TITLE
fix(hooks): scope the injection throttle to the session, not the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **New hook sessions no longer inherit another window's injection throttle.** Identical memory blocks remain suppressed within one identified session, while a different or unidentified session receives its own context; the best-effort cache is bounded to its most recently recorded sessions.
+
 - **`Store.Revise` keeps its own replacement identity.** A write interleaved in the same namespace could make the library method return that unrelated fact's ID and point its victims at it; the method now uses the identity returned by its own committed replacement write.
 
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.

--- a/cmd/graymatter/cmd_hooks_hardening_test.go
+++ b/cmd/graymatter/cmd_hooks_hardening_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,18 +130,17 @@ func TestHookState_CorruptedStateFileIsUnseen(t *testing.T) {
 	seedHookStoreFacts(t, "the rate limit is 60 requests per minute")
 
 	// Corrupt the state file after a first (injecting) call.
-	if _, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "rate limit"}); err != nil {
+	if _, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "corrupt-state", CWD: mustWorkdir(), Prompt: "rate limit"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(hookStatePath(dataDir), []byte("{corrupt"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	out, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "rate limit again"})
-	if err != nil {
-		t.Fatalf("corrupt state must not error the hook: %v", err)
-	}
-	if out == "" {
-		t.Error("corrupt state must be treated as unseen and inject again")
+	for _, content := range []string{"{corrupt", "null"} {
+		if err := os.WriteFile(hookStatePath(dataDir), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "corrupt-state", CWD: mustWorkdir(), Prompt: "rate limit again"})
+		if err != nil || out == "" {
+			t.Errorf("state %q: out=%q err=%v, want fail-open injection", content, out, err)
+		}
 	}
 }
 
@@ -151,7 +151,8 @@ func TestHookState_PerAgentKeys(t *testing.T) {
 	seedHookStoreFacts(t, "the rate limit is 60 requests per minute", "postgres runs on db-01")
 
 	agent := deriveAgentID(mustWorkdir())
-	if _, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "rate limit"}); err != nil {
+	const sessionID = "per-agent"
+	if _, err := dispatchHook("user-prompt", hookEventPayload{SessionID: sessionID, CWD: mustWorkdir(), Prompt: "rate limit"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -162,8 +163,61 @@ func TestHookState_PerAgentKeys(t *testing.T) {
 	if err := json.Unmarshal(data, &st); err != nil {
 		t.Fatalf("state file unreadable: %v", err)
 	}
-	if _, ok := st["last_block_sha256:"+agent]; !ok {
+	if _, ok := st[hookStateKey(agent, sessionID)]; !ok {
 		t.Fatalf("state file does not key the block per agent: %v", st)
+	}
+}
+
+func TestHookState_ThrottleIsPerSessionAndMissingIDFailsOpen(t *testing.T) {
+	withHooksEnv(t)
+	seedHookStoreFacts(t, "the rate limit is 60 requests per minute")
+	payload := hookEventPayload{SessionID: "session-a", CWD: mustWorkdir(), Prompt: "rate limit"}
+
+	first, err := dispatchHook("user-prompt", payload)
+	if err != nil || first == "" {
+		t.Fatalf("first session A turn: out=%q err=%v", first, err)
+	}
+	if again, err := dispatchHook("user-prompt", payload); err != nil || again != "" {
+		t.Fatalf("second session A turn: out=%q err=%v, want suppressed", again, err)
+	}
+	payload.SessionID = "session-b"
+	if other, err := dispatchHook("user-prompt", payload); err != nil || other == "" {
+		t.Fatalf("first session B turn: out=%q err=%v, want injected", other, err)
+	}
+	payload.SessionID = "session-a"
+	if again, err := dispatchHook("user-prompt", payload); err != nil || again != "" {
+		t.Fatalf("later session A turn: out=%q err=%v, want still suppressed", again, err)
+	}
+	payload.SessionID = ""
+	for turn := 1; turn <= 2; turn++ {
+		if out, err := dispatchHook("user-prompt", payload); err != nil || out == "" {
+			t.Fatalf("missing-session turn %d: out=%q err=%v, want fail-open injection", turn, out, err)
+		}
+	}
+}
+
+func TestHookState_BoundsMostRecentSessions(t *testing.T) {
+	withHooksEnv(t)
+	const extra = 5
+	for i := 0; i < hookStateSessionLimit+extra; i++ {
+		hookStateRecordBlock("bounded-agent", fmt.Sprintf("session-%02d", i), "same block")
+	}
+	data, err := os.ReadFile(hookStatePath(dataDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var st map[string]string
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatal(err)
+	}
+	if len(st) != hookStateSessionLimit {
+		t.Fatalf("state entries = %d, want cap %d", len(st), hookStateSessionLimit)
+	}
+	for i := 0; i < hookStateSessionLimit+extra; i++ {
+		_, present := st[hookStateKey("bounded-agent", fmt.Sprintf("session-%02d", i))]
+		if want := i >= extra; present != want {
+			t.Errorf("session %d present=%v, want %v", i, present, want)
+		}
 	}
 }
 

--- a/cmd/graymatter/cmd_hooks_test.go
+++ b/cmd/graymatter/cmd_hooks_test.go
@@ -708,7 +708,7 @@ func TestHookRun_UserPromptRecallAndThrottle(t *testing.T) {
 	}
 	_ = store.Close()
 
-	first, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "rate limit"})
+	first, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "throttle", CWD: mustWorkdir(), Prompt: "rate limit"})
 	if err != nil {
 		t.Fatalf("first recall: %v", err)
 	}
@@ -716,7 +716,7 @@ func TestHookRun_UserPromptRecallAndThrottle(t *testing.T) {
 		t.Errorf("first injection = %q, want the matching fact", first)
 	}
 
-	second, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "rate limit again please"})
+	second, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "throttle", CWD: mustWorkdir(), Prompt: "rate limit again please"})
 	if err != nil {
 		t.Fatalf("second recall: %v", err)
 	}
@@ -728,7 +728,7 @@ func TestHookRun_UserPromptRecallAndThrottle(t *testing.T) {
 		t.Errorf("state file missing: %v", err)
 	}
 
-	third, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "where does postgres run"})
+	third, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "throttle", CWD: mustWorkdir(), Prompt: "where does postgres run"})
 	if err != nil {
 		t.Fatalf("third recall: %v", err)
 	}
@@ -949,7 +949,7 @@ func TestHookRun_UserPrompt_SharedThrottle(t *testing.T) {
 	withHooksEnv(t)
 	seedSharedFacts(t, "Deploys freeze on Fridays: do not deploy to production on Fridays")
 
-	first, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "can I deploy on a Friday"})
+	first, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "shared-throttle", CWD: mustWorkdir(), Prompt: "can I deploy on a Friday"})
 	if err != nil {
 		t.Fatalf("first turn: %v", err)
 	}
@@ -957,7 +957,7 @@ func TestHookRun_UserPrompt_SharedThrottle(t *testing.T) {
 		t.Fatalf("first injection = %q, want the shared convention", first)
 	}
 
-	second, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "and what about Saturday"})
+	second, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "shared-throttle", CWD: mustWorkdir(), Prompt: "and what about Saturday"})
 	if err != nil {
 		t.Fatalf("second turn: %v", err)
 	}
@@ -974,7 +974,7 @@ func TestHookRun_UserPrompt_SharedThrottle(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = store.Close()
-	third, err := dispatchHook("user-prompt", hookEventPayload{CWD: mustWorkdir(), Prompt: "when does the ship window reopen"})
+	third, err := dispatchHook("user-prompt", hookEventPayload{SessionID: "shared-throttle", CWD: mustWorkdir(), Prompt: "when does the ship window reopen"})
 	if err != nil {
 		t.Fatalf("third turn: %v", err)
 	}

--- a/cmd/graymatter/hooks_run.go
+++ b/cmd/graymatter/hooks_run.go
@@ -13,6 +13,8 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,9 +49,12 @@ const (
 	// are small JSON objects; anything beyond this is not a hook payload.
 	hookStdinMax = 1 << 20
 
-	// hooksStateFile caches the last injected block's hash so an identical
-	// recall is not re-injected on consecutive turns.
+	// hooksStateFile caches recent injected block hashes so an identical recall
+	// is not re-injected on consecutive turns in the same session.
 	hooksStateFile = "state.json"
+
+	hookStateSessionLimit  = 32
+	hookStateSessionPrefix = "last_block_sha256:v2:"
 
 	// hooksRememberPrefix turns a prompt into a deterministic instant-save,
 	// no model in the loop.
@@ -280,8 +285,8 @@ func hookSessionStart(agent string, payload hookEventPayload) (string, error) {
 
 // hookUserPrompt either performs a deterministic remember (prompt starts with
 // "remember:" or "remember shared:") or a short recall from both namespaces.
-// Consecutive turns with identical recall output are suppressed via the state
-// file: the context is already there.
+// Consecutive turns with identical recall output in the same identified
+// session are suppressed via the state file: the context is already there.
 func hookUserPrompt(agent string, payload hookEventPayload) (string, error) {
 	prompt := strings.TrimSpace(payload.Prompt)
 	if prompt == "" {
@@ -337,10 +342,10 @@ func hookUserPrompt(agent string, payload hookEventPayload) (string, error) {
 	if degrade != nil {
 		hookLog(payload, "user-prompt", timeNow().Sub(start), "error", degrade.Error())
 	}
-	if hookStateSeenBlock(agent, block) {
-		return "", nil // identical context already injected on a recent turn
+	if hookStateSeenBlock(agent, payload.SessionID, block) {
+		return "", nil // identical context is already present in this session
 	}
-	hookStateRecordBlock(agent, block)
+	hookStateRecordBlock(agent, payload.SessionID, block)
 	return block, nil
 }
 
@@ -515,10 +520,11 @@ func hookStatePath(dataDir string) string {
 	return filepath.Join(dataDir, "hooks", hooksStateFile)
 }
 
-// hookStateSeenBlock reports whether this exact block was the last one
-// injected for this agent. Read failures mean "not seen" — a missing cache
-// only causes a redundant injection.
-func hookStateSeenBlock(agent, block string) bool {
+// hookStateSeenBlock fails open without a session ID to avoid false suppression.
+func hookStateSeenBlock(agent, sessionID, block string) bool {
+	if sessionID == "" {
+		return false
+	}
 	data, err := os.ReadFile(hookStatePath(dataDir))
 	if err != nil {
 		return false
@@ -527,12 +533,16 @@ func hookStateSeenBlock(agent, block string) bool {
 	if err := json.Unmarshal(data, &st); err != nil {
 		return false
 	}
-	return st[hookStateKey(agent)] == hookBlockHash(block)
+	_, hash, ok := hookStateEntry(st[hookStateKey(agent, sessionID)])
+	return ok && hash == hookBlockHash(block)
 }
 
-// hookStateRecordBlock stores the block's hash as the last injected one for
-// this agent. Best-effort: a failure to write only costs a duplicate injection.
-func hookStateRecordBlock(agent, block string) {
+// hookStateRecordBlock retains the latest block per identified session.
+// Best-effort failures only cost a duplicate injection.
+func hookStateRecordBlock(agent, sessionID, block string) {
+	if sessionID == "" {
+		return
+	}
 	path := hookStatePath(dataDir)
 	_ = os.MkdirAll(filepath.Dir(path), 0o755)
 
@@ -540,15 +550,54 @@ func hookStateRecordBlock(agent, block string) {
 	if data, err := os.ReadFile(path); err == nil {
 		_ = json.Unmarshal(data, &st) // keep other agents' entries when readable
 	}
-	st[hookStateKey(agent)] = hookBlockHash(block)
+	if st == nil {
+		st = map[string]string{}
+	}
+
+	type sessionEntry struct {
+		key      string
+		sequence uint64
+	}
+	key := hookStateKey(agent, sessionID)
+	entries := make([]sessionEntry, 0, len(st)+1)
+	var maxSequence uint64
+	for existingKey, value := range st {
+		if strings.HasPrefix(existingKey, hookStateSessionPrefix) {
+			sequence, _, ok := hookStateEntry(value)
+			if !ok || existingKey == key {
+				delete(st, existingKey)
+				continue
+			}
+			entries = append(entries, sessionEntry{existingKey, sequence})
+			if sequence > maxSequence {
+				maxSequence = sequence
+			}
+		}
+	}
+	sequence := maxSequence + 1
+	st[key] = fmt.Sprintf("%d:%s", sequence, hookBlockHash(block))
+	entries = append(entries, sessionEntry{key, sequence})
+	sort.Slice(entries, func(i, j int) bool { return entries[i].sequence > entries[j].sequence })
+	if len(entries) > hookStateSessionLimit {
+		for _, entry := range entries[hookStateSessionLimit:] {
+			delete(st, entry.key)
+		}
+	}
 	if out, err := json.Marshal(st); err == nil {
 		_ = os.WriteFile(path, out, 0o644)
 	}
 }
 
-// hookStateKey namespaces the hash per agent so two agents in one project do
-// not suppress each other's injections.
-func hookStateKey(agent string) string { return "last_block_sha256:" + agent }
+// The state-file path scopes the store; this key adds agent + opaque session.
+func hookStateKey(agent, sessionID string) string {
+	return hookStateSessionPrefix + agent + ":" + hookBlockHash(sessionID)
+}
+
+func hookStateEntry(value string) (uint64, string, bool) {
+	sequenceText, hash, ok := strings.Cut(value, ":")
+	sequence, err := strconv.ParseUint(sequenceText, 10, 64)
+	return sequence, hash, ok && err == nil && hash != ""
+}
 
 func hookBlockHash(block string) string {
 	sum := sha256.Sum256([]byte(block))


### PR DESCRIPTION
The throttle that stops an identical memory block being re-injected on consecutive turns remembered "already delivered" per agent, in a file that belongs to the store rather than to the window. Every session sharing that store and namespace shared the single entry, and `SessionStart` never invalidated it, so the code conflated *already delivered to this namespace* with *already present in this context*.

The old comment shows the dimension that was missed — it namespaced per agent "so two agents in one project do not suppress each other's injections". Two agents were considered. Two windows of the same agent were not.

The effect: a new session asks something an earlier window already asked, and gets nothing. `SessionStart` masks it only when the fact is recent enough to make its five-fact cut; an important old fact falls off the edge, which is the case persistent memory exists to cover.

## The fix

The key now carries the store (through the file's path), the agent, and the session. The session ID is hashed rather than stored verbatim: an opaque client identifier has no business sitting in plaintext in a file on disk.

Two decisions worth stating rather than leaving implicit:

**No session identity means no suppression.** A repeated block costs tokens; a missing block costs the fact. Both the read and the write path fail open.

**The file is bounded** to its most recently recorded sessions, evicted by a recorded sequence rather than by wall-clock time, so a machine's clock cannot strand entries.

Suppression inside one session is untouched — that is the feature, and it keeps working exactly as before.

## Verification

- A block delivered in session A is suppressed on A's next identical turn, delivered to session B, and still suppressed when A comes back.
- An unidentified session receives the block every time.
- The bound holds, verified by counting entries after recording more sessions than the cap and checking exactly which ones survived.
- The existing throttle tests keep their assertions unchanged; they gained the session ID the new contract requires as fixture data.
- Hook tests and the full CLI entrypoint package green under `-race`.

## Two notes

A state file containing the JSON literal `null` used to panic the hook: `json.Unmarshal` replaces the initialised map with a nil one without returning an error, and the next assignment panics. That violated the hooks' absolute contract of failing quietly, and it is fixed here as part of the same helper. The fail-open test now covers both syntactically invalid JSON and `null`; only the first was covered before.

Entries written by the previous key format stay in the file. They are never read and never rewritten, and there is at most one per agent, so the file stays bounded — but they are dead weight until something sweeps them.
