### PR TITLE
fix(benchmarks): align the hook latency contract with what the code and CI actually do

### DIFF
--- a/benchmarks/hook_latency/main.go
+++ b/benchmarks/hook_latency/main.go
@@ -1,5 +1,5 @@
-// hook_latency gates the Claude Code hooks' hot path against what the code
-// actually controls — never against shared-CI hardware.
+// hook_latency measures the Claude Code hooks' hot path against what the code
+// actually controls — never against shared-CI hardware. CI runs it report-only.
 //
 // Absolute wall-clock budgets are a hardware lottery: the same tree measured
 // p99 user-prompt 121 ms on a dev machine, 170 ms on macOS runners and
@@ -8,7 +8,7 @@
 // "checkpoint budget" failed there without a single line of Go being wrong.
 // Gating absolutes on shared runners gates the runner queue, not the code.
 //
-// What is gated instead is hardware-invariant:
+// What the benchmark checks instead is machine-relative:
 //
 //	1. recall delta     user-prompt p99 − pre-compact p99 ≤ 200 ms
 //	   (pre-compact measures this machine's spawn+connect+checkpoint cost;
@@ -17,14 +17,14 @@
 //	   tokenize or full decode shows up immediately)
 //	2. session-end delta session-end p99 − pre-compact p99 ≤ 200 ms
 //	   (the detached consolidation spawn must add almost nothing)
-//	3. scaling          in-process Recall(10k facts) ≤ 20 × Recall(500)
-//	   (catches algorithmic blowups — accidental O(n²) passes, full
-//	   re-decodes — independent of how fast the machine is)
+//	3. scaling          (Recall(10k)/Recall(500)) / (10000/500)
+//	   ≤ recallScalingMaxNormalized (1.0x is linear; catches algorithmic
+//	   blowups — accidental O(n²) passes, full re-decodes)
 //
 // Absolute numbers are still measured and printed: they are reference data
 // for humans, and the published reference-hardware figure (user-prompt p99
 // 121 ms on the dev machine that set the budgets) stays in the README beside
-// the deltas CI enforces.
+// the checks this benchmark reports. CI does not block merges on this result.
 //
 // The queries deliberately overlap the seeded corpus so every measured run
 // produces a distinct injected block — an unmatched query returns the same
@@ -33,7 +33,7 @@
 //
 // Usage:
 //
-//	go test ./benchmarks/hook_latency/   # the CI gate
+//	go test ./benchmarks/hook_latency/   # CI report-only measurement
 //	go run  ./benchmarks/hook_latency    # human-readable report
 package main
 
@@ -66,8 +66,8 @@ const (
 	// (deltas: ~90 ms dev, ~136 ms macOS, ~92 ms Windows) while a
 	// reintroduced double-tokenize (+40 ms) or a per-fact write txn
 	// (+500 ms) breach it decisively.
-	recallDeltaBudget      = 200 * time.Millisecond
-	sessionEndDeltaBudget  = 200 * time.Millisecond
+	recallDeltaBudget     = 200 * time.Millisecond
+	sessionEndDeltaBudget = 200 * time.Millisecond
 	// Scaling is normalized by the size ratio (Recall(10k)/Recall(500)) /
 	// (10000/500), so 1.0x is exactly linear. Measured on the reference
 	// machine: 1.17x (cache and GC make ten-thousand-item work slightly
@@ -322,6 +322,9 @@ func measureRecallScaling(dir string) (float64, error) {
 
 	if smallBest <= 0 {
 		return 0, fmt.Errorf("small recall measured %v", smallBest)
+	}
+	if bigBest <= 0 {
+		return 0, fmt.Errorf("big recall measured %v", bigBest)
 	}
 	return float64(bigBest) / float64(smallBest), nil
 }


### PR DESCRIPTION
`benchmarks/hook_latency/main.go` is the root-module twin of the measurement in `internal/benchsyn`. When that one was corrected, this file kept the same two defects — the scope of that change was the twin's test comment — plus a third the audit turned up.

**It called itself a CI gate.** The header presented the deltas as something CI enforces, and the usage block labelled the command "the CI gate". The workflow does the opposite on purpose: it excludes this measurement from the blocking step, with a comment explaining that timings on shared runners are noisy, and runs it in the bench job with `continue-on-error: true`.

**The scaling number was wrong.** The header stated the gate as `Recall(10k) ≤ 20 × Recall(500)`. The code gates the *normalized* ratio against `recallScalingMaxNormalized`, which is 2.5 — so the real allowance is 50×, not 20×. The header understated the tolerance by a factor of two and a half. It now states the formula and names the constant, so the text cannot drift from the value again.

**A zero duration passed as an excellent result.** `measureRecallScaling` validated the small store's timing and not the large one, so a zero for one of the fast recalls produced a ratio of 0 — and the gate only counts a value *above* the maximum as a breach. A missing measurement was being published as the best possible one. It is now a measurement error, and the caller already propagates it, so the run stops instead of reporting a perfect number.

That last one is not hypothetical. A normal run prints `Recall(10k) / Recall(500) = 1.5x raw · 0.07x of linear`, and raw ratios below 1 have been observed — this measurement operates near the clock's resolution floor.

## Verification

`go test ./benchmarks/hook_latency/` green with `OPENAI_API_KEY` set in the environment, still reporting the keyword embedder with no network. Builds and vet green.

One file. No constant changed, no CI configuration touched, and the twin's test comment is left as it was corrected.
