### PR TITLE
test(memory): stop the reconcile hook deadlocking the blocking CI step

### DIFF
--- a/pkg/memory/store_gaps_test.go
+++ b/pkg/memory/store_gaps_test.go
@@ -354,16 +354,30 @@ func TestVectorReconcileLoop_RetriesOnCadenceUntilShutdown(t *testing.T) {
 		Embedder:                &stubEmbedder{vec: []float32{1, 2}},
 		VectorBackend:           vs,
 		VectorReconcileInterval: 30 * time.Millisecond,
-		OnVectorIndexError:      func(string, string, error) { hooked <- struct{}{} },
+		OnVectorIndexError: func(string, string, error) {
+			select {
+			case hooked <- struct{}{}:
+			default:
+			}
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	// Put leaves the pending marker behind (the backend refuses), so the
-	// cadence tick — not the inline attempt — must be what reports next.
+	// Put leaves the pending marker behind when the backend refuses.
 	if err := s.Put(ctx, "loop", "planted after open, picked up by the tick"); err != nil {
 		t.Fatal(err)
+	}
+	// Discard every notification queued before Put returned. Any later event
+	// can only come from a cadence retry of the pending marker.
+drainQueued:
+	for {
+		select {
+		case <-hooked:
+		default:
+			break drainQueued
+		}
 	}
 
 	select {


### PR DESCRIPTION
`main` went red on `530c71a`: `pkg/memory` hit the 600s timeout on windows-latest/go1.26.7 with `TestVectorReconcileLoop_RetriesOnCadenceUntilShutdown` hung for eight minutes. No production code is involved — the test deadlocked itself.

The test installed a hook that sent to a channel with a **blocking** send, against a reconcile loop ticking every 30 ms and a vector backend that refuses every call. The hook fires from two places: the inline attempt inside the write path, and every turn of the background reconciler. The test consumed exactly one value from an eight-slot buffer.

So the buffer was not a fix; it was the width of the race window. Once the loop produced eight sends — 240 ms — every later sender blocked forever, and the one that blocked could be the test's own `Put`, which is why it never reached the `select` that would have drained the channel. `Close()` then waited on the loop's WaitGroup while the loop sat in a channel send. Nothing moved until the test binary died, taking the whole matrix cell with it.

The CI dump shows exactly that: the test's `Put` and the reconcile loop both parked in `chan send` on the same line, and the main goroutine waiting in `t.Run`.

This is not a defect in the callback contract. `OnVectorIndexError` is documented as needing to be safe for concurrent use, and it is invoked synchronously from the write path and the reconciler — a callback that blocks blocks its caller, which is the caller's own doing. Of the four tests in the package that use the hook, this was the only one sending to a channel; the other three count.

## The fix

The send is now non-blocking. The test needs to know a retry happened, not how many.

The second half is the assertion itself. Its comment claimed the cadence tick, not the inline attempt, is what reports next — but the backend fails inline too, so the single receive could just as easily have been satisfied by the write path's own notification. The test now discards everything queued before `Put` returned and waits for a later signal. Since the inline hook fires once per `Put` and that `Put` has returned, anything arriving after the drain can only be a cadence retry. The comment now says that instead.

The timeout, the `Close()` check and everything the test asserts are unchanged.

## Verification

Passing normally is not evidence here — the previous eleven runs on `main` passed. So the overflow was forced deliberately: a 1.5 s delay before the drain, roughly fifty ticks against an eight-slot buffer and six times the overflow that killed CI. Green three times under `-race`. Against the blocking send, that same scaffold hangs. The scaffold is not part of this change.

Also green: the test alone at `-count=20` under `-race`, and the full `pkg/memory` suite under the exact CI command, at 85.1% coverage against a 70% gate.

One test file, `+17/-3`, no production file in the diff.
