### PR TITLE
fix(memory): keep consolidation summary identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - **New hook sessions no longer inherit another window's injection throttle.** Identical memory blocks remain suppressed within one identified session, while a different or unidentified session receives its own context; the best-effort cache is bounded to its most recently recorded sessions.
 
+- **Consolidation keeps its own summary identity.** A concurrent write of identical summary text could make consumed facts point at the other writer's copy; consolidation now uses the identity returned by its own committed summary write.
+
 - **`Store.Revise` keeps its own replacement identity.** A write interleaved in the same namespace could make the library method return that unrelated fact's ID and point its victims at it; the method now uses the identity returned by its own committed replacement write.
 
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.

--- a/pkg/memory/consolidate.go
+++ b/pkg/memory/consolidate.go
@@ -390,9 +390,9 @@ func stripCodeFence(s string) string {
 //     exportable and auditable, and pruning collects them on the ordinary
 //     schedule. Zeroing their weight instead would let step 3 of this very
 //     cycle delete each receipt milliseconds after writing it.
-//   - The receipt points at the real summary fact's ID. Falling back to the
-//     generic SupersededByAgent marker on lookup failure would falsify the
-//     audit trail ("an agent retired this"), so failure aborts instead.
+//   - The receipt points at the exact summary fact this cycle wrote. Looking
+//     it up by text could select an identical fact from a concurrent writer
+//     and falsify the audit trail.
 //
 // It returns how many facts were actually tombstoned; per-fact write failures
 // are joined into the returned error without stopping the remaining ones.
@@ -418,15 +418,11 @@ func (s *Store) applyProposal(ctx context.Context, agentID string, batch []Fact,
 		consumed = append(consumed, f)
 	}
 
-	if err := s.Put(ctx, agentID, prop.Summary); err != nil {
+	summary, err := s.putReturningFact(ctx, agentID, prop.Summary)
+	if err != nil {
 		return 0, fmt.Errorf("put consolidation summary: %w", err)
 	}
-	summaryID := s.factIDByText(agentID, prop.Summary)
-	if summaryID == "" {
-		// Unreachable in practice — Put just stored exactly this text — but
-		// refusing here is what keeps every receipt resolvable.
-		return 0, fmt.Errorf("consolidation summary vanished after put; batch left untouched")
-	}
+	summaryID := summary.ID
 
 	var errs []error
 	applied := 0

--- a/pkg/memory/consolidate_test.go
+++ b/pkg/memory/consolidate_test.go
@@ -250,6 +250,66 @@ func TestConsolidate_SummarizeGuard(t *testing.T) {
 	}
 }
 
+func TestConsolidate_ConcurrentIdenticalPutKeepsSummaryIdentity(t *testing.T) {
+	s, cleanup := openTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	var tick atomic.Int64
+	s.now = func() time.Time { return time.Unix(tick.Add(1), 0).UTC() }
+
+	const agent = "concurrent-consolidators"
+	const summary = "the deploy window is Tuesday 02:00 UTC"
+	first, err := s.putReturningFact(ctx, agent, "deploys used to be Monday")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := s.putReturningFact(ctx, agent, "the deploy window moved once already")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	summaryCommitted := make(chan string)
+	releaseConsolidation := make(chan struct{})
+	var claimed atomic.Bool
+	s.cfg.OnPut = func(_, id string, _ time.Duration) {
+		if claimed.CompareAndSwap(false, true) {
+			summaryCommitted <- id
+			<-releaseConsolidation
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.applyProposal(ctx, agent, []Fact{first, second}, &consolidationProposal{
+			Summary:  summary,
+			Consumes: []string{first.ID, second.ID},
+		})
+		done <- err
+	}()
+
+	correctID := <-summaryCommitted // committed by this cycle; applyProposal is held before tombstoning
+	interloper, putErr := s.putReturningFact(ctx, agent, summary)
+	close(releaseConsolidation)
+	applyErr := <-done
+	if putErr != nil {
+		t.Fatal(putErr)
+	}
+	if interloper.ID == correctID {
+		t.Fatal("interleaved write reused the consolidation summary identity")
+	}
+	if applyErr != nil {
+		t.Fatal(applyErr)
+	}
+	for _, victim := range []Fact{first, second} {
+		stored, ok := s.loadFact(agent, victim.ID)
+		if !ok || stored.SupersededBy != correctID {
+			t.Errorf("victim %q: present=%v SupersededBy=%q, want %q (interloper %q)",
+				victim.ID, ok, stored.SupersededBy, correctID, interloper.ID)
+		}
+	}
+}
+
 // TestConsolidate_PutBeforeDelete verifies the atomic contract: when
 // summarisation succeeds, old facts are deleted; if Put fails, nothing is lost.
 // We test the happy path here (Put succeeds, batch is deleted).


### PR DESCRIPTION
## Summary

- Preserve the summary ID returned by the committed consolidation write.
- Keep consumed facts linked to the summary created by their own consolidation cycle.
- Cover concurrent identical-summary writes with a deterministic regression test.

## Validation

- Full pull-request CI across the supported operating systems and Go versions.