### PR TITLE
fix(mcp): keep reflect replacement identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - **`Store.Revise` keeps its own replacement identity.** A write interleaved in the same namespace could make the library method return that unrelated fact's ID and point its victims at it; the method now uses the identity returned by its own committed replacement write.
 
+- **`memory_reflect update` keeps its own replacement identity.** A concurrent write in the same `agent_id` could make the tool point the corrected fact's tombstone at an unrelated fact; the tool now uses the identity returned by its own committed replacement write over both direct and daemon-backed stores.
+
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
 
 - **Hook scope management and diagnostics now match their public contract.** `hooks uninstall --all` and `hooks doctor --all` cover project and global settings, while the unsafe `hooks install --all` form is rejected to prevent duplicate hook execution. `hooks doctor` reports an uninitialised store without creating it, including when settings are missing or malformed.

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -19,6 +19,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -379,6 +380,26 @@ type rememberBackend struct {
 
 func (b rememberBackend) Put(ctx context.Context, agentID, text string) error {
 	return b.mem.Remember(ctx, agentID, text)
+}
+
+// PutReturningFact preserves Remember semantics and returns the durable identity.
+func (b rememberBackend) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	store, ok := b.AdvancedStore.(interface {
+		PutReturningFact(context.Context, string, string) (memory.Fact, error)
+		LaunchAsyncConsolidate(string, memory.ConsolidateConfig)
+	})
+	if !ok {
+		return memory.Fact{}, errors.New("memory store does not expose PutReturningFact")
+	}
+	fact, err := store.PutReturningFact(ctx, agentID, text)
+	if err != nil {
+		return memory.Fact{}, fmt.Errorf("graymatter: remember: %w", err)
+	}
+	cfg := b.mem.Config()
+	if cfg.AsyncConsolidate {
+		store.LaunchAsyncConsolidate(agentID, cfg)
+	}
+	return fact, nil
 }
 
 func (b rememberBackend) PutShared(ctx context.Context, text string) error {

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -262,11 +262,11 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if text == "" {
 			return toolError("text (the corrected fact) is required for update")
 		}
-		before, err := s.backend.List(agentID)
+		facts, err := s.backend.List(agentID)
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
-		victim, ok := findByText(before, target)
+		victim, ok := findByText(facts, target)
 		if !ok {
 			return toolError(fmt.Sprintf("target fact not found: %q", target))
 		}
@@ -275,17 +275,23 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		// Write the correction before retiring what it corrects. The previous
 		// order zeroed the old fact's weight first, so a failing Remember left
 		// the agent with a retired fact and no replacement.
-		if err := s.backend.Remember(ctx, agentID, text); err != nil {
+		writer, ok := s.backend.(interface {
+			PutReturningFact(context.Context, string, string) (memory.Fact, error)
+		})
+		if !ok {
+			return toolError("add updated fact: backend does not expose identity-preserving writes")
+		}
+		replacement, err := writer.PutReturningFact(ctx, agentID, text)
+		if err != nil {
 			return toolError(fmt.Sprintf("add updated fact: %v", err))
+		}
+		if replacement.ID == "" {
+			return toolError("add updated fact: backend returned an empty fact identity")
 		}
 
 		// Point the tombstone at the replacement so the correction can be
 		// followed later, rather than only showing that something was retired.
-		replacementID := newFactID(s.backend, agentID, before)
-		if replacementID == "" {
-			replacementID = memory.SupersededByAgent
-		}
-		if err := s.supersedeFact(agentID, victim, replacementID); err != nil {
+		if err := s.supersedeFact(agentID, victim, replacement.ID); err != nil {
 			return toolError(fmt.Sprintf("supersede old fact: %v", err))
 		}
 		resultMsg = fmt.Sprintf("Updated fact for agent %q.", agentID)
@@ -388,28 +394,6 @@ func findByText(facts []memory.Fact, text string) (memory.Fact, bool) {
 		}
 	}
 	return memory.Fact{}, false
-}
-
-// newFactID returns the ID of the fact added since the `before` snapshot was
-// taken. Matching on identity rather than text keeps it correct when the new
-// fact repeats wording that is already stored. Returns "" if the new fact
-// cannot be identified — the caller falls back to a generic marker rather than
-// leaving the correction untombstoned.
-func newFactID(backend Backend, agentID string, before []memory.Fact) string {
-	after, err := backend.List(agentID)
-	if err != nil {
-		return ""
-	}
-	known := make(map[string]bool, len(before))
-	for _, f := range before {
-		known[f.ID] = true
-	}
-	for _, f := range after {
-		if !known[f.ID] {
-			return f.ID
-		}
-	}
-	return ""
 }
 
 // supersedeFact retires a fact: it is tombstoned so Recall skips it from

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -121,6 +121,30 @@ func (b *DirectBackend) Remember(ctx context.Context, agentID, text string) erro
 	return b.mem.Remember(ctx, agentID, text)
 }
 
+// PutReturningFact preserves Remember semantics and returns the durable identity.
+func (b *DirectBackend) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	advanced := b.mem.Advanced()
+	if advanced == nil {
+		return memory.Fact{}, errors.New("memory store not initialised")
+	}
+	store, ok := advanced.(interface {
+		PutReturningFact(context.Context, string, string) (memory.Fact, error)
+		LaunchAsyncConsolidate(string, memory.ConsolidateConfig)
+	})
+	if !ok {
+		return memory.Fact{}, errors.New("memory store does not expose PutReturningFact")
+	}
+	fact, err := store.PutReturningFact(ctx, agentID, text)
+	if err != nil {
+		return memory.Fact{}, fmt.Errorf("graymatter: remember: %w", err)
+	}
+	cfg := b.mem.Config()
+	if cfg.AsyncConsolidate {
+		store.LaunchAsyncConsolidate(agentID, cfg)
+	}
+	return fact, nil
+}
+
 func (b *DirectBackend) Recall(ctx context.Context, agentID, query string, topK int) ([]string, error) {
 	if topK <= 0 {
 		return b.mem.Recall(ctx, agentID, query)

--- a/cmd/graymatter/internal/mcp/supersede_test.go
+++ b/cmd/graymatter/internal/mcp/supersede_test.go
@@ -2,9 +2,12 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/daemon"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
@@ -16,9 +19,199 @@ import (
 // exactly what it meant to write.
 
 const (
-	staleFact = "Billing runs through Lemon Squeezy"
-	freshFact = "Billing runs through Polar"
+	staleFact       = "Billing runs through Lemon Squeezy"
+	freshFact       = "Billing runs through Polar"
+	interleavedFact = "The deployment window is Thursday at 03:00 UTC"
 )
+
+type reflectInterleavingBackend struct {
+	Backend
+	armed         bool
+	replacementID string
+	interloperID  string
+}
+
+func (b *reflectInterleavingBackend) Remember(ctx context.Context, agentID, text string) error {
+	if err := b.Backend.Remember(ctx, agentID, text); err != nil {
+		return err
+	}
+	if !b.armed {
+		return nil
+	}
+	b.replacementID = b.newestID(agentID, text)
+	return b.interleave(ctx, agentID)
+}
+
+// Keep this optional so the same test compiles against the pre-fix Backend:
+// that handler calls Remember above, while the fixed handler takes this path.
+func (b *reflectInterleavingBackend) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	writer, ok := b.Backend.(interface {
+		PutReturningFact(context.Context, string, string) (memory.Fact, error)
+	})
+	if !ok {
+		return memory.Fact{}, errors.New("backend does not expose PutReturningFact")
+	}
+	fact, err := writer.PutReturningFact(ctx, agentID, text)
+	if err != nil {
+		return memory.Fact{}, err
+	}
+	if b.armed {
+		b.replacementID = fact.ID
+		err = b.interleave(ctx, agentID)
+	}
+	return fact, err
+}
+
+func (b *reflectInterleavingBackend) interleave(ctx context.Context, agentID string) error {
+	b.armed = false
+	if err := b.Backend.Remember(ctx, agentID, interleavedFact); err != nil {
+		return err
+	}
+	b.interloperID = b.newestID(agentID, interleavedFact)
+	return nil
+}
+
+func (b *reflectInterleavingBackend) newestID(agentID, text string) string {
+	facts, err := b.Backend.List(agentID)
+	if err != nil {
+		return ""
+	}
+	for _, fact := range facts {
+		if fact.Text == text {
+			return fact.ID
+		}
+	}
+	return ""
+}
+
+func newDaemonReflectBackend(t *testing.T) Backend {
+	t.Helper()
+	dataDir := t.TempDir()
+
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- daemon.Run(daemon.RunOptions{
+			DataDir: dataDir,
+			Logf: func(format string, _ ...any) {
+				if strings.HasPrefix(format, "graymatter daemon ready:") {
+					close(ready)
+				}
+			},
+		})
+	}()
+	select {
+	case <-ready:
+	case err := <-done:
+		t.Fatalf("daemon exited before ready: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("daemon did not become ready")
+	}
+
+	client, err := daemon.ConnectNoSpawn(dataDir)
+	if err != nil {
+		t.Fatalf("connect daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Shutdown()
+		_ = client.Close()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("daemon shutdown: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("daemon did not stop")
+		}
+	})
+	return client
+}
+
+func TestMemoryReflect_UpdateKeepsItsReplacementIdentity(t *testing.T) {
+	// Keep both paths provider-free; the invalid scheme prevents an Ollama dial.
+	t.Setenv("GRAYMATTER_OLLAMA_URL", "disabled://")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("VOYAGE_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	tests := []struct {
+		name string
+		open func(*testing.T) Backend
+	}{
+		{
+			name: "direct",
+			open: func(t *testing.T) Backend {
+				s, _ := newTestServer(t)
+				return s.backend
+			},
+		},
+		{name: "daemon_rpc", open: newDaemonReflectBackend},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			base := tc.open(t)
+			const agentID = "concurrent-reflect"
+			const oldText = "The deployment window is Wednesday at 03:00 UTC"
+			const correctedText = "The deployment window is Tuesday at 03:00 UTC"
+
+			// Arm only after seeding: otherwise the interleaving is consumed by
+			// setup and the test does not exercise the vulnerable window.
+			if err := base.Remember(ctx, agentID, oldText); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			interleaved := &reflectInterleavingBackend{Backend: base, armed: true}
+			s := New(interleaved, "test")
+
+			res, err := s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+				"action": "update", "agent_id": agentID,
+				"target": oldText, "text": correctedText,
+			}))
+			if err != nil || res.IsError {
+				t.Fatalf("memory_reflect update: %v / %s", err, resultText(t, res))
+			}
+			if interleaved.replacementID == "" || interleaved.interloperID == "" {
+				t.Fatalf("interleaving IDs = replacement %q, interloper %q; want both", interleaved.replacementID, interleaved.interloperID)
+			}
+			if interleaved.replacementID == interleaved.interloperID {
+				t.Fatal("replacement and interloper reused one identity")
+			}
+
+			facts, err := base.List(agentID)
+			if err != nil {
+				t.Fatalf("list facts: %v", err)
+			}
+			byID := make(map[string]memory.Fact, len(facts))
+			for _, fact := range facts {
+				byID[fact.ID] = fact
+			}
+			// This guard proves the ID called "replacement" belongs to this
+			// invocation's corrected text before testing the tombstone.
+			if got := byID[interleaved.replacementID].Text; got != correctedText {
+				t.Fatalf("replacement ID carries %q, want corrected text %q", got, correctedText)
+			}
+			if got := byID[interleaved.interloperID].Text; got != interleavedFact {
+				t.Fatalf("interloper ID carries %q, want %q", got, interleavedFact)
+			}
+
+			var victim memory.Fact
+			for _, fact := range facts {
+				if fact.Text == oldText {
+					victim = fact
+					break
+				}
+			}
+			if victim.ID == "" {
+				t.Fatal("seeded victim not found")
+			}
+			if victim.SupersededBy != interleaved.replacementID {
+				t.Fatalf("victim SupersededBy=%q, want this call's replacement %q (interloper %q)",
+					victim.SupersededBy, interleaved.replacementID, interleaved.interloperID)
+			}
+		})
+	}
+}
 
 // TestMemoryReflect_UpdateRemovesOldFactFromSearch is the regression test for
 // the correction case: after an update, the superseded statement must not come

--- a/cmd/graymatter/store_handle.go
+++ b/cmd/graymatter/store_handle.go
@@ -79,6 +79,10 @@ type cliStore interface {
 	Close() error
 }
 
+type returningFactStore interface {
+	PutReturningFact(context.Context, string, string) (memory.Fact, error)
+}
+
 // daemonStore adapts *daemon.Client to cliStore (only the bits the client
 // doesn't already satisfy structurally).
 type daemonStore struct {
@@ -107,10 +111,16 @@ func (d daemonStore) ExportGraphObsidian(outDir string) error {
 // daemon is both reachable and speaking a compatible protocol.
 func (d daemonStore) Ready() error { return d.Ping() }
 
-// compile-time checks: both implementations satisfy cliStore.
+// compile-time checks: store implementations satisfy their internal contracts.
 var (
 	_ cliStore = daemonStore{}
 	_ cliStore = (*directStore)(nil)
+)
+
+var (
+	_ returningFactStore = daemonStore{}
+	_ returningFactStore = (*directStore)(nil)
+	_ returningFactStore = (*reconnectingStore)(nil)
 )
 
 // openStore is the single entry point commands use to reach the store.
@@ -182,6 +192,26 @@ func maybeWireKG(adv graymatter.AdvancedStore) error {
 
 func (d *directStore) Remember(ctx context.Context, agentID, text string) error {
 	return d.mem.Remember(ctx, agentID, text)
+}
+
+// PutReturningFact preserves Remember semantics and returns the durable identity.
+func (d *directStore) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	store, ok := d.store.(interface {
+		PutReturningFact(context.Context, string, string) (memory.Fact, error)
+		LaunchAsyncConsolidate(string, memory.ConsolidateConfig)
+	})
+	if !ok {
+		return memory.Fact{}, fmt.Errorf("memory store does not expose PutReturningFact")
+	}
+	fact, err := store.PutReturningFact(ctx, agentID, text)
+	if err != nil {
+		return memory.Fact{}, fmt.Errorf("graymatter: remember: %w", err)
+	}
+	cfg := d.mem.Config()
+	if cfg.AsyncConsolidate {
+		store.LaunchAsyncConsolidate(agentID, cfg)
+	}
+	return fact, nil
 }
 
 func (d *directStore) PutShared(ctx context.Context, text string) error {

--- a/cmd/graymatter/store_reconnect.go
+++ b/cmd/graymatter/store_reconnect.go
@@ -124,6 +124,20 @@ func (r *reconnectingStore) Remember(ctx context.Context, agentID, text string) 
 	return r.do(func(s cliStore) error { return s.Remember(ctx, agentID, text) })
 }
 
+func (r *reconnectingStore) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	var fact memory.Fact
+	err := r.do(func(s cliStore) error {
+		writer, ok := s.(returningFactStore)
+		if !ok {
+			return errors.New("store does not expose PutReturningFact")
+		}
+		var err error
+		fact, err = writer.PutReturningFact(ctx, agentID, text)
+		return err
+	})
+	return fact, err
+}
+
 func (r *reconnectingStore) PutShared(ctx context.Context, text string) error {
 	return r.do(func(s cliStore) error { return s.PutShared(ctx, text) })
 }

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -38,6 +38,7 @@ Starting with **v0.1.0**, GrayMatter follows a best-effort compatibility policy 
 |---|---|
 | `Open(cfg StoreConfig) (*Store, error)` | |
 | `(*Store).Put(ctx, agentID, text string) error` | |
+| `(*Store).PutReturningFact(ctx, agentID, text string) (Fact, error)` | Added after v0.18.0. Concrete `Store` capability, intentionally not part of `AdvancedStore`; returns the exact fact committed so callers can persist its identity without a post-write lookup |
 | `(*Store).Delete(agentID, factID string) error` | |
 | `(*Store).List(agentID string) ([]Fact, error)` | |
 | `(*Store).ListAgents() ([]string, error)` | |

--- a/pkg/memory/rpc/client.go
+++ b/pkg/memory/rpc/client.go
@@ -180,6 +180,15 @@ func (c *Client) Put(ctx context.Context, agentID, text string) error {
 	return c.call("Put", &PutRequest{AgentID: agentID, Text: text}, &PutResponse{})
 }
 
+// PutReturningFact writes a fact and returns the exact value committed remotely.
+func (c *Client) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	var resp PutReturningFactResponse
+	if err := c.call("PutReturningFact", &PutReturningFactRequest{AgentID: agentID, Text: text}, &resp); err != nil {
+		return memory.Fact{}, err
+	}
+	return resp.Fact, nil
+}
+
 // PutShared writes a fact to the __shared__ namespace.
 func (c *Client) PutShared(ctx context.Context, text string) error {
 	return c.call("PutShared", &PutSharedRequest{Text: text}, &PutSharedResponse{})

--- a/pkg/memory/rpc/server.go
+++ b/pkg/memory/rpc/server.go
@@ -44,6 +44,11 @@ type Backend interface {
 	PendingVectorCount() int
 }
 
+// returningFactWriter keeps the additive capability out of public Backend.
+type returningFactWriter interface {
+	PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error)
+}
+
 // compile-time guarantee that *memory.Store satisfies Backend.
 var _ Backend = (*memory.Store)(nil)
 
@@ -263,6 +268,21 @@ func (s *Server) Stop() {
 func (s *Server) Put(req *PutRequest, resp *PutResponse) error {
 	defer s.touch()
 	return s.backend.Put(context.Background(), req.AgentID, req.Text)
+}
+
+// PutReturningFact handles an identity-preserving write when supported.
+func (s *Server) PutReturningFact(req *PutReturningFactRequest, resp *PutReturningFactResponse) error {
+	defer s.touch()
+	writer, ok := s.backend.(returningFactWriter)
+	if !ok {
+		return errors.New("rpc: backend does not expose PutReturningFact")
+	}
+	fact, err := writer.PutReturningFact(context.Background(), req.AgentID, req.Text)
+	if err != nil {
+		return err
+	}
+	resp.Fact = fact
+	return nil
 }
 
 // PutShared handles a remote AdvancedStore.PutShared.

--- a/pkg/memory/rpc/wire.go
+++ b/pkg/memory/rpc/wire.go
@@ -32,6 +32,17 @@ type PutRequest struct {
 // PutResponse carries no data; presence indicates success.
 type PutResponse struct{}
 
+// PutReturningFactRequest is the wire form of Store.PutReturningFact.
+type PutReturningFactRequest struct {
+	AgentID string
+	Text    string
+}
+
+// PutReturningFactResponse carries the exact fact committed by the write.
+type PutReturningFactResponse struct {
+	Fact memory.Fact
+}
+
 // PutSharedRequest is the wire form of AdvancedStore.PutShared.
 type PutSharedRequest struct {
 	Text string

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -488,8 +488,15 @@ func (s *Store) PutConfident(ctx context.Context, agentID, text, confidence stri
 // This closes the crash window between the bbolt write and the vector write:
 // after a crash, reconcileVectors() at Open() drains the pending bucket.
 func (s *Store) Put(ctx context.Context, agentID, text string) error {
-	_, err := s.putReturningFact(ctx, agentID, text)
+	_, err := s.PutReturningFact(ctx, agentID, text)
 	return err
+}
+
+// PutReturningFact writes a fact and returns the exact value committed. It is
+// the identity-preserving counterpart to Put for callers that must persist a
+// reference to their own write without rediscovering it through List.
+func (s *Store) PutReturningFact(ctx context.Context, agentID, text string) (Fact, error) {
+	return s.putReturningFact(ctx, agentID, text)
 }
 
 // putReturningFact is the single durable write path: it commits the fact and


### PR DESCRIPTION
## Summary

- Preserve the replacement ID returned by `memory_reflect update`.
- Carry that identity through direct, daemon-backed, and reconnecting store paths.
- Cover concurrent same-namespace writes with deterministic regression tests.

## Validation

- Full pull-request CI across the supported operating systems and Go versions.