### PR TITLE
docs(release): version references to v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
-## [Unreleased]
+## [0.19.0] - 2026-09-05
 
 ### Added
 
@@ -25,11 +25,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - **New hook sessions no longer inherit another window's injection throttle.** Identical memory blocks remain suppressed within one identified session, while a different or unidentified session receives its own context; the best-effort cache is bounded to its most recently recorded sessions.
 
-- **Consolidation keeps its own summary identity.** A concurrent write of identical summary text could make consumed facts point at the other writer's copy; consolidation now uses the identity returned by its own committed summary write.
+- **`Store.Revise` now binds replacement lineage to the identity returned by its committed write.** The returned ID and every retired fact's `SupersededBy` reference stay anchored to that exact replacement, including when another write commits concurrently in the same namespace.
 
-- **`Store.Revise` keeps its own replacement identity.** A write interleaved in the same namespace could make the library method return that unrelated fact's ID and point its victims at it; the method now uses the identity returned by its own committed replacement write.
+- **Consolidation applies the same write-derived identity guarantee to summaries.** Consumed facts reference the exact summary created by their consolidation cycle, including when another writer commits identical summary text concurrently.
 
-- **`memory_reflect update` keeps its own replacement identity.** A concurrent write in the same `agent_id` could make the tool point the corrected fact's tombstone at an unrelated fact; the tool now uses the identity returned by its own committed replacement write over both direct and daemon-backed stores.
+- **`memory_reflect update` carries the guarantee across direct and daemon-backed stores.** The corrected fact's tombstone receives the exact ID returned by its replacement write, preserving revision lineage through overlapping writes in the same `agent_id`.
 
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
 

--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ scoop install graymatter
 
 ```bash
 # Linux (x86_64)
-curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.18.0/graymatter_0.18.0_linux_amd64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
+curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.19.0/graymatter_0.19.0_linux_amd64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.18.0/graymatter_0.18.0_darwin_arm64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
+curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.19.0/graymatter_0.19.0_darwin_arm64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
 
 # Windows (PowerShell)
-iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.18.0/graymatter_0.18.0_windows_amd64.zip -OutFile graymatter.zip
+iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.19.0/graymatter_0.19.0_windows_amd64.zip -OutFile graymatter.zip
 Expand-Archive graymatter.zip -DestinationPath .
 ```
 </details>
@@ -554,4 +554,4 @@ It is exactly one thing: **the missing stateful layer for Go agents**, packaged 
 
 ---
 
-*GrayMatter — v0.18.0 — August 2026*
+*GrayMatter — v0.19.0 — September 2026*

--- a/cmd/graymatter/go.mod
+++ b/cmd/graymatter/go.mod
@@ -36,7 +36,7 @@ toolchain go1.26.7
 
 require (
 	github.com/BurntSushi/toml v1.4.0
-	github.com/angelnicolasc/graymatter v0.18.0
+	github.com/angelnicolasc/graymatter v0.19.0
 	github.com/anthropics/anthropic-sdk-go v1.33.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4

--- a/server.json
+++ b/server.json
@@ -7,5 +7,5 @@
     "url": "https://github.com/angelnicolasc/graymatter",
     "source": "github"
   },
-  "version": "0.18.0"
+  "version": "0.19.0"
 }


### PR DESCRIPTION
## Summary

- publish the v0.19.0 changelog with the two newly enabled defaults and the complete 13-item reliability set
- update all README release assets and the displayed version, plus the server manifest
- advance the CLI module's core dependency to v0.19.0 as part of the release boundary

## Validation

- root module: `GOWORK=off go test ./...`, `go vet ./...`, `go build ./...`
- CLI module: `go test ./...`, `go vet ./...`, `go build ./...` against the repository root via the same temporary source replacement used by CI; no replacement remains in the commit
- release invariants: exactly four files, 13 `Fixed` entries, three double-versioned asset URLs, zero Go source changes, clean `git diff --check`