### PR TITLE
fix(mcp): apply reflection to every eligible exact match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
-- **`memory_reflect` now applies `forget`, `update`, `pin` and `unpin` to every eligible exact-text match in the selected namespace.** Forgetting a fact stored twice previously reported success while leaving a copy recallable; retired revision receipts now stay intact.
-
 - **New hook sessions no longer inherit another window's injection throttle.** Identical memory blocks remain suppressed within one identified session, while a different or unidentified session receives its own context; the best-effort cache is bounded to its most recently recorded sessions.
 
 - **`Store.Revise` now binds replacement lineage to the identity returned by its committed write.** The returned ID and every retired fact's `SupersededBy` reference stay anchored to that exact replacement, including when another write commits concurrently in the same namespace.
@@ -32,6 +30,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **Consolidation applies the same write-derived identity guarantee to summaries.** Consumed facts reference the exact summary created by their consolidation cycle, including when another writer commits identical summary text concurrently.
 
 - **`memory_reflect update` carries the guarantee across direct and daemon-backed stores.** The corrected fact's tombstone receives the exact ID returned by its replacement write, preserving revision lineage through overlapping writes in the same `agent_id`.
+
+- **`memory_reflect` now applies `forget`, `update`, `pin` and `unpin` to every eligible exact-text match in the selected namespace.** Forgetting a fact stored twice previously reported success while leaving a copy recallable; retired revision receipts now stay intact.
 
 - **Claude Code hooks now launch GrayMatter with structured `command` + `args`.** Installed hooks no longer pass executable paths through a shell, so paths containing spaces or shell metacharacters work unchanged on every platform with Claude Code 2.1.139 or later. Reinstalling migrates both the prior string form and the pre-marker legacy form; uninstall and drift detection continue to recognize them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **`memory_reflect` now applies `forget`, `update`, `pin` and `unpin` to every eligible exact-text match in the selected namespace.** Forgetting a fact stored twice previously reported success while leaving a copy recallable; retired revision receipts now stay intact.
+
 - **New hook sessions no longer inherit another window's injection throttle.** Identical memory blocks remain suppressed within one identified session, while a different or unidentified session receives its own context; the best-effort cache is bounded to its most recently recorded sessions.
 
 - **`Store.Revise` now binds replacement lineage to the identity returned by its committed write.** The returned ID and every retired fact's `SupersededBy` reference stay anchored to that exact replacement, including when another write commits concurrently in the same namespace.

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -266,11 +266,11 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
-		victim, ok := findByText(facts, target)
-		if !ok {
+		victims := findByText(facts, target, false)
+		if len(victims) == 0 {
 			return toolError(fmt.Sprintf("target fact not found: %q", target))
 		}
-		oldText = victim.Text
+		oldText = target
 
 		// Write the correction before retiring what it corrects. The previous
 		// order zeroed the old fact's weight first, so a failing Remember left
@@ -291,8 +291,10 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 
 		// Point the tombstone at the replacement so the correction can be
 		// followed later, rather than only showing that something was retired.
-		if err := s.supersedeFact(agentID, victim, replacement.ID); err != nil {
-			return toolError(fmt.Sprintf("supersede old fact: %v", err))
+		for _, victim := range victims {
+			if err := s.supersedeFact(agentID, victim, replacement.ID); err != nil {
+				return toolError(fmt.Sprintf("supersede old fact: %v", err))
+			}
 		}
 		resultMsg = fmt.Sprintf("Updated fact for agent %q.", agentID)
 
@@ -310,16 +312,18 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
-		victim, ok := findByText(facts, wanted)
-		if !ok {
+		victims := findByText(facts, wanted, false)
+		if len(victims) == 0 {
 			return toolError(fmt.Sprintf("target fact not found: %q", wanted))
 		}
-		oldText = victim.Text
+		oldText = wanted
 
 		// Nothing replaces this one, so the tombstone records that an agent
 		// decided to drop it.
-		if err := s.supersedeFact(agentID, victim, memory.SupersededByAgent); err != nil {
-			return toolError(fmt.Sprintf("suppress fact: %v", err))
+		for _, victim := range victims {
+			if err := s.supersedeFact(agentID, victim, memory.SupersededByAgent); err != nil {
+				return toolError(fmt.Sprintf("suppress fact: %v", err))
+			}
 		}
 		resultMsg = fmt.Sprintf("Fact suppressed for agent %q.", agentID)
 
@@ -350,23 +354,22 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 		if err != nil {
 			return toolError(fmt.Sprintf("list facts: %v", err))
 		}
-		victim, ok := findByText(facts, wanted)
-		if !ok {
+		// Pin only live copies. Unpin also clears retired copies, preserving
+		// the existing flag-cleanup behavior without changing their receipts.
+		victims := findByText(facts, wanted, action == "unpin")
+		if len(victims) == 0 {
 			return toolError(fmt.Sprintf("target fact not found: %q", wanted))
 		}
-		// Pinning a retired fact would promise permanence for something that
-		// is no longer live; unpinning one is harmless flag hygiene.
-		if action == "pin" && victim.IsSuperseded() {
-			return toolError("cannot pin a superseded fact")
-		}
-		victim.Pinned = action == "pin"
-		if victim.Pinned {
-			victim.PinnedAt = time.Now().UTC()
-		} else {
-			victim.PinnedAt = time.Time{}
-		}
-		if err := s.backend.UpdateFact(agentID, victim); err != nil {
-			return toolError(fmt.Sprintf("%s failed: %v", action, err))
+		for _, victim := range victims {
+			victim.Pinned = action == "pin"
+			if victim.Pinned {
+				victim.PinnedAt = time.Now().UTC()
+			} else {
+				victim.PinnedAt = time.Time{}
+			}
+			if err := s.backend.UpdateFact(agentID, victim); err != nil {
+				return toolError(fmt.Sprintf("%s failed: %v", action, err))
+			}
 		}
 		resultMsg = fmt.Sprintf("Fact %s for agent %q. Pinned facts are exempt from decay, pruning and summarisation.", action, agentID)
 
@@ -386,14 +389,18 @@ func (s *Server) handleMemoryReflect(ctx context.Context, req mcp.CallToolReques
 	return toolStructured(reflectResult{Action: action, Agent: agentID, OK: true}, resultMsg)
 }
 
-// findByText returns the first fact whose text matches exactly.
-func findByText(facts []memory.Fact, text string) (memory.Fact, bool) {
+// findByText selects every exact match from one List snapshot: acting on just
+// one duplicate leaves the same belief live or with inconsistent pin state.
+// Retired receipts are excluded unless unpin requests flag cleanup; later
+// writes of the same text are separate facts, outside this operation's snapshot.
+func findByText(facts []memory.Fact, text string, includeRetired bool) []memory.Fact {
+	var matches []memory.Fact
 	for _, f := range facts {
-		if f.Text == text {
-			return f, true
+		if f.Text == text && (includeRetired || !f.IsSuperseded()) {
+			matches = append(matches, f)
 		}
 	}
-	return memory.Fact{}, false
+	return matches
 }
 
 // supersedeFact retires a fact: it is tombstoned so Recall skips it from

--- a/cmd/graymatter/internal/mcp/handlers_test.go
+++ b/cmd/graymatter/internal/mcp/handlers_test.go
@@ -2,12 +2,16 @@ package mcp
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
 	graymatter "github.com/angelnicolasc/graymatter"
+	"github.com/angelnicolasc/graymatter/pkg/memory"
 )
 
 // newTestServer returns an MCP Server backed by a real Memory in a temp dir,
@@ -343,5 +347,175 @@ func TestMemoryReflect_UpdateSupersedes(t *testing.T) {
 	}
 	if w := factWeight(t, mem, "a1", newFact); w <= 0 {
 		t.Errorf("new fact weight = %v, want > 0", w)
+	}
+}
+
+func TestMemoryReflect_AllExactMatches(t *testing.T) {
+	t.Setenv("GRAYMATTER_OLLAMA_URL", "disabled://")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("VOYAGE_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	for _, transport := range []string{"direct", "daemon_rpc"} {
+		t.Run(transport, func(t *testing.T) {
+			for _, action := range []string{"forget", "update", "pin", "unpin", "update_same_text"} {
+				t.Run(action, func(t *testing.T) {
+					s, _ := newTestServer(t)
+					if transport == "daemon_rpc" {
+						s = New(newDaemonReflectBackend(t), "test")
+					}
+					ctx := context.Background()
+					const text = "the staging database is phoenix-staging.eu-west-1"
+					replacement := "the staging database is phoenix-staging.eu-west-2"
+					if action == "update_same_text" {
+						action, replacement = "update", text
+					}
+					for _, value := range []string{text, text, text, strings.ToUpper(text), text + " "} {
+						mustAdd(t, s, "duplicates", value)
+					}
+					mustAdd(t, s, "other", text)
+					before, err := s.backend.List("duplicates")
+					if err != nil || len(before) != 5 {
+						t.Fatalf("seed: %v / %d facts", err, len(before))
+					}
+					retiredID := ""
+					for i := range before {
+						f := &before[i]
+						if f.Text != text {
+							continue
+						}
+						if retiredID == "" {
+							retiredID, f.SupersededBy = f.ID, "historical-replacement"
+						}
+						f.Pinned = action == "unpin"
+						if f.Pinned {
+							f.PinnedAt = time.Unix(1, 0).UTC()
+						}
+						if err := s.backend.UpdateFact("duplicates", *f); err != nil {
+							t.Fatal(err)
+						}
+					}
+					res, err := s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+						"action": action, "agent_id": "duplicates", "target": text, "text": replacement,
+					}))
+					if err != nil || res.IsError {
+						t.Fatalf("%s: %v / %s", action, err, resultText(t, res))
+					}
+					after, err := s.backend.List("duplicates")
+					if err != nil {
+						t.Fatal(err)
+					}
+					byID := make(map[string]memory.Fact)
+					replacementID := ""
+					for _, f := range after {
+						byID[f.ID] = f
+						if f.Text == replacement && !f.IsSuperseded() {
+							if replacementID != "" {
+								t.Fatal("update wrote more than one replacement")
+							}
+							replacementID = f.ID
+						}
+					}
+					if action == "update" && replacementID == "" {
+						t.Fatal("update did not write a live replacement")
+					}
+					for _, f := range before {
+						want := f
+						if f.Text == text && (f.ID != retiredID || action == "unpin") {
+							switch action {
+							case "forget":
+								want.SupersededBy = memory.SupersededByAgent
+							case "update":
+								want.SupersededBy = replacementID
+							case "pin":
+								want.Pinned, want.PinnedAt = true, byID[f.ID].PinnedAt
+								if want.PinnedAt.IsZero() {
+									t.Error("pin omitted its timestamp")
+								}
+							case "unpin":
+								want.Pinned, want.PinnedAt = false, time.Time{}
+							}
+						}
+						if !reflect.DeepEqual(byID[f.ID], want) {
+							t.Errorf("fact %s: got %+v, want %+v", f.ID, byID[f.ID], want)
+						}
+					}
+					other, err := s.backend.List("other")
+					if err != nil || len(other) != 1 || other[0].IsSuperseded() || other[0].Pinned {
+						t.Fatalf("other namespace changed: %v / %+v", err, other)
+					}
+					got := search(t, s, "duplicates", "staging database phoenix")
+					if (action == "forget" || action == "update") && replacement != text && strings.Contains(got, ". "+text+"\n") {
+						t.Fatalf("retired text is still recallable: %s", got)
+					}
+					if action == "update" && !strings.Contains(got, replacement) {
+						t.Fatalf("replacement is not recallable: %s", got)
+					}
+					if action == "forget" || (action == "update" && replacement != text) {
+						res, err = s.handleMemoryReflect(ctx, reflectReq(map[string]any{
+							"action": action, "agent_id": "duplicates", "target": text, "text": replacement,
+						}))
+						if err != nil || !res.IsError {
+							t.Fatalf("retired-only target must fail: %v / %+v", err, res)
+						}
+						retried, err := s.backend.List("duplicates")
+						if err != nil || len(retried) != len(after) {
+							t.Fatalf("retired-only target created a fact: %v / %+v", err, retried)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+type reflectWriteFailureBackend struct {
+	*DirectBackend
+	updates         int
+	failReplacement bool
+}
+
+func (b *reflectWriteFailureBackend) UpdateFact(agentID string, f memory.Fact) error {
+	b.updates++
+	if b.updates == 2 {
+		return errors.New("injected write failure")
+	}
+	return b.DirectBackend.UpdateFact(agentID, f)
+}
+
+func (b *reflectWriteFailureBackend) PutReturningFact(ctx context.Context, agentID, text string) (memory.Fact, error) {
+	if b.failReplacement {
+		return memory.Fact{}, errors.New("injected replacement failure")
+	}
+	return b.DirectBackend.PutReturningFact(ctx, agentID, text)
+}
+
+func TestMemoryReflect_DuplicateWriteFailure(t *testing.T) {
+	for _, action := range []string{"forget", "update", "pin", "unpin", "replacement_failure"} {
+		t.Run(action, func(t *testing.T) {
+			s, _ := newTestServer(t)
+			mustAdd(t, s, "a1", staleFact)
+			mustAdd(t, s, "a1", staleFact)
+			backend := &reflectWriteFailureBackend{DirectBackend: s.backend.(*DirectBackend), failReplacement: action == "replacement_failure"}
+			s.backend = backend
+			if backend.failReplacement {
+				action = "update"
+			}
+			res, err := s.handleMemoryReflect(context.Background(), reflectReq(map[string]any{
+				"action": action, "agent_id": "a1", "target": staleFact, "text": freshFact,
+			}))
+			if err != nil || !res.IsError || !strings.Contains(resultText(t, res), "injected") {
+				t.Fatalf("write failure reported success: %v / %+v", err, res)
+			}
+			wantUpdates, wantFacts := 2, 2
+			if backend.failReplacement {
+				wantUpdates = 0
+			} else if action == "update" {
+				wantFacts++ // replacement must exist before any victim is retired
+			}
+			facts, err := backend.List("a1")
+			if err != nil || len(facts) != wantFacts || backend.updates != wantUpdates {
+				t.Fatalf("failure state: err=%v facts=%d updates=%d; want %d/%d", err, len(facts), backend.updates, wantFacts, wantUpdates)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`memory_reflect forget` could report success while another copy of the same text remained recallable. `update`, `pin` and `unpin` also silently selected just the first match. The handler now applies each action to every eligible exact-text match in the selected namespace.

Text is the tool's selector, so all matching live copies represent the requested belief. `forget` retires them all; `update` writes one replacement first and points every selected copy to its exact returned ID. Pinning every live copy gives that belief a consistent retention policy. `unpin` clears every matching copy, including retired ones, preserving the existing ability to clean up historical pins. Existing revision receipts are otherwise excluded. A target with only retired matches returns the existing not-found error for `update`, `forget` and `pin`, without writing a replacement or changing lineage; pinning retired-only text remains an error.

Parameters, schemas, success text and structured results are unchanged. No text normalization, storage migration or library API change is involved. Selection uses one `List` snapshot, so a subsequently added fact is outside the operation. Writes retain the existing per-fact persistence model: a storage failure can leave partial progress, and the tool returns an error rather than reporting success.

Validation:

- The deterministic regression failed on the original handler for all four actions, through direct and daemon/RPC backends; the corrected handler passes.
- Coverage includes duplicate live facts alongside retired receipts, exact matching without trimming or case folding, namespace isolation, one replacement with correct lineage, an update whose replacement repeats the original text, and retired-only targets. Injected replacement and second-write failures verify error reporting and write ordering.
- `go test -race -count=1 ./internal/mcp/...` passed on Windows. The CI CLI coverage package set passed with 78.1% total statement coverage against the 65% gate.
- Tests used the CI source replacement for the unpublished library tag; the temporary `go.mod` edit is excluded from the commit.
- The combined code from this PR and #115 passed builds, `go vet ./...`, and full `go test -race -count=1 ./...` runs in both modules under Go 1.26.7 on Linux in Docker, with test fixtures on a temporary memory filesystem. The branches merge cleanly.
- The complete [CI run](https://github.com/angelnicolasc/graymatter/actions/runs/34072949629) passed on this head, including Linux/macOS/Windows with Go 1.25 and 1.26.7, coverage union, version consistency and vulnerability checks.

An existing issue found during review remains separate: updating a vocabulary alias through MCP loses `KindAlias`, making the replacement injectable as ordinary memory. This was reproduced against the original handler and recorded for follow-up. Concurrent revisions of the same victim also retain their existing per-write behavior; this change adds no transaction or conflict-resolution protocol.
