### PR TITLE
fix: preserve checkpoint resume errors and distinguish missing history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test CLI module with coverage
         working-directory: cmd/graymatter
         shell: bash
-        run: go test -race -count=1 -timeout=300s -coverprofile=../../coverage-cli.out -covermode=atomic ./internal/harness/... ./internal/kg/... ./internal/server/... ./internal/plugin/... ./internal/mcp/... ./internal/daemon/... ./internal/httpauth/...
+        run: go test -race -count=1 -timeout=300s -coverprofile=../../coverage-cli.out -covermode=atomic ./internal/harness/... ./internal/kg/... ./internal/server/... ./internal/plugin/... ./internal/mcp/... ./internal/session/... ./internal/daemon/... ./internal/httpauth/...
 
       # The two coverage steps above enumerate packages explicitly, which left
       # the root package and the CLI entrypoint untested on every platform:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - **`checkpoint_resume` errors now reach strict MCP clients.** The invalid structured error payload made clients reject the entire response, leaving callers without a checkpoint or an explanation. Errors now carry text with `isError`, while successful results retain their schema and prose ([#117](https://github.com/angelnicolasc/graymatter/issues/117)).
+- **Checkpoint resume distinguishes absence from storage and daemon failures.** Only an empty checkpoint history reports not-found, including through the daemon; unreadable checkpoint records now fail explicitly instead of silently resuming older state or appearing absent ([#118](https://github.com/angelnicolasc/graymatter/issues/118)).
 
 ## [0.19.0] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **`checkpoint_resume` errors now reach strict MCP clients.** The invalid structured error payload made clients reject the entire response, leaving callers without a checkpoint or an explanation. Errors now carry text with `isError`, while successful results retain their schema and prose ([#117](https://github.com/angelnicolasc/graymatter/issues/117)).
+
 ## [0.19.0] - 2026-09-06
 
 ### Added

--- a/cmd/graymatter/internal/daemon/checkpoint_resume_test.go
+++ b/cmd/graymatter/internal/daemon/checkpoint_resume_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+	"github.com/angelnicolasc/graymatter/pkg/memory/rpc"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestCheckpointResumeErrorRoundTrip(t *testing.T) {
+	h := newDirectHost(t)
+	dir := t.TempDir()
+	ln, cleanup, err := rpc.Listen(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	srv := rpc.NewServer(nil, nil)
+	srv.RegisterExtra(HostServiceName, h)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(srv.Stop)
+	conn, err := rpc.Dial(rpc.DialOptions{DataDir: dir, PingOnDial: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{Client: conn}
+	t.Cleanup(func() { _ = c.Close() })
+
+	if cp, err := c.CheckpointResume("missing"); cp != nil || !errors.Is(err, session.ErrNoCheckpoint) {
+		t.Fatalf("missing = %+v, %v; want ErrNoCheckpoint after RPC", cp, err)
+	}
+	// The request shape sent by older clients must still receive an error,
+	// rather than mistaking the additive NotFound field for an empty success.
+	var legacy CheckpointResumeResponse
+	if err := c.hostCall("CheckpointResume", &struct{ AgentID string }{"missing"}, &legacy); err == nil {
+		t.Fatal("legacy resume request returned success for missing checkpoint")
+	}
+	saved, err := c.CheckpointSave(session.Checkpoint{AgentID: "a", State: map[string]any{"step": "two"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cp, err := c.CheckpointResume("a"); err != nil || cp.ID != saved.ID || cp.State["step"] != "two" {
+		t.Fatalf("saved = %+v, %v", cp, err)
+	}
+	if err := h.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("sessions")).Bucket([]byte("a")).Put([]byte("broken"), []byte("invalid JSON"))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cp, err := c.CheckpointResume("a"); cp != nil || err == nil || errors.Is(err, session.ErrNoCheckpoint) || !strings.Contains(err.Error(), "decode checkpoint") {
+		t.Fatalf("corrupt = %+v, %v; want decode error after RPC", cp, err)
+	}
+	if err := h.mem.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if cp, err := c.CheckpointResume("a"); cp != nil || err == nil || errors.Is(err, session.ErrNoCheckpoint) || !strings.Contains(err.Error(), bolt.ErrDatabaseNotOpen.Error()) {
+		t.Fatalf("closed database = %+v, %v; want storage error after RPC", cp, err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if cp, err := c.CheckpointResume("a"); cp != nil || err == nil || errors.Is(err, session.ErrNoCheckpoint) {
+		t.Fatalf("closed connection = %+v, %v; want transport error", cp, err)
+	}
+}

--- a/cmd/graymatter/internal/daemon/client.go
+++ b/cmd/graymatter/internal/daemon/client.go
@@ -172,8 +172,11 @@ func (c *Client) CheckpointLoad(agentID, checkpointID string) (*session.Checkpoi
 // CheckpointResume retrieves the most recent checkpoint for agentID.
 func (c *Client) CheckpointResume(agentID string) (*session.Checkpoint, error) {
 	var resp CheckpointResumeResponse
-	if err := c.hostCall("CheckpointResume", &CheckpointResumeRequest{AgentID: agentID}, &resp); err != nil {
+	if err := c.hostCall("CheckpointResume", &CheckpointResumeRequest{AgentID: agentID, ReportNotFound: true}, &resp); err != nil {
 		return nil, err
+	}
+	if resp.NotFound {
+		return nil, fmt.Errorf("%w for agent %q", session.ErrNoCheckpoint, agentID)
 	}
 	return &resp.CP, nil
 }

--- a/cmd/graymatter/internal/daemon/host.go
+++ b/cmd/graymatter/internal/daemon/host.go
@@ -42,7 +42,7 @@ type Host struct {
 	db      *bolt.DB
 	graph   *kg.Graph
 	adapter *kg.GraphAdapter
-	kgAuto  bool // whether consolidation feeds the graph (opts.KG / env / sentinel)
+	kgAuto  bool   // whether consolidation feeds the graph (opts.KG / env / sentinel)
 	stop    func() // initiates graceful daemon shutdown
 }
 
@@ -54,8 +54,16 @@ type CheckpointSaveResponse struct{ CP session.Checkpoint }
 type CheckpointLoadRequest struct{ AgentID, CheckpointID string }
 type CheckpointLoadResponse struct{ CP session.Checkpoint }
 
-type CheckpointResumeRequest struct{ AgentID string }
-type CheckpointResumeResponse struct{ CP session.Checkpoint }
+type CheckpointResumeRequest struct {
+	AgentID string
+	// Opt in so older clients still receive an RPC error on absence, never
+	// a successful response containing an empty checkpoint.
+	ReportNotFound bool
+}
+type CheckpointResumeResponse struct {
+	CP       session.Checkpoint
+	NotFound bool
+}
 
 type CheckpointListRequest struct{ AgentID string }
 type CheckpointListResponse struct{ CPs []session.Checkpoint }
@@ -118,8 +126,8 @@ type StoreOverviewResponse struct {
 	TotalLiveFacts   int            `json:"total_live_facts"`
 	TotalTombstones  int            `json:"total_tombstones"`
 	PendingVectorOps int            `json:"pending_vector_ops"`
-	Consolidations   int            `json:"consolidations"`    // cycles that applied at least one proposal
-	FactsConsumed    int            `json:"facts_consumed"`    // batch facts tombstoned by those proposals
+	Consolidations   int            `json:"consolidations"` // cycles that applied at least one proposal
+	FactsConsumed    int            `json:"facts_consumed"` // batch facts tombstoned by those proposals
 	Agents           []AgentSummary `json:"agents"`
 }
 
@@ -157,6 +165,10 @@ func (h *Host) CheckpointLoad(req *CheckpointLoadRequest, resp *CheckpointLoadRe
 // CheckpointResume retrieves the most recent checkpoint for an agent.
 func (h *Host) CheckpointResume(req *CheckpointResumeRequest, resp *CheckpointResumeResponse) error {
 	cp, err := session.Resume(h.db, req.AgentID)
+	if req.ReportNotFound && errors.Is(err, session.ErrNoCheckpoint) {
+		resp.NotFound = true
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -194,7 +195,10 @@ func (s *Server) handleCheckpointResume(ctx context.Context, req mcp.CallToolReq
 
 	cp, err := s.backend.CheckpointResume(agentID)
 	if err != nil {
-		return toolError(fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err))
+		if errors.Is(err, session.ErrNoCheckpoint) {
+			return toolError(fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err))
+		}
+		return toolError(fmt.Sprintf("checkpoint resume error: %v", err))
 	}
 
 	stateJSON, _ := json.MarshalIndent(cp.State, "", "  ")

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -194,12 +194,7 @@ func (s *Server) handleCheckpointResume(ctx context.Context, req mcp.CallToolReq
 
 	cp, err := s.backend.CheckpointResume(agentID)
 	if err != nil {
-		// Typed not-found: structuredContent carries the machine-readable
-		// error code, content keeps the historical prose, isError marks it.
-		notice := fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err)
-		res := mcp.NewToolResultStructured(checkpointResumeNotFound{Error: "not_found", AgentID: agentID}, notice)
-		res.IsError = true
-		return res, nil
+		return toolError(fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err))
 	}
 
 	stateJSON, _ := json.MarshalIndent(cp.State, "", "  ")

--- a/cmd/graymatter/internal/mcp/structured_contract_test.go
+++ b/cmd/graymatter/internal/mcp/structured_contract_test.go
@@ -3,7 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
 )
 
 // The issue-#76 acceptance requires that handler outputs validate against the
@@ -150,6 +154,42 @@ func TestCheckpointResumeNotFoundIsTextError(t *testing.T) {
 		t.Error("resume error must omit structuredContent on the wire")
 	}
 	if got, want := resultText(t, res), `no checkpoint found for agent "sc-ghost": no checkpoints for agent "sc-ghost"`; got != want {
+		t.Errorf("text = %q, want %q", got, want)
+	}
+}
+
+type resumeErrorBackend struct {
+	Backend
+	err error
+}
+
+func (b resumeErrorBackend) CheckpointResume(string) (*session.Checkpoint, error) {
+	return nil, b.err
+}
+
+func TestCheckpointResumeBackendFailure(t *testing.T) {
+	for _, cause := range []error{errors.New("memory store not initialised"), errors.New("daemon connection lost"), errors.New("no checkpoints")} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			s := New(resumeErrorBackend{err: cause}, "test")
+			res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{"agent_id": "sc-a"}))
+			if err != nil || !res.IsError || res.StructuredContent != nil {
+				t.Fatalf("result = %+v, error = %v; want text-only tool error", res, err)
+			}
+			if got, want := resultText(t, res), "checkpoint resume error: "+cause.Error(); got != want {
+				t.Errorf("text = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestCheckpointResumeWrappedAbsence(t *testing.T) {
+	cause := fmt.Errorf("backend: %w", session.ErrNoCheckpoint)
+	s := New(resumeErrorBackend{err: cause}, "test")
+	res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{"agent_id": "sc-a"}))
+	if err != nil || !res.IsError || res.StructuredContent != nil {
+		t.Fatalf("result = %+v, error = %v; want text-only tool error", res, err)
+	}
+	if got, want := resultText(t, res), `no checkpoint found for agent "sc-a": `+cause.Error(); got != want {
 		t.Errorf("text = %q, want %q", got, want)
 	}
 }

--- a/cmd/graymatter/internal/mcp/structured_contract_test.go
+++ b/cmd/graymatter/internal/mcp/structured_contract_test.go
@@ -15,8 +15,7 @@ import (
 //     subset of the schema properties and which contains every required
 //     schema property (omitempty fields may be absent, nothing else);
 //  3. every present key has the JSON type the schema declares;
-//  4. the not-found resume error is typed, isError, and its payload matches
-//     its own declared shape.
+//  4. resume errors set isError and omit structuredContent on the wire.
 
 type schemaShape struct {
 	Type       string `json:"type"`
@@ -126,7 +125,7 @@ func TestStructuredContentMatchesOutputSchema(t *testing.T) {
 	}
 }
 
-func TestCheckpointResumeNotFoundIsTypedError(t *testing.T) {
+func TestCheckpointResumeNotFoundIsTextError(t *testing.T) {
 	s, _ := newTestServer(t)
 	res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{"agent_id": "sc-ghost"}))
 	if err != nil {
@@ -136,15 +135,22 @@ func TestCheckpointResumeNotFoundIsTypedError(t *testing.T) {
 		t.Fatal("not-found must set isError")
 	}
 
-	payload, ok := res.StructuredContent.(checkpointResumeNotFound)
-	if !ok {
-		t.Fatalf("structured content is %T, want checkpointResumeNotFound", res.StructuredContent)
+	if res.StructuredContent != nil {
+		validateAgainstSchema(t, "checkpoint_resume", outputSchemas(t)["checkpoint_resume"], res.StructuredContent)
 	}
-	if payload.Error != "not_found" {
-		t.Errorf("error code = %q, want not_found", payload.Error)
+	raw, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if payload.AgentID != "sc-ghost" {
-		t.Errorf("agent_id = %q, want sc-ghost", payload.AgentID)
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := wire["structuredContent"]; present {
+		t.Error("resume error must omit structuredContent on the wire")
+	}
+	if got, want := resultText(t, res), `no checkpoint found for agent "sc-ghost": no checkpoints for agent "sc-ghost"`; got != want {
+		t.Errorf("text = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/graymatter/internal/mcp/types.go
+++ b/cmd/graymatter/internal/mcp/types.go
@@ -70,14 +70,6 @@ type checkpointResumeResult struct {
 	MessageCount int            `json:"message_count,omitempty"`
 }
 
-// checkpointResumeNotFound is the typed error payload for resume with no
-// checkpoint. It travels with isError=true and the same prose fallback the
-// tool has always returned, so nothing that matched the old error breaks.
-type checkpointResumeNotFound struct {
-	Error   string `json:"error"`
-	AgentID string `json:"agent_id"`
-}
-
 type reflectResult struct {
 	Action string `json:"action"`
 	Agent  string `json:"agent"`

--- a/cmd/graymatter/internal/session/checkpoint.go
+++ b/cmd/graymatter/internal/session/checkpoint.go
@@ -6,6 +6,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -15,6 +16,10 @@ import (
 )
 
 var bucketSessions = []byte("sessions")
+
+// ErrNoCheckpoint means the agent has no saved checkpoints. Storage and
+// decoding failures do not match this sentinel.
+var ErrNoCheckpoint = errors.New("no checkpoints")
 
 // Message is a single turn in an agent conversation, stored in a checkpoint.
 type Message struct {
@@ -77,7 +82,8 @@ func Load(db *bolt.DB, agentID, checkpointID string) (*Checkpoint, error) {
 	return &cp, nil
 }
 
-// List returns all checkpoints for agentID sorted newest first.
+// List returns all checkpoints for agentID sorted newest first. An unreadable
+// checkpoint is an error: silently skipping it could resume an older state.
 func List(db *bolt.DB, agentID string) ([]Checkpoint, error) {
 	var checkpoints []Checkpoint
 	err := db.View(func(tx *bolt.Tx) error {
@@ -86,10 +92,10 @@ func List(db *bolt.DB, agentID string) ([]Checkpoint, error) {
 		if b == nil {
 			return nil
 		}
-		return b.ForEach(func(_, v []byte) error {
+		return b.ForEach(func(k, v []byte) error {
 			var cp Checkpoint
 			if err := json.Unmarshal(v, &cp); err != nil {
-				return nil // skip corrupt
+				return fmt.Errorf("decode checkpoint %q for agent %q: %w", k, agentID, err)
 			}
 			checkpoints = append(checkpoints, cp)
 			return nil
@@ -111,7 +117,7 @@ func Latest(db *bolt.DB, agentID string) (*Checkpoint, error) {
 		return nil, err
 	}
 	if len(cps) == 0 {
-		return nil, fmt.Errorf("no checkpoints for agent %q", agentID)
+		return nil, fmt.Errorf("%w for agent %q", ErrNoCheckpoint, agentID)
 	}
 	return &cps[0], nil
 }

--- a/cmd/graymatter/internal/session/checkpoint_test.go
+++ b/cmd/graymatter/internal/session/checkpoint_test.go
@@ -1,0 +1,86 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+func checkpointDB(t *testing.T) *bolt.DB {
+	t.Helper()
+	db, err := bolt.Open(filepath.Join(t.TempDir(), "checkpoints.db"), 0o600, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket(bucketSessions)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestLatestRejectsCorruptCheckpoint(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "only corrupt", true: "valid and corrupt"}[mixed], func(t *testing.T) {
+			db := checkpointDB(t)
+			if mixed {
+				if _, err := Save(db, Checkpoint{AgentID: "a"}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := db.Update(func(tx *bolt.Tx) error {
+				b, err := tx.Bucket(bucketSessions).CreateBucketIfNotExists([]byte("a"))
+				if err != nil {
+					return err
+				}
+				return b.Put([]byte("broken"), []byte("invalid JSON"))
+			}); err != nil {
+				t.Fatal(err)
+			}
+			cp, err := Latest(db, "a")
+			var decodeErr *json.SyntaxError
+			if !errors.As(err, &decodeErr) || errors.Is(err, ErrNoCheckpoint) || cp != nil {
+				t.Fatalf("Latest = %+v, %v; corruption must prevent a successful resume", cp, err)
+			}
+		})
+	}
+}
+
+func TestResumeDistinguishesAbsenceFromStorageFailure(t *testing.T) {
+	db := checkpointDB(t)
+	if cp, err := Resume(db, "missing"); cp != nil || !errors.Is(err, ErrNoCheckpoint) {
+		t.Fatalf("missing agent = %+v, %v; want ErrNoCheckpoint", cp, err)
+	}
+	older, err := Save(db, Checkpoint{AgentID: "a", CreatedAt: time.Unix(1, 0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newer, err := Save(db, Checkpoint{AgentID: "a", CreatedAt: time.Unix(2, 0), State: map[string]any{"step": "two"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cp, err := Resume(db, "a"); err != nil || cp.ID != newer.ID || cp.State["step"] != "two" {
+		t.Fatalf("resume latest = %+v, %v", cp, err)
+	}
+	for _, cp := range []Checkpoint{older, newer} {
+		if err := Delete(db, "a", cp.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if cp, err := Resume(db, "a"); cp != nil || !errors.Is(err, ErrNoCheckpoint) {
+		t.Fatalf("empty agent bucket = %+v, %v; want ErrNoCheckpoint", cp, err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if cp, err := Resume(db, "a"); cp != nil || !errors.Is(err, bolt.ErrDatabaseNotOpen) || errors.Is(err, ErrNoCheckpoint) {
+		t.Fatalf("closed database = %+v, %v; want storage error", cp, err)
+	}
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -69,8 +69,8 @@ Every success result carries **both** a `structuredContent` object (declared in 
 // checkpoint_resume — structuredContent (state/message_count omitted when empty)
 { "id": "01JZK7...", "created_at": "2026-04-28T13:42:11Z", "state": { "task": "db migration", "step": 3 } }
 
-// checkpoint_resume with no checkpoint — isError=true, structuredContent:
-{ "error": "not_found", "agent_id": "migration-agent" }
+// checkpoint_resume with no checkpoint — isError=true, text content only:
+"no checkpoint found for agent \"migration-agent\": no checkpoints for agent \"migration-agent\""
 // (content keeps the historical "no checkpoint found for agent ..." prose)
 
 // memory_reflect — structuredContent

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -183,10 +183,11 @@ and when both spellings arrive `agent_id` wins.
 | `checkpoint_resume` | `{"id", "created_at", "state"?, "message_count"?}` | `state` is the persisted JSON object; keys marked `?` may be absent when empty |
 | `memory_reflect` | `{"action", "agent", "ok"}` | `ok` is `true` on success |
 
-One error carries a typed payload: `checkpoint_resume` with no checkpoint
-returns `isError: true` with `{"error": "not_found", "agent_id"}`. All other
-errors (validation, storage, unavailable features) are prose-only `isError`
-results and carry no machine-readable contract — their wording may change.
+Errors, including `checkpoint_resume` with no checkpoint, return text-only
+`isError: true` results without `structuredContent`; their wording may change.
+The former `{"error": "not_found", "agent_id"}` payload violated the declared
+success schema and was removed to prevent strict clients from rejecting the
+entire response (#117; [ADR-013 amendment](decisions/013-structured-tool-results.md)).
 
 ---
 

--- a/docs/decisions/013-structured-tool-results.md
+++ b/docs/decisions/013-structured-tool-results.md
@@ -57,6 +57,21 @@ This follows the [MCP tool error and output-schema contract](https://modelcontex
 structured results must match the advertised schema; execution errors can
 carry text with `isError=true`.
 
+### Error classification (#118)
+
+Only `errors.Is(err, session.ErrNoCheckpoint)` selects the historical absence
+notice. Other failures retain their cause under `checkpoint resume error`.
+Checkpoint reads propagate decoding errors instead of silently discarding
+records and presenting incomplete history as a successful or empty resume.
+
+The daemon transports absence in an opt-in `NotFound` response field, because
+`net/rpc` serializes returned errors as strings and loses sentinel identity.
+`ReportNotFound` in the request protects older clients: without the opt-in,
+absence still returns an RPC error. A new client talking to an older daemon
+preserves its untyped error as an operational failure; restarting that daemon
+with the updated binary enables typed absence. No error-text matching or
+general-purpose error protocol is introduced.
+
 ## Consequences
 
 - Success text-parsing clients are unaffected by construction: the text content is

--- a/docs/decisions/013-structured-tool-results.md
+++ b/docs/decisions/013-structured-tool-results.md
@@ -34,22 +34,37 @@ content:
 | `checkpoint_resume` | `{id, created_at, state?, message_count?}` |
 | `memory_reflect` | `{action, agent, ok: true}` |
 
-The one error type worth a contract gets a typed payload: `checkpoint_resume`
-with no checkpoint returns `isError=true` with
-`{error: "not_found", agent_id}` as structured content and the historical
-prose as text. Validation errors stay prose-only: they are misuse messages,
-not part of the result contract, and typing every misuse path would freeze
-error strings into a public schema for no consumer benefit.
+Errors return `isError=true` with text content only; `structuredContent` is
+reserved for successful results matching the declared output schema.
+
+### Amendment — 2026-09-07 (#117)
+
+The original typed `checkpoint_resume` error (`{error: "not_found", agent_id}`)
+did not conform to its success-only output schema. Strict clients rejected
+the entire response, hiding both the error code and the explanation. The
+original test checked that payload against a separate Go type instead of the
+schema advertised in `tools/list`, so it protected the defect.
+
+Resume errors now use the same text-only error helper as other tools. This
+removes the invalid structured error payload while retaining `isError`, the
+historical not-found prose, and the success schema and prose unchanged. It is
+an intentional compatibility correction: consumers of the old error object
+must use the tool-error result instead. Widening the success schema or turning
+absence into success would change a larger, working contract. A future
+machine-readable absence result requires a separate contract decision.
+
+This follows the [MCP tool error and output-schema contract](https://modelcontextprotocol.io/specification/2025-06-18/server/tools):
+structured results must match the advertised schema; execution errors can
+carry text with `isError=true`.
 
 ## Consequences
 
-- Text-parsing clients are unaffected by construction: the text content is
+- Success text-parsing clients are unaffected by construction: the text content is
   unchanged, and the contract tests pin it (`handlers_test.go` asserts the
   same strings as before the migration).
 - `structured_contract_test.go` validates every success payload against its
   declared schema (key subset, required presence, primitive/union type match)
-  and the typed not-found payload — schema drift or payload drift is a CI
-  failure.
+  and asserts that resume errors omit structured content on the wire.
 - The wire contract this decision introduces — tool names, parameter names,
   schemas, and `structuredContent` keys — is covered by the compatibility
   promise in [api-stability.md](../api-stability.md#mcp-wire-contract-stable-within-the-v0x-series).


### PR DESCRIPTION
Strict MCP clients rejected the entire `checkpoint_resume` error response because its structured payload did not match the advertised success schema. The same handler also described every backend failure as a missing checkpoint, encouraging callers to start over after storage or daemon failures.

Errors now return text with `isError=true` and omit `structuredContent`. The successful payload, output schema, input parameters and success prose are unchanged. ADR-013 records this compatibility correction: its original typed error was meant to distinguish absence, but violated the schema and the handler applied it to every failure. `TestCheckpointResumeNotFoundIsTypedError` intentionally becomes a regression against the actual advertised schema and the serialized error result.

`session.ErrNoCheckpoint`, checked with `errors.Is`, identifies only an empty history. The daemon carries that condition in an opt-in response so older clients still receive an RPC error instead of an empty successful checkpoint. A client connected to an older daemon preserves untyped failures as operational errors; restarting the daemon with the updated binary enables typed absence. No error-text matching or generic error framework is added.

Checkpoint decoding failures now propagate instead of silently skipping unreadable records and resuming incomplete history. This also affects checkpoint listing when its history contains invalid JSON; healthy histories and persisted data are unchanged. The additional scope is the daemon transport, regression coverage, CI's session-package gate, and the existing documentation of the removed error payload. Other tool handlers and `checkpoint_save` are unchanged. The existing `memory_reflect` destructive annotation concern remains separate from this change.

Validation:

- Both primary regressions failed before their respective fixes: invalid schema keys/missing required keys for #117, and operational failures labeled as absence for #118. The mixed valid/corrupt history regression also failed before the read fix.
- Windows/amd64, Go 1.26.1: full `go test -count=1 ./...` suites in both workspace modules; both builds; `go vet ./...` in both modules.
- Isolated Linux/amd64 containers, Go 1.26.7 and Go 1.25.14: `go test -race -count=1 -timeout=300s ./internal/mcp/... ./internal/session/... ./internal/daemon/...` passed with networking disabled.
- Real RPC coverage includes missing/saved/corrupt checkpoints, closed storage, closed connection and legacy request compatibility. Handler coverage includes wrapped absence and a same-text error that is not the sentinel.

Closes #117
Closes #118
