### PR TITLE
ci(docs): skip the preview upload for pull requests from forks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -59,8 +59,17 @@ jobs:
       # PRs: upload a version and get a preview URL without touching
       # production traffic. The URL lands in this step's log and in the
       # Worker's Version History.
+      #
+      # Skipped for pull requests from forks. GitHub withholds secrets from
+      # them by design, so wrangler would run with an empty token and fail:
+      # a red check on every outside contribution, for a reason that has
+      # nothing to do with the contribution. Install and Build still run, so
+      # a fork PR that breaks the site is still caught; only the upload is
+      # skipped. The fix is NOT pull_request_target: that runs with the base
+      # repository secrets while checking out the fork code, which is
+      # precisely how a preview job becomes a credential leak.
       - name: Preview (PR)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Every pull request from a fork got a red `docs` check that had nothing to do with the change in it.

The `Preview (PR)` step uploads a Cloudflare version and runs on any `pull_request` event. GitHub withholds secrets from fork pull requests by design, so on those the step ran `wrangler` with an empty `CLOUDFLARE_API_TOKEN` and failed every time. The contributor sees a failing check; the log says nothing about their work.

The upload is now conditional on the head repository being this one.

`Install` and `Build` still run on fork PRs, which is the part that carries signal: a change that breaks the site is still caught. Only the upload — the part that structurally cannot work without credentials — is skipped.

## What this is not

`pull_request_target` is the other way to make this green, and it is the wrong one. It runs the workflow in the base repository's context, with its secrets available, while checking out the fork's code. That is how a docs preview becomes a credential leak. The condition above exists so nobody reaches for it later.
