### PR TITLE
chore(release): prepare v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
-## [Unreleased]
+## [0.19.1] - 2026-09-07
 
 ### Fixed
 
 - **`checkpoint_resume` errors now reach strict MCP clients.** The invalid structured error payload made clients reject the entire response, leaving callers without a checkpoint or an explanation. Errors now carry text with `isError`, while successful results retain their schema and prose ([#117](https://github.com/angelnicolasc/graymatter/issues/117)).
 - **Checkpoint resume distinguishes absence from storage and daemon failures.** Only an empty checkpoint history reports not-found, including through the daemon; unreadable checkpoint records now fail explicitly instead of silently resuming older state or appearing absent ([#118](https://github.com/angelnicolasc/graymatter/issues/118)).
+- **Generated memory guidance now favors durable, actionable facts and explains pin/unpin correctly.** Unneeded facts no longer appear free, permanence comes from the user or project policy, and corrections use update/forget ([#113](https://github.com/angelnicolasc/graymatter/issues/113); thanks to [@bashrusakh](https://github.com/bashrusakh)).
 
 ## [0.19.0] - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ scoop install graymatter
 
 ```bash
 # Linux (x86_64)
-curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.19.0/graymatter_0.19.0_linux_amd64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
+curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.19.1/graymatter_0.19.1_linux_amd64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.19.0/graymatter_0.19.0_darwin_arm64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
+curl -sSL https://github.com/angelnicolasc/graymatter/releases/download/v0.19.1/graymatter_0.19.1_darwin_arm64.tar.gz | tar -xz && sudo mv graymatter /usr/local/bin/
 
 # Windows (PowerShell)
-iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.19.0/graymatter_0.19.0_windows_amd64.zip -OutFile graymatter.zip
+iwr https://github.com/angelnicolasc/graymatter/releases/download/v0.19.1/graymatter_0.19.1_windows_amd64.zip -OutFile graymatter.zip
 Expand-Archive graymatter.zip -DestinationPath .
 ```
 </details>
@@ -554,4 +554,4 @@ It is exactly one thing: **the missing stateful layer for Go agents**, packaged 
 
 ---
 
-*GrayMatter — v0.19.0 — September 2026*
+*GrayMatter — v0.19.1 — September 2026*

--- a/cmd/graymatter/go.mod
+++ b/cmd/graymatter/go.mod
@@ -36,7 +36,7 @@ toolchain go1.26.7
 
 require (
 	github.com/BurntSushi/toml v1.4.0
-	github.com/angelnicolasc/graymatter v0.19.0
+	github.com/angelnicolasc/graymatter v0.19.1
 	github.com/anthropics/anthropic-sdk-go v1.33.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4

--- a/server.json
+++ b/server.json
@@ -7,5 +7,5 @@
     "url": "https://github.com/angelnicolasc/graymatter",
     "source": "github"
   },
-  "version": "0.19.0"
+  "version": "0.19.1"
 }


### PR DESCRIPTION
Prepare v0.19.1 with the checkpoint recovery fixes from #119 and the generated memory guidance from #114. The changelog records the user-visible storage and pin/unpin correction and credits @bashrusakh.

The CLI's library requirement, registry metadata, README downloads, and release notes now agree on 0.19.1. This changes exactly four files and no Go source files.

Validation:
- Root library and standalone CLI builds passed in Docker with Go 1.26.7, using the existing temporary source-replace pattern in an isolated copy.
- The built CLI and MCP initialize response both report 0.19.1.
- All three download URLs use 0.19.1 in both the path and filename; the README footer and server metadata match.
- The only remaining previous GrayMatter version reference is the historical changelog heading. Node's unrelated 20.19.0 constraints remain unchanged.

Publication remains a separate signed-tag step after CI passes.
