### PR TITLE
feat(mcp): add opt-in checkpoint absence result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repo **is** a memory system for AI agents. While you work here, you also ge
 | `memory_alias` | `agent_id`, `term`, `equivalents` | — |
 | `memory_reflect` | `action` (`add`\|`update`\|`forget`\|`link`\|`pin`\|`unpin`), plus at least one of **`agent_id`** (canonical) or `agent` (deprecated alias; `agent_id` wins when both are set) | `text`, `target` (which one is required depends on `action` — for `forget`/`pin`/`unpin`, either works) |
 | `checkpoint_save` | `agent_id` | `state` (JSON-encoded string) |
-| `checkpoint_resume` | `agent_id` | — |
+| `checkpoint_resume` | `agent_id` | `on_missing` (enum `error`\|`empty`, default `error`) |
 
 > **`memory_reflect` uses `agent_id` (canonical since ADR-014).** The other six also use `agent_id`. The deprecated alias `agent` is still accepted for compatibility; `agent_id` wins when both are set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`checkpoint_resume` can report a missing checkpoint as a successful, machine-readable result.** A new optional `on_missing` parameter (`"error"` — the default — or `"empty"`) lets callers ask for `{"found": false, "agent_id"}` with `isError` unset instead of the historical not-found tool error, so a session-start check can tell "nothing saved yet" from a broken store without parsing prose. The output schema declares both result shapes under `oneOf`; storage and daemon failures stay prose-only errors in both modes. See [ADR-015](docs/decisions/015-checkpoint-resume-empty-result.md).
+
+### Notes
+
+- **`checkpoint_resume`'s default becomes `on_missing: "empty"` in v0.21.0.** v0.20.0 ships the option opt-in so callers can adopt and observe the additive result before absence stops being an error; `"error"` stays accepted as the legacy behaviour throughout v0.x. The flip is announced here and in `docs/api-stability.md`, per the prior-minor notice rule.
+
+---
+
 ## [0.19.1] - 2026-09-07
 
 ### Fixed

--- a/cmd/graymatter/cmd_init_instructions.go
+++ b/cmd/graymatter/cmd_init_instructions.go
@@ -114,7 +114,7 @@ guidance.
 | ~memory_reflect~ | ~action~, ~agent_id~ (or deprecated ~agent~ alias) | ~text~, ~target~ (required by action) |
 | ~ALIAS_TOOL~ | ~agent_id~, ~term~, ~equivalents~ | teach the store a vocabulary bridge |
 | ~checkpoint_save~ | ~agent_id~ | ~state~ |
-| ~checkpoint_resume~ | ~agent_id~ | |
+| ~checkpoint_resume~ | ~agent_id~ | ~on_missing~: ~"error"~ (default) or ~"empty"~ when no checkpoint is ordinary control flow |
 
 ~agent_id~ is canonical for every tool. ~memory_reflect~ also accepts the
 deprecated ~agent~ alias; ~agent_id~ wins when both are set.

--- a/cmd/graymatter/cmd_init_instructions_test.go
+++ b/cmd/graymatter/cmd_init_instructions_test.go
@@ -38,7 +38,7 @@ func TestUpsertInstructions_CreatesFile(t *testing.T) {
 		"| `memory_reflect` | `action`, `agent_id` (or deprecated `agent` alias) | `text`, `target` (required by action) |",
 		"| `memory_alias` | `agent_id`, `term`, `equivalents` | teach the store a vocabulary bridge |",
 		"| `checkpoint_save` | `agent_id` | `state` |",
-		"| `checkpoint_resume` | `agent_id` | |",
+		"| `checkpoint_resume` | `agent_id` | `on_missing`: `\"error\"` (default) or `\"empty\"` when no checkpoint is ordinary control flow |",
 		"`agent_id` is canonical for every tool",
 		"`agent_id` wins when both are set",
 	} {

--- a/cmd/graymatter/go.mod
+++ b/cmd/graymatter/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/mark3labs/mcp-go v0.58.0
 	github.com/muesli/termenv v0.16.0
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.8.1
 	go.etcd.io/bbolt v1.3.11
 	golang.org/x/sys v0.34.0
@@ -69,7 +70,6 @@ require (
 	github.com/philippgille/chromem-go v0.7.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/cmd/graymatter/go.sum
+++ b/cmd/graymatter/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/angelnicolasc/graymatter v0.16.4 h1:RE/R/4pxbwigZAA+82EzTey2EN/JBxfv2lfrSO+fviM=
-github.com/angelnicolasc/graymatter v0.16.4/go.mod h1:TFD49Czju0PNrOSarCGqWj/putjlAcfRjMjb4p4J5lo=
+github.com/angelnicolasc/graymatter v0.19.1 h1:U8jhkcYJf45c2xxnFvRMEG+TBRkqOUP1w73mib++HC8=
+github.com/angelnicolasc/graymatter v0.19.1/go.mod h1:TFD49Czju0PNrOSarCGqWj/putjlAcfRjMjb4p4J5lo=
 github.com/anthropics/anthropic-sdk-go v1.33.0 h1:YlRqiI+PjULBA8NoeeJmkXtFzTmjZZA7oFvpZ4FU7eU=
 github.com/anthropics/anthropic-sdk-go v1.33.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/cmd/graymatter/internal/mcp/checkpoint_resume_rpc_test.go
+++ b/cmd/graymatter/internal/mcp/checkpoint_resume_rpc_test.go
@@ -1,0 +1,192 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// These tests exercise checkpoint_resume end to end through the JSON-RPC
+// transport, because the contract they protect is client-visible: tools/list
+// advertises a union output schema (ADR-015), and a strict client validates
+// every structuredContent payload against it — including the absence result
+// that must serialize its false marker rather than an empty object. Handler
+// tests alone cannot prove that; the wire can.
+//
+// The union cannot be evaluated by the hand-rolled key/type checks in
+// structured_contract_test.go, so a real JSON Schema engine compiles the
+// advertised schema here. The helper is reused by that file.
+
+// checkpointResumeRPCResult is the subset of a tools/call response these
+// tests inspect. StructuredContent stays raw so an absent key (len 0) is
+// distinguishable from an empty object.
+type checkpointResumeRPCResult struct {
+	Result *struct {
+		Content           []json.RawMessage `json:"content"`
+		StructuredContent json.RawMessage   `json:"structuredContent"`
+		IsError           bool              `json:"isError"`
+	} `json:"result"`
+	Error json.RawMessage `json:"error"`
+}
+
+func callToolJSONRPC(t *testing.T, s *Server, id int, name string, arguments map[string]any) checkpointResumeRPCResult {
+	t.Helper()
+
+	request, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      name,
+			"arguments": arguments,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal tools/call: %v", err)
+	}
+	raw, err := json.Marshal(s.mcpSrv.HandleMessage(context.Background(), request))
+	if err != nil {
+		t.Fatalf("marshal tools/call response: %v", err)
+	}
+
+	var response checkpointResumeRPCResult
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode tools/call response: %v\n%s", err, raw)
+	}
+	if response.Result == nil {
+		t.Fatalf("tools/call returned no result: %s", raw)
+	}
+	return response
+}
+
+// compileOutputSchema compiles a raw outputSchema from tools/list so payloads
+// can be validated with real branch selection (oneOf requires it).
+func compileOutputSchema(t *testing.T, raw json.RawMessage) *jsonschema.Schema {
+	t.Helper()
+
+	var document any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatalf("decode output schema: %v\n%s", err, raw)
+	}
+	compiler := jsonschema.NewCompiler()
+	const location = "memory://tool-output.json"
+	if err := compiler.AddResource(location, document); err != nil {
+		t.Fatalf("add output schema: %v", err)
+	}
+	schema, err := compiler.Compile(location)
+	if err != nil {
+		t.Fatalf("compile output schema: %v\n%s", err, raw)
+	}
+	return schema
+}
+
+// validateStructuredAgainstToolSchema validates a handler payload against the
+// outputSchema the server actually advertises for toolName in tools/list.
+func validateStructuredAgainstToolSchema(t *testing.T, toolName string, structured any) {
+	t.Helper()
+
+	tool, ok := listToolDefs(t)[toolName]
+	if !ok {
+		t.Fatalf("%s: missing from tools/list", toolName)
+	}
+	schema := compileOutputSchema(t, tool.OutputSchema)
+
+	raw, err := json.Marshal(structured)
+	if err != nil {
+		t.Fatalf("%s: marshal structured content: %v", toolName, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("%s: structured content is not a JSON object: %v", toolName, err)
+	}
+	if err := schema.Validate(payload); err != nil {
+		t.Fatalf("%s: structured content failed outputSchema validation: %v\npayload: %s", toolName, err, raw)
+	}
+}
+
+func TestCheckpointResumeJSONRPCWireContract(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	resume, ok := listToolDefs(t)["checkpoint_resume"]
+	if !ok {
+		t.Fatal("checkpoint_resume missing from tools/list")
+	}
+	schema := compileOutputSchema(t, resume.OutputSchema)
+
+	// Found: the success payload validates as the checkpoint branch.
+	save := callToolJSONRPC(t, s, 1, "checkpoint_save", map[string]any{
+		"agent_id": "rpc-agent",
+		"state":    `{"step":3}`,
+	})
+	if save.Result.IsError {
+		t.Fatalf("checkpoint_save failed: %+v", save.Result)
+	}
+
+	success := callToolJSONRPC(t, s, 2, "checkpoint_resume", map[string]any{"agent_id": "rpc-agent"})
+	if success.Result.IsError {
+		t.Fatalf("checkpoint_resume success path returned an error: %+v", success.Result)
+	}
+	var successPayload map[string]any
+	if err := json.Unmarshal(success.Result.StructuredContent, &successPayload); err != nil {
+		t.Fatalf("decode success structuredContent: %v", err)
+	}
+	if successPayload["id"] == nil || successPayload["created_at"] == nil {
+		t.Fatalf("success result missing required fields: %v", successPayload)
+	}
+	if err := schema.Validate(successPayload); err != nil {
+		t.Fatalf("success payload failed union schema (branch 1): %v", err)
+	}
+
+	// Default absence: text-only isError, no structuredContent key at all.
+	missing := callToolJSONRPC(t, s, 3, "checkpoint_resume", map[string]any{"agent_id": "rpc-ghost"})
+	if !missing.Result.IsError {
+		t.Fatalf("missing checkpoint should set isError: %+v", missing.Result)
+	}
+	if len(missing.Result.StructuredContent) != 0 {
+		t.Fatalf("default absence must omit structuredContent on the wire, got %s", missing.Result.StructuredContent)
+	}
+
+	// on_missing="empty": successful, machine-readable absence (branch 2).
+	empty := callToolJSONRPC(t, s, 4, "checkpoint_resume", map[string]any{
+		"agent_id":   "rpc-ghost",
+		"on_missing": "empty",
+	})
+	if empty.Result.IsError {
+		t.Fatalf("on_missing=empty absence returned an error: %+v", empty.Result)
+	}
+	var emptyPayload map[string]any
+	if err := json.Unmarshal(empty.Result.StructuredContent, &emptyPayload); err != nil {
+		t.Fatalf("decode absence structuredContent: %v", err)
+	}
+	found, present := emptyPayload["found"]
+	if !present {
+		t.Fatalf("absence payload dropped the found marker (omitempty regression): %s", empty.Result.StructuredContent)
+	}
+	if found != false {
+		t.Fatalf("absence payload found = %v, want false", found)
+	}
+	if emptyPayload["agent_id"] != "rpc-ghost" {
+		t.Fatalf("absence payload agent_id = %v, want rpc-ghost", emptyPayload["agent_id"])
+	}
+	if err := schema.Validate(emptyPayload); err != nil {
+		t.Fatalf("absence payload failed union schema (branch 2): %v", err)
+	}
+	if raw := string(empty.Result.StructuredContent); !strings.Contains(raw, `"found":false`) {
+		t.Fatalf("absence structuredContent = %s, want the false marker on the wire", raw)
+	}
+
+	// Invalid values are rejected before the backend is consulted.
+	bad := callToolJSONRPC(t, s, 5, "checkpoint_resume", map[string]any{
+		"agent_id":   "rpc-ghost",
+		"on_missing": "sometimes",
+	})
+	if !bad.Result.IsError {
+		t.Fatalf("invalid on_missing should error: %+v", bad.Result)
+	}
+	if len(bad.Result.StructuredContent) != 0 {
+		t.Fatalf("invalid on_missing carried structuredContent: %s", bad.Result.StructuredContent)
+	}
+}

--- a/cmd/graymatter/internal/mcp/checkpoint_resume_rpc_test.go
+++ b/cmd/graymatter/internal/mcp/checkpoint_resume_rpc_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -116,7 +117,9 @@ func TestCheckpointResumeJSONRPCWireContract(t *testing.T) {
 	}
 	schema := compileOutputSchema(t, resume.OutputSchema)
 
-	// Found: the success payload validates as the checkpoint branch.
+	// Found: every mode returns the ordinary checkpoint payload when a checkpoint
+	// exists. on_missing affects absence only; the explicit modes must not select
+	// the found:false branch.
 	save := callToolJSONRPC(t, s, 1, "checkpoint_save", map[string]any{
 		"agent_id": "rpc-agent",
 		"state":    `{"step":3}`,
@@ -125,23 +128,69 @@ func TestCheckpointResumeJSONRPCWireContract(t *testing.T) {
 		t.Fatalf("checkpoint_save failed: %+v", save.Result)
 	}
 
-	success := callToolJSONRPC(t, s, 2, "checkpoint_resume", map[string]any{"agent_id": "rpc-agent"})
-	if success.Result.IsError {
-		t.Fatalf("checkpoint_resume success path returned an error: %+v", success.Result)
+	defaultSuccess := callToolJSONRPC(t, s, 2, "checkpoint_resume", map[string]any{"agent_id": "rpc-agent"})
+	if defaultSuccess.Result.IsError {
+		t.Fatalf("checkpoint_resume default success path returned an error: %+v", defaultSuccess.Result)
 	}
-	var successPayload map[string]any
-	if err := json.Unmarshal(success.Result.StructuredContent, &successPayload); err != nil {
-		t.Fatalf("decode success structuredContent: %v", err)
+	var baselinePayload map[string]any
+	if err := json.Unmarshal(defaultSuccess.Result.StructuredContent, &baselinePayload); err != nil {
+		t.Fatalf("decode default success structuredContent: %v", err)
 	}
-	if successPayload["id"] == nil || successPayload["created_at"] == nil {
-		t.Fatalf("success result missing required fields: %v", successPayload)
+	if baselinePayload["id"] == nil || baselinePayload["created_at"] == nil {
+		t.Fatalf("default success result missing required fields: %v", baselinePayload)
 	}
-	if err := schema.Validate(successPayload); err != nil {
-		t.Fatalf("success payload failed union schema (branch 1): %v", err)
+	state, ok := baselinePayload["state"].(map[string]any)
+	if !ok {
+		t.Fatalf("default success result state = %T, want object: %v", baselinePayload["state"], baselinePayload)
+	}
+	if step, ok := state["step"].(float64); !ok || step != 3 {
+		t.Fatalf("default success result state.step = %v, want 3", state["step"])
+	}
+	for _, absenceKey := range []string{"found", "agent_id"} {
+		if _, present := baselinePayload[absenceKey]; present {
+			t.Fatalf("default success result carried absence key %q: %v", absenceKey, baselinePayload)
+		}
+	}
+	if err := schema.Validate(baselinePayload); err != nil {
+		t.Fatalf("default success payload failed union schema (checkpoint branch): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		id   int
+		args map[string]any
+	}{
+		{"explicit error", 3, map[string]any{"agent_id": "rpc-agent", "on_missing": "error"}},
+		{"explicit empty", 4, map[string]any{"agent_id": "rpc-agent", "on_missing": "empty"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			success := callToolJSONRPC(t, s, tc.id, "checkpoint_resume", tc.args)
+			if success.Result.IsError {
+				t.Fatalf("checkpoint_resume success path returned an error: %+v", success.Result)
+			}
+			var successPayload map[string]any
+			if err := json.Unmarshal(success.Result.StructuredContent, &successPayload); err != nil {
+				t.Fatalf("decode success structuredContent: %v", err)
+			}
+			if successPayload["id"] == nil || successPayload["created_at"] == nil {
+				t.Fatalf("success result missing required fields: %v", successPayload)
+			}
+			for _, absenceKey := range []string{"found", "agent_id"} {
+				if _, present := successPayload[absenceKey]; present {
+					t.Fatalf("success result carried absence key %q: %v", absenceKey, successPayload)
+				}
+			}
+			if err := schema.Validate(successPayload); err != nil {
+				t.Fatalf("success payload failed union schema (checkpoint branch): %v", err)
+			}
+			if !reflect.DeepEqual(successPayload, baselinePayload) {
+				t.Fatalf("success payload = %v, want default payload %v", successPayload, baselinePayload)
+			}
+		})
 	}
 
 	// Default absence: text-only isError, no structuredContent key at all.
-	missing := callToolJSONRPC(t, s, 3, "checkpoint_resume", map[string]any{"agent_id": "rpc-ghost"})
+	missing := callToolJSONRPC(t, s, 5, "checkpoint_resume", map[string]any{"agent_id": "rpc-ghost"})
 	if !missing.Result.IsError {
 		t.Fatalf("missing checkpoint should set isError: %+v", missing.Result)
 	}
@@ -150,7 +199,7 @@ func TestCheckpointResumeJSONRPCWireContract(t *testing.T) {
 	}
 
 	// on_missing="empty": successful, machine-readable absence (branch 2).
-	empty := callToolJSONRPC(t, s, 4, "checkpoint_resume", map[string]any{
+	empty := callToolJSONRPC(t, s, 6, "checkpoint_resume", map[string]any{
 		"agent_id":   "rpc-ghost",
 		"on_missing": "empty",
 	})
@@ -179,7 +228,7 @@ func TestCheckpointResumeJSONRPCWireContract(t *testing.T) {
 	}
 
 	// Invalid values are rejected with a text-only error result.
-	bad := callToolJSONRPC(t, s, 5, "checkpoint_resume", map[string]any{
+	bad := callToolJSONRPC(t, s, 7, "checkpoint_resume", map[string]any{
 		"agent_id":   "rpc-ghost",
 		"on_missing": "sometimes",
 	})

--- a/cmd/graymatter/internal/mcp/checkpoint_resume_rpc_test.go
+++ b/cmd/graymatter/internal/mcp/checkpoint_resume_rpc_test.go
@@ -178,7 +178,7 @@ func TestCheckpointResumeJSONRPCWireContract(t *testing.T) {
 		t.Fatalf("absence structuredContent = %s, want the false marker on the wire", raw)
 	}
 
-	// Invalid values are rejected before the backend is consulted.
+	// Invalid values are rejected with a text-only error result.
 	bad := callToolJSONRPC(t, s, 5, "checkpoint_resume", map[string]any{
 		"agent_id":   "rpc-ghost",
 		"on_missing": "sometimes",

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -193,9 +193,10 @@ func (s *Server) handleCheckpointResume(ctx context.Context, req mcp.CallToolReq
 		return toolError("agent_id is required")
 	}
 
-	// on_missing is an input enum in the schema, but mcp-go does not enforce
-	// enums at call time, so the handler validates it explicitly. Missing means
-	// the historical behaviour; the types are checked before the value so a
+	// on_missing is an input enum in the schema; mcp-go can enforce it with the
+	// server.WithInputSchemaValidation option, but this server does not enable
+	// that option, so the handler validates it explicitly. Missing means the
+	// historical behaviour; the types are checked before the value so a
 	// non-string argument cannot slip through as the default.
 	onMissing := "error"
 	if raw, present := args["on_missing"]; present {

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -193,11 +193,30 @@ func (s *Server) handleCheckpointResume(ctx context.Context, req mcp.CallToolReq
 		return toolError("agent_id is required")
 	}
 
+	// on_missing is an input enum in the schema, but mcp-go does not enforce
+	// enums at call time, so the handler validates it explicitly. Missing means
+	// the historical behaviour; the types are checked before the value so a
+	// non-string argument cannot slip through as the default.
+	onMissing := "error"
+	if raw, present := args["on_missing"]; present {
+		value, ok := raw.(string)
+		if !ok || (value != "error" && value != "empty") {
+			return toolError(`on_missing must be "error" or "empty"`)
+		}
+		onMissing = value
+	}
+
 	cp, err := s.backend.CheckpointResume(agentID)
 	if err != nil {
 		if errors.Is(err, session.ErrNoCheckpoint) {
+			if onMissing == "empty" {
+				return toolStructured(checkpointResumeEmpty{Found: false, AgentID: agentID},
+					fmt.Sprintf("No checkpoint saved for agent %q yet.", agentID))
+			}
 			return toolError(fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err))
 		}
+		// Storage, daemon, and corrupt-record failures stay prose-only in both
+		// modes: they are not absence and must never masquerade as found:false.
 		return toolError(fmt.Sprintf("checkpoint resume error: %v", err))
 	}
 

--- a/cmd/graymatter/internal/mcp/handlers_test.go
+++ b/cmd/graymatter/internal/mcp/handlers_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	bolt "go.etcd.io/bbolt"
 
 	graymatter "github.com/angelnicolasc/graymatter"
 	"github.com/angelnicolasc/graymatter/pkg/memory"
@@ -111,6 +113,218 @@ func TestCheckpoint_SaveResume(t *testing.T) {
 	// resume for an unknown agent errors
 	if res, _ := s.handleCheckpointResume(ctx, reflectReq(map[string]any{"agent_id": "ghost"})); !res.IsError {
 		t.Error("checkpoint_resume for unknown agent should error")
+	}
+}
+
+// TestCheckpointResumeOnMissingEmpty covers the opt-in absence result
+// (ADR-015): default and explicit "error" keep the historical text-only tool
+// error; "empty" is a successful result carrying the typed absence marker.
+func TestCheckpointResumeOnMissingEmpty(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	historical := `no checkpoint found for agent "ghost": no checkpoints for agent "ghost"`
+	for _, args := range []map[string]any{
+		{"agent_id": "ghost"},
+		{"agent_id": "ghost", "on_missing": "error"},
+	} {
+		res, err := s.handleCheckpointResume(ctx, reflectReq(args))
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !res.IsError || res.StructuredContent != nil {
+			t.Fatalf("args %v: result = %+v, want text-only isError", args, res)
+		}
+		if got := resultText(t, res); got != historical {
+			t.Errorf("args %v: text = %q, want %q", args, got, historical)
+		}
+	}
+
+	res, err := s.handleCheckpointResume(ctx, reflectReq(map[string]any{
+		"agent_id":   "ghost",
+		"on_missing": "empty",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("on_missing=empty must be a success result: %s", resultText(t, res))
+	}
+	payload, ok := res.StructuredContent.(checkpointResumeEmpty)
+	if !ok {
+		t.Fatalf("structuredContent = %T, want checkpointResumeEmpty", res.StructuredContent)
+	}
+	if payload.Found || payload.AgentID != "ghost" {
+		t.Fatalf("absence payload = %+v, want found=false agent_id=ghost", payload)
+	}
+	if got, want := resultText(t, res), `No checkpoint saved for agent "ghost" yet.`; got != want {
+		t.Errorf("text = %q, want %q", got, want)
+	}
+	validateStructuredAgainstToolSchema(t, "checkpoint_resume", res.StructuredContent)
+}
+
+// TestCheckpointResumeEmptyResultWireShape pins the false marker on the wire.
+// found carries no omitempty precisely so it survives encoding; a regression
+// there serialises the payload as {} and re-creates the #117 failure.
+func TestCheckpointResumeEmptyResultWireShape(t *testing.T) {
+	s, _ := newTestServer(t)
+	res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{
+		"agent_id":   "wire-ghost",
+		"on_missing": "empty",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	raw, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var wire struct {
+		StructuredContent map[string]json.RawMessage `json:"structuredContent"`
+		IsError           bool                       `json:"isError"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if wire.IsError {
+		t.Fatalf("isError present on the empty path: %s", raw)
+	}
+	found, ok := wire.StructuredContent["found"]
+	if !ok {
+		t.Fatalf("structuredContent dropped \"found\" (omitempty regression): %s", raw)
+	}
+	var value bool
+	if err := json.Unmarshal(found, &value); err != nil || value {
+		t.Fatalf("found = %s (%v), want false", found, err)
+	}
+	if got := string(wire.StructuredContent["agent_id"]); got != `"wire-ghost"` {
+		t.Fatalf("agent_id = %s, want \"wire-ghost\"", got)
+	}
+}
+
+// TestCheckpointResumeOnMissingValidation covers the values a caller can send
+// outside the declared enum. mcp-go does not enforce input enums, so the
+// handler must, and it must not fall back to the default for a malformed value.
+func TestCheckpointResumeOnMissingValidation(t *testing.T) {
+	s, _ := newTestServer(t)
+	for _, tc := range []struct {
+		name  string
+		value any
+	}{
+		{"unknown string", "sometimes"},
+		{"empty string", ""},
+		{"number", float64(1)},
+		{"bool", true},
+		{"null", nil},
+		{"object", map[string]any{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{
+				"agent_id":   "ghost",
+				"on_missing": tc.value,
+			}))
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !res.IsError || res.StructuredContent != nil {
+				t.Fatalf("on_missing=%v result = %+v, want text-only tool error", tc.value, res)
+			}
+			if got, want := resultText(t, res), `on_missing must be "error" or "empty"`; got != want {
+				t.Errorf("text = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestCheckpointResumeOperationalFailuresStayProseOnly proves the empty mode
+// never swallows an operational failure as absence: only the ErrNoCheckpoint
+// sentinel selects the found:false result.
+func TestCheckpointResumeOperationalFailuresStayProseOnly(t *testing.T) {
+	causes := []struct {
+		name string
+		err  error
+	}{
+		{"unwrapped absence text", errors.New("no checkpoints")},
+		{"daemon failure", errors.New("daemon connection lost")},
+		{"storage failure", errors.New("bbolt: database is unavailable")},
+	}
+	for _, onMissing := range []string{"error", "empty"} {
+		for _, cause := range causes {
+			t.Run("on_missing="+onMissing+"/"+cause.name, func(t *testing.T) {
+				s, _ := newTestServer(t)
+				s.backend = resumeErrorBackend{Backend: s.backend, err: cause.err}
+				res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{
+					"agent_id":   "sc-a",
+					"on_missing": onMissing,
+				}))
+				if err != nil || !res.IsError || res.StructuredContent != nil {
+					t.Fatalf("result = %+v, error = %v; want text-only tool error", res, err)
+				}
+				if got, want := resultText(t, res), "checkpoint resume error: "+cause.err.Error(); got != want {
+					t.Errorf("text = %q, want %q", got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestCheckpointResumeUninitializedStoreStaysProseOnly keeps the empty mode
+// from reporting an unusable store as a successful absence.
+func TestCheckpointResumeUninitializedStoreStaysProseOnly(t *testing.T) {
+	var empty graymatter.Memory
+	for _, onMissing := range []string{"error", "empty"} {
+		t.Run("on_missing="+onMissing, func(t *testing.T) {
+			s := New(NewDirectBackend(&empty, nil), "test")
+			res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{
+				"agent_id":   "sc-a",
+				"on_missing": onMissing,
+			}))
+			if err != nil || !res.IsError || res.StructuredContent != nil {
+				t.Fatalf("result = %+v, error = %v; want text-only tool error", res, err)
+			}
+			if got := resultText(t, res); !strings.Contains(got, "not initialised") {
+				t.Errorf("error text = %q, want uninitialized-store diagnostic", got)
+			}
+		})
+	}
+}
+
+// TestCheckpointResumeCorruptRecordStaysProseOnly is the decoding-failure side
+// of the same rule: a damaged record is not an absent checkpoint, in either
+// mode (the #118 classification was pinned for the default mode; the empty
+// mode must not weaken it).
+func TestCheckpointResumeCorruptRecordStaysProseOnly(t *testing.T) {
+	s, mem := newTestServer(t)
+	if err := mem.Advanced().DB().Update(func(tx *bolt.Tx) error {
+		b, err := tx.Bucket([]byte("sessions")).CreateBucketIfNotExists([]byte("corrupt-agent"))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("corrupt-id"), []byte("{not valid json"))
+	}); err != nil {
+		t.Fatalf("write corrupt checkpoint: %v", err)
+	}
+
+	for _, onMissing := range []string{"error", "empty"} {
+		t.Run("on_missing="+onMissing, func(t *testing.T) {
+			res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{
+				"agent_id":   "corrupt-agent",
+				"on_missing": onMissing,
+			}))
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !res.IsError || res.StructuredContent != nil {
+				t.Fatalf("result = %+v, want text-only tool error", res)
+			}
+			if got := resultText(t, res); !strings.Contains(got, "decode checkpoint") {
+				t.Errorf("error text = %q, want decode diagnostic", got)
+			}
+			if got := resultText(t, res); strings.Contains(got, "not_found") {
+				t.Errorf("corrupt checkpoint was misclassified as not_found: %q", got)
+			}
+		})
 	}
 }
 

--- a/cmd/graymatter/internal/mcp/output_schema_test.go
+++ b/cmd/graymatter/internal/mcp/output_schema_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -22,7 +23,7 @@ func TestOutputSchemaOfGeneratesForEveryResultType(t *testing.T) {
 		{"memory_search", outputSchemaOf[searchResult]()},
 		{"memory_add", outputSchemaOf[addResult]()},
 		{"checkpoint_save", outputSchemaOf[checkpointSaveResult]()},
-		{"checkpoint_resume", outputSchemaOf[checkpointResumeResult]()},
+		{"checkpoint_resume", checkpointResumeOutputSchema()},
 		{"memory_reflect", outputSchemaOf[reflectResult]()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -41,5 +42,71 @@ func TestOutputSchemaOfGeneratesForEveryResultType(t *testing.T) {
 				t.Fatalf("%s: generated output schema never reached the wire", tc.name)
 			}
 		})
+	}
+}
+
+// TestCheckpointResumeOutputSchemaIsUnion pins the union builder's shape: two
+// object branches, the generated success payload first and the exact absence
+// marker second, with no root-level properties/required/additionalProperties
+// (a root constraint applies to every branch and breaks validation).
+func TestCheckpointResumeOutputSchemaIsUnion(t *testing.T) {
+	tool := mcp.NewTool("checkpoint_resume", checkpointResumeOutputSchema())
+	raw, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		OutputSchema json.RawMessage `json:"outputSchema"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(wire.OutputSchema, &root); err != nil {
+		t.Fatalf("decode outputSchema: %v", err)
+	}
+	for _, forbidden := range []string{"properties", "required", "additionalProperties"} {
+		if _, present := root[forbidden]; present {
+			t.Errorf("union root must not declare %s; it would constrain every branch", forbidden)
+		}
+	}
+	var rootType string
+	if err := json.Unmarshal(root["type"], &rootType); err != nil || rootType != "object" {
+		t.Fatalf("union root type = %s (%v), want object", root["type"], err)
+	}
+
+	var branches []json.RawMessage
+	if err := json.Unmarshal(root["oneOf"], &branches); err != nil {
+		t.Fatalf("decode oneOf: %v", err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("oneOf has %d branches, want 2", len(branches))
+	}
+
+	// Branch 1 is generated from the Go result type, never hand-written, so
+	// it cannot drift from checkpointResumeResult.
+	generated, err := mcp.SchemaForRaw[checkpointResumeResult]()
+	if err != nil {
+		t.Fatalf("generate success schema: %v", err)
+	}
+	assertJSONEquivalent(t, "success branch", branches[0], generated)
+
+	// Branch 2 is the exact absence contract (ADR-015).
+	assertJSONEquivalent(t, "absence branch", branches[1],
+		json.RawMessage(`{"type":"object","additionalProperties":false,"required":["found","agent_id"],"properties":{"found":{"type":"boolean","enum":[false]},"agent_id":{"type":"string"}}}`))
+}
+
+func assertJSONEquivalent(t *testing.T, name string, got, want json.RawMessage) {
+	t.Helper()
+	var gotAny, wantAny any
+	if err := json.Unmarshal(got, &gotAny); err != nil {
+		t.Fatalf("%s: decode got: %v", name, err)
+	}
+	if err := json.Unmarshal(want, &wantAny); err != nil {
+		t.Fatalf("%s: decode want: %v", name, err)
+	}
+	if !reflect.DeepEqual(gotAny, wantAny) {
+		t.Errorf("%s = %s, want %s", name, got, want)
 	}
 }

--- a/cmd/graymatter/internal/mcp/output_schema_test.go
+++ b/cmd/graymatter/internal/mcp/output_schema_test.go
@@ -92,6 +92,21 @@ func TestCheckpointResumeOutputSchemaIsUnion(t *testing.T) {
 	}
 	assertJSONEquivalent(t, "success branch", branches[0], generated)
 
+	// The branches must stay disjoint for oneOf matching: a future field
+	// addition that brings found or agent_id into checkpointResumeResult would
+	// make some payloads match both branches.
+	var successBranch struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(branches[0], &successBranch); err != nil {
+		t.Fatalf("decode success branch properties: %v", err)
+	}
+	for _, key := range []string{"found", "agent_id"} {
+		if _, present := successBranch.Properties[key]; present {
+			t.Errorf("success branch must not declare absence key %q", key)
+		}
+	}
+
 	// Branch 2 is the exact absence contract (ADR-015).
 	assertJSONEquivalent(t, "absence branch", branches[1],
 		json.RawMessage(`{"type":"object","additionalProperties":false,"required":["found","agent_id"],"properties":{"found":{"type":"boolean","enum":[false]},"agent_id":{"type":"string"}}}`))

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -489,16 +489,26 @@ func (s *Server) registerTools() {
 	)
 
 	// checkpoint_resume
+	//
+	// The output schema is the generated result union, not outputSchemaOf:
+	// on_missing="empty" makes absence a second successful shape (ADR-015), and
+	// only a union can declare both without presenting the absence marker as a
+	// checkpoint. The default keeps the historical text-only not-found error.
 	s.mcpSrv.AddTool(
 		mcp.NewTool("checkpoint_resume",
 			mcp.WithToolTitle("Load the latest checkpoint"),
-			mcp.WithDescription("Read an agent's most recent checkpoint without modifying anything: returns its ID, creation time (RFC3339), and the saved state as indented JSON, plus a message-turn count when messages were captured. Use at session start to detect and resume interrupted work; checkpoints are created with checkpoint_save. Errors with \"no checkpoint found\" when the agent has none."),
+			mcp.WithDescription("Read an agent's most recent checkpoint without modifying anything: returns its ID, creation time (RFC3339), and the saved state as indented JSON, plus a message-turn count when messages were captured. Use at session start to detect and resume interrupted work; checkpoints are created with checkpoint_save. With no checkpoint, on_missing=\"error\" (default) returns the historical not-found error; on_missing=\"empty\" returns a successful {\"found\": false, \"agent_id\"} result. Errors stay prose-only for storage and daemon failures."),
 			readOnlyTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent whose latest checkpoint to load."),
 			),
-			outputSchemaOf[checkpointResumeResult](),
+			mcp.WithString("on_missing",
+				mcp.Enum("error", "empty"),
+				mcp.DefaultString("error"),
+				mcp.Description("What to return when the agent has no checkpoint: \"error\" (default) keeps the historical not-found tool error; \"empty\" returns a successful {\"found\": false, \"agent_id\"} result."),
+			),
+			checkpointResumeOutputSchema(),
 		),
 		s.handleCheckpointResume,
 	)
@@ -575,6 +585,48 @@ func outputSchemaOf[T any]() mcp.ToolOption {
 		panic(fmt.Sprintf("graymatter/mcp: cannot generate output schema for %T: %v", zero, err))
 	}
 	return mcp.WithRawOutputSchema(raw)
+}
+
+// checkpointResumeAbsenceSchema is the absence branch of checkpoint_resume's
+// declared output: the successful {"found": false, "agent_id"} result that
+// on_missing="empty" returns. It is a schema branch rather than an error
+// payload because strict MCP clients validate structuredContent against the
+// tool's outputSchema whenever it is present, even alongside isError=true
+// (#117) — and because absence is now a successful result, not an error.
+//
+// found is pinned to false and required: {"found": true} never exists (real
+// success returns checkpointResumeResult), so the enum makes that constraint
+// machine-checkable. additionalProperties:false stays on this branch; the
+// union root deliberately carries none — a root-level additionalProperties
+// applies to every branch and would reject both payloads.
+var checkpointResumeAbsenceSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "found": {"type": "boolean", "enum": [false]},
+    "agent_id": {"type": "string"}
+  },
+  "required": ["found", "agent_id"],
+  "additionalProperties": false
+}`)
+
+// checkpointResumeOutputSchema declares checkpoint_resume's two successful
+// result shapes under oneOf: the checkpoint payload and the absence marker.
+// The success branch is generated from checkpointResumeResult, never
+// hand-written, so it cannot drift from the Go type; this helper panics at
+// registration when generation fails, mirroring outputSchemaOf (TD-002).
+func checkpointResumeOutputSchema() mcp.ToolOption {
+	success, err := mcp.SchemaForRaw[checkpointResumeResult]()
+	if err != nil {
+		panic(fmt.Sprintf("graymatter/mcp: cannot generate output schema for %T: %v", checkpointResumeResult{}, err))
+	}
+	union, err := json.Marshal(struct {
+		Type  string            `json:"type"`
+		OneOf []json.RawMessage `json:"oneOf"`
+	}{Type: "object", OneOf: []json.RawMessage{success, checkpointResumeAbsenceSchema}})
+	if err != nil {
+		panic(fmt.Sprintf("graymatter/mcp: cannot build checkpoint_resume output schema: %v", err))
+	}
+	return mcp.WithRawOutputSchema(union)
 }
 
 // toolStructured returns a result whose structuredContent is payload and whose

--- a/cmd/graymatter/internal/mcp/structured_contract_test.go
+++ b/cmd/graymatter/internal/mcp/structured_contract_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // The issue-#76 acceptance requires that handler outputs validate against the
-// declared outputSchema. These tests enforce that contract deterministically,
-// without pulling a schema validator dependency:
+// declared outputSchema. These tests enforce that contract deterministically
+// for flat object schemas:
 //
 //  1. every tool declares an outputSchema (type object) in tools/list;
 //  2. every success result carries structuredContent whose key set is a
@@ -20,6 +20,10 @@ import (
 //     schema property (omitempty fields may be absent, nothing else);
 //  3. every present key has the JSON type the schema declares;
 //  4. resume errors set isError and omit structuredContent on the wire.
+//
+// Point 2/3's hand-rolled checks cannot evaluate a oneOf union, so tools whose
+// output schema is a union (checkpoint_resume, ADR-015) are validated with a
+// real JSON Schema engine instead — see validateAgainstSchema.
 
 type schemaShape struct {
 	Type       string `json:"type"`
@@ -29,6 +33,10 @@ type schemaShape struct {
 		Type any `json:"type"`
 	} `json:"properties"`
 	Required []string `json:"required"`
+	// OneOf is set on output schemas that declare more than one successful
+	// result shape. Each branch is a flat object shape; the root carries no
+	// properties/required of its own.
+	OneOf []schemaShape `json:"oneOf"`
 }
 
 func outputSchemas(t *testing.T) map[string]schemaShape {
@@ -52,6 +60,20 @@ func TestToolsDeclareObjectOutputSchemas(t *testing.T) {
 	for name, schema := range outputSchemas(t) {
 		if schema.Type != "object" {
 			t.Errorf("%s: outputSchema.type = %q, want object", name, schema.Type)
+		}
+		// A union root declares its shapes in oneOf branches and must not
+		// constrain the branches with properties/required of its own
+		// (a root additionalProperties:false would reject both).
+		if len(schema.OneOf) > 0 {
+			for i, branch := range schema.OneOf {
+				if branch.Type != "object" {
+					t.Errorf("%s: oneOf[%d].type = %q, want object", name, i, branch.Type)
+				}
+				if len(branch.Properties) == 0 {
+					t.Errorf("%s: oneOf[%d] has no properties", name, i)
+				}
+			}
+			continue
 		}
 		if len(schema.Properties) == 0 {
 			t.Errorf("%s: outputSchema has no properties", name)
@@ -196,8 +218,14 @@ func TestCheckpointResumeWrappedAbsence(t *testing.T) {
 
 // validateAgainstSchema checks the payload against the declared schema shape:
 // key subset of properties, required keys present, primitive types matching.
+// Union schemas need branch selection and cannot be evaluated by those
+// hand-rolled checks, so they go through a real JSON Schema engine.
 func validateAgainstSchema(t *testing.T, toolName string, schema schemaShape, structured any) {
 	t.Helper()
+	if len(schema.OneOf) > 0 {
+		validateStructuredAgainstToolSchema(t, toolName, structured)
+		return
+	}
 	raw, err := json.Marshal(structured)
 	if err != nil {
 		t.Fatalf("%s: marshal structured content: %v", toolName, err)

--- a/cmd/graymatter/internal/mcp/tdqs_contract_test.go
+++ b/cmd/graymatter/internal/mcp/tdqs_contract_test.go
@@ -171,7 +171,7 @@ func TestToolSchemaContract(t *testing.T) {
 		"memory_add":          {props: []string{"agent_id", "text"}, required: []string{"agent_id", "text"}},
 		"memory_alias":        {props: []string{"agent_id", "term", "equivalents"}, required: []string{"agent_id", "term", "equivalents"}},
 		"checkpoint_save":     {props: []string{"agent_id", "state"}, required: []string{"agent_id"}},
-		"checkpoint_resume":   {props: []string{"agent_id"}, required: []string{"agent_id"}},
+		"checkpoint_resume":   {props: []string{"agent_id", "on_missing"}, required: []string{"agent_id"}},
 		"memory_reflect":      {props: []string{"action", "agent", "agent_id", "text", "target"}, required: []string{"action"}},
 	}
 
@@ -225,6 +225,20 @@ func TestToolSchemaContract(t *testing.T) {
 			case "memory_search":
 				if d, ok := schema.Properties["top_k"].Default.(float64); !ok || d != 8 {
 					t.Errorf("memory_search.top_k default = %v, want 8", schema.Properties["top_k"].Default)
+				}
+			case "checkpoint_resume":
+				if d, ok := schema.Properties["on_missing"].Default.(string); !ok || d != "error" {
+					t.Errorf("checkpoint_resume.on_missing default = %v, want \"error\"", schema.Properties["on_missing"].Default)
+				}
+				wantEnum := []string{"error", "empty"}
+				got := schema.Properties["on_missing"].Enum
+				if len(got) != len(wantEnum) {
+					t.Fatalf("checkpoint_resume.on_missing enum = %v, want %v", got, wantEnum)
+				}
+				for i, v := range wantEnum {
+					if got[i] != v {
+						t.Errorf("checkpoint_resume.on_missing enum[%d] = %v, want %q", i, got[i], v)
+					}
 				}
 			case "memory_reflect":
 				wantEnum := []string{"add", "update", "forget", "link", "pin", "unpin"}

--- a/cmd/graymatter/internal/mcp/types.go
+++ b/cmd/graymatter/internal/mcp/types.go
@@ -70,6 +70,21 @@ type checkpointResumeResult struct {
 	MessageCount int            `json:"message_count,omitempty"`
 }
 
+// checkpointResumeEmpty is checkpoint_resume's successful absence result,
+// returned when the caller passes on_missing="empty" and the agent has no
+// checkpoint (ADR-015). A separate type rather than checkpointResumeResult
+// with empty fields: absence is a different result shape, and the union
+// output schema validates it as its own branch.
+//
+// Found deliberately carries no omitempty. encoding/json drops a false bool
+// behind omitempty, which would serialise {"found": false} as {} — a success
+// result with no machine-readable marker, which is the strict-client failure
+// this payload exists to fix (#117). The wire-level test pins the key.
+type checkpointResumeEmpty struct {
+	Found   bool   `json:"found"`
+	AgentID string `json:"agent_id"`
+}
+
 type reflectResult struct {
 	Action string `json:"action"`
 	Agent  string `json:"agent"`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -25,7 +25,7 @@ Seven tools are registered by `graymatter mcp serve` (see [`cmd/graymatter/inter
 | `memory_add` | `agent_id` (string), `text` (string) | — | Confirmation string |
 | `memory_alias` | `agent_id` (string), `term` (string), `equivalents` (string array) | — | Confirmation naming the term and its equivalents |
 | `checkpoint_save` | `agent_id` (string) | `state` (JSON-encoded string) | Confirmation containing the checkpoint ID |
-| `checkpoint_resume` | `agent_id` (string) | — | `Checkpoint "id" restored` + `Created:` (RFC3339) + indented `State:` JSON; error result when none exists |
+| `checkpoint_resume` | `agent_id` (string) | `on_missing` (`"error"` \| `"empty"`, default `"error"`) | `Checkpoint "id" restored` + `Created:` (RFC3339) + indented `State:` JSON; by default an error result when none exists — with `on_missing: "empty"` a successful `{"found": false, "agent_id"}` result |
 | `memory_reflect` | `action` (`add`\|`update`\|`forget`\|`link`\|`pin`\|`unpin`), plus at least one of **`agent_id`** (canonical) or `agent` (deprecated alias; `agent_id` wins when both are set) | `text` (string), `target` (string — old fact text for `update`/`forget`/`pin`/`unpin`; target node ID for `link`) | Confirmation string |
 
 > ℹ️ **`memory_reflect` accepts both `agent_id` (canonical) and `agent` (deprecated alias).** Since the canonical flip ([ADR-014](decisions/014-agent-id-canonical.md)) at least one of the two is required — the schema enforces it as an `anyOf` allowing both — and `agent_id` wins when both are set. New integrations spell it `agent_id`, matching every other tool.
@@ -74,6 +74,13 @@ Every success result carries **both** a `structuredContent` object (declared in 
 // checkpoint_resume with no checkpoint — isError=true, text content only:
 "no checkpoint found for agent \"migration-agent\": no checkpoints for agent \"migration-agent\""
 // (content keeps the historical "no checkpoint found for agent ..." prose)
+
+// checkpoint_resume with no checkpoint and on_missing="empty" — success:
+{ "found": false, "agent_id": "migration-agent" }
+// text: "No checkpoint saved for agent \"migration-agent\" yet."
+// Without on_missing the default "error" keeps the historical isError result
+// above; v0.21.0 flips the default to "empty". Storage and daemon failures
+// stay prose-only errors in both modes.
 
 // memory_reflect — structuredContent
 { "action": "update", "agent": "backend-agent", "ok": true }

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -136,9 +136,10 @@ all — compiles against the payloads below. Within the v0.x series:
 
 - **Tool names, parameter names, and required parameters** will not be removed or renamed.
 - **`outputSchema` objects are authoritative**: a success result's
-  `structuredContent` conforms to the tool's declared schema, which sets
-  `additionalProperties: false`. New keys arrive only through a schema
-  revision, never silently.
+  `structuredContent` conforms to the tool's declared schema. Each result
+  shape sets `additionalProperties: false` — on a `oneOf` union, each branch,
+  since a root-level constraint would apply to every branch. New keys arrive
+  only through a schema revision, never silently.
 - **Text content** remains functionally equivalent to `structuredContent` per
   the MCP compatibility guidance. Exact prose wording is best-effort and may
   be reworded; clients should read the structured payload.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -166,7 +166,7 @@ verified against a live `tools/list` exchange at the time of writing.
 | `memory_add` | `agent_id`, `text` | — |
 | `memory_alias` | `agent_id`, `term`, `equivalents` | — |
 | `checkpoint_save` | `agent_id` | `state` (string containing a JSON object) |
-| `checkpoint_resume` | `agent_id` | — |
+| `checkpoint_resume` | `agent_id` | `on_missing` (`"error"` \| `"empty"`, default `"error"`) |
 | `memory_reflect` | `action`, plus at least one of `agent_id` (canonical) or `agent` (deprecated alias; `agent_id` wins when both are set) | `text`, `target` |
 
 `memory_reflect.action` is an enum: `add`, `update`, `forget`, `link`, `pin`,
@@ -185,13 +185,23 @@ and when both spellings arrive `agent_id` wins.
 | `memory_alias` | `{"agent_id", "term", "equivalents", "stored"}` | `stored` is `true` on success |
 | `checkpoint_save` | `{"agent_id", "checkpoint_id", "created_at"}` | `created_at` is RFC3339 |
 | `checkpoint_resume` | `{"id", "created_at", "state"?, "message_count"?}` | `state` is the persisted JSON object; keys marked `?` may be absent when empty |
+| `checkpoint_resume` with `on_missing: "empty"` | `{"found": false, "agent_id"}` | Added in v0.20.0. The successful absence result; `found` is always `false` and is declared non-optional. The output schema declares this shape and the success shape under `oneOf` |
 | `memory_reflect` | `{"action", "agent", "ok"}` | `ok` is `true` on success |
 
-Errors, including `checkpoint_resume` with no checkpoint, return text-only
-`isError: true` results without `structuredContent`; their wording may change.
-The former `{"error": "not_found", "agent_id"}` payload violated the declared
+Errors return text-only `isError: true` results without `structuredContent`;
+their wording may change. `checkpoint_resume` with no checkpoint returns such
+an error **by default**; the optional `on_missing` parameter (`"error"` — the
+default — or `"empty"`) lets a caller opt into the successful
+`{"found": false, "agent_id"}` result above instead. This is an additive
+option, not a behaviour change for existing callers; the default becomes
+`"empty"` in **v0.21.0** (prior-minor notice, per the deprecation rule above),
+and `"error"` remains accepted as the legacy behaviour throughout v0.x.
+Storage, daemon, and corrupt-record failures stay prose-only in both modes. The
+former `{"error": "not_found", "agent_id"}` payload violated the declared
 success schema and was removed to prevent strict clients from rejecting the
-entire response (#117; [ADR-013 amendment](decisions/013-structured-tool-results.md)).
+entire response (#117; [ADR-013 amendment](decisions/013-structured-tool-results.md));
+the machine-readable absence result that amendment deferred is
+[ADR-015](decisions/015-checkpoint-resume-empty-result.md).
 
 ---
 

--- a/docs/decisions/013-structured-tool-results.md
+++ b/docs/decisions/013-structured-tool-results.md
@@ -21,10 +21,12 @@ mcp-go v0.58 provides `NewToolResultStructured(payload, fallbackText)` and
 
 ## Decision
 
-Every tool declares an `outputSchema` generated from a Go type in
-`internal/mcp/types.go`, and every success handler returns the payload as
-`structuredContent` with its **byte-identical pre-existing prose** as text
-content:
+Every tool declares an `outputSchema`. Normal single-shape schemas are
+generated mechanically from Go types in `internal/mcp/types.go`; [ADR-015](015-checkpoint-resume-empty-result.md)
+later documents the explicit `checkpoint_resume` union exception, whose normal
+checkpoint branch remains generated while `server.go` composes its absence
+branch. Every success handler returns the payload as `structuredContent` with
+its **byte-identical pre-existing prose** as text content:
 
 | tool | structured payload |
 |------|--------------------|
@@ -98,9 +100,12 @@ general-purpose error protocol is introduced.
 - **Structured-only responses** (`NewToolResultStructuredOnly`): breaks the
   text contract the MCP spec explicitly asks tools to keep
   ("SHOULD also return functionally equivalent unstructured content").
-- **A schema-validator dependency for the tests**: the deterministic
-  key-set/type checks in `structured_contract_test.go` cover the contract
-  surface without adding a direct dependency on a validator library.
+- **A schema-validator dependency for the tests**: at the time of this
+  decision, the deterministic key-set/type checks in
+  `structured_contract_test.go` covered the contract surface without adding a
+  direct dependency on a validator library. [ADR-015](015-checkpoint-resume-empty-result.md)
+  later revisited that choice for the explicitly composed `checkpoint_resume`
+  union and validates it with `github.com/santhosh-tekuri/jsonschema/v6`.
 
 ## Reversal condition
 

--- a/docs/decisions/013-structured-tool-results.md
+++ b/docs/decisions/013-structured-tool-results.md
@@ -52,9 +52,10 @@ an intentional compatibility correction: consumers of the old error object
 must use the tool-error result instead. Widening the success schema or turning
 absence into success would change a larger, working contract. A future
 machine-readable absence result requires a separate contract decision. That
-decision is [ADR-015](015-checkpoint-resume-empty-result.md): an opt-in
-`on_missing: "empty"` result with a staged default flip, not a reversal of this
-amendment.
+decision is [ADR-015](015-checkpoint-resume-empty-result.md): it takes the
+deferred separate decision on an opt-in, staged path — an `on_missing: "empty"`
+result with a staged default flip — rather than folding the schema widening
+into the #117 correction.
 
 This follows the [MCP tool error and output-schema contract](https://modelcontextprotocol.io/specification/2025-06-18/server/tools):
 structured results must match the advertised schema; execution errors can

--- a/docs/decisions/013-structured-tool-results.md
+++ b/docs/decisions/013-structured-tool-results.md
@@ -51,7 +51,10 @@ historical not-found prose, and the success schema and prose unchanged. It is
 an intentional compatibility correction: consumers of the old error object
 must use the tool-error result instead. Widening the success schema or turning
 absence into success would change a larger, working contract. A future
-machine-readable absence result requires a separate contract decision.
+machine-readable absence result requires a separate contract decision. That
+decision is [ADR-015](015-checkpoint-resume-empty-result.md): an opt-in
+`on_missing: "empty"` result with a staged default flip, not a reversal of this
+amendment.
 
 This follows the [MCP tool error and output-schema contract](https://modelcontextprotocol.io/specification/2025-06-18/server/tools):
 structured results must match the advertised schema; execution errors can

--- a/docs/decisions/015-checkpoint-resume-empty-result.md
+++ b/docs/decisions/015-checkpoint-resume-empty-result.md
@@ -1,0 +1,117 @@
+# 015 — checkpoint_resume returns a successful, machine-readable absence result
+
+**Status:** Accepted — **Date:** 2026-09-12
+
+## Context
+
+Since #117, `checkpoint_resume` with no checkpoint returns a text-only
+`isError: true` result. That fixed a real defect — the older typed error
+payload (`{"error": "not_found", "agent_id"}`) did not conform to the tool's
+success-only `outputSchema`, and strict clients rejected the entire response —
+but it left absence undetectable without parsing prose. An agent booting with
+`checkpoint_resume` cannot programmatically distinguish "you have no saved
+state" from "the store is broken", which is exactly the distinction a session
+start needs.
+
+The [ADR-013 amendment](013-structured-tool-results.md) deferred a
+machine-readable absence result to a separate contract decision. This is that
+decision.
+
+**Client review evidence.** OpenCode 1.18.29's bundled MCP client uses ajv's
+`compile` and validates `structuredContent` against the tool's declared
+`outputSchema` whenever it is present, regardless of `isError`. It also
+rejects a successful (non-error) result that omits `structuredContent` for a
+tool that declares an `outputSchema` ("has an output schema but did not return
+structured content"). Consequences:
+
+- A text-only **success** result is not viable for any tool with an
+  `outputSchema`; a machine-readable absence result must carry
+  `structuredContent`.
+- `_meta` is not a fallback: it is not the validated field, and clients that
+  enforce the schema reject the result before any `_meta` is read.
+- Emitting `structuredContent` on the **error** path (the #117 design) must
+  satisfy the advertised schema — which is why absence could not simply stay
+  an error with a typed payload.
+
+## Decision
+
+Add an optional `on_missing` parameter to `checkpoint_resume`, enum
+`"error" | "empty"`, default `"error"`:
+
+- `default` / `"error"`: unchanged from v0.19.1 — text-only `isError: true`,
+  historical prose, no `structuredContent`.
+- `"empty"`: success (`isError` absent/false) with `structuredContent`
+  `{"found": false, "agent_id": "<id>"}` (wire type `checkpointResumeEmpty`,
+  `found` without `omitempty` so `false` cannot vanish) and text
+  `No checkpoint saved for agent "<id>" yet.`
+- Real failures (storage, daemon, corrupt records, uninitialized store) stay
+  prose-only `isError: true` in both modes; only the `ErrNoCheckpoint` sentinel
+  selects the absence result.
+
+The output schema becomes a root-object `oneOf` union: the generated
+`checkpointResumeResult` branch (built mechanically, never hand-written) plus
+an absence branch `{"type":"object","additionalProperties":false,"required":
+["found","agent_id"],"properties":{"found":{"type":"boolean","enum":[false]},
+"agent_id":{"type":"string"}}}`. The union root declares no
+`properties`/`required`/`additionalProperties` of its own — a root-level
+`additionalProperties: false` applies to every branch and rejects both
+payloads.
+
+**Staged migration.** `"empty"` is opt-in in v0.20.0. The default flips to
+`"empty"` in v0.21.0, announced in the v0.20.0 changelog and in
+`docs/api-stability.md` (the prior-minor notice the deprecation rule
+requires). `"error"` remains accepted as the legacy behaviour throughout
+v0.x, so no caller breaks at either step.
+
+**Fallback if a real client rejects `oneOf`.** Collapse the output schema to a
+single permissive object declaring all six keys (`id`, `created_at`, `state`,
+`message_count`, `found`, `agent_id`), none required,
+`additionalProperties: false`, while keeping `structuredContent` on both
+paths. The wire payloads do not change; only the schema's validation strength
+does. The release gate before the default flip is a real OpenChamber/OpenCode
+smoke run against this schema, not just the contract tests.
+
+## Consequences
+
+- A session-start caller can opt into `{"found": false}` and stop treating
+  "no checkpoint yet" as a failure, without a prose parser.
+- Existing callers are unaffected by construction: the default path is
+  byte-identical to v0.19.1, and the union schema accepts the success payload
+  unchanged.
+- The union root means `structured_contract_test.go`'s hand-rolled key/type
+  checks cannot validate this tool; checkpoint resume payloads are validated
+  with `github.com/santhosh-tekuri/jsonschema/v6` (already in the module graph
+  via mcp-go, promoted to a direct test dependency).
+- The zero-value trap is pinned twice: `checkpointResumeEmpty.Found` must not
+  carry `omitempty`, and a wire test asserts `"found": false` is present in
+  the serialized response.
+
+## Alternatives rejected
+
+- **Typed error `structuredContent`** — the #117 payload
+  (`{"error": "not_found", "agent_id"}` with `isError: true`). Rejected: it
+  violates the success-only output schema, which is the defect #117 fixed.
+- **Text-only success** — rejected: a schema-bearing tool's successful result
+  that omits `structuredContent` is rejected outright by the reviewed client.
+- **`_meta` marker** — rejected: not schema-validated, not surfaced to
+  callers, and rejected before it can be read when `structuredContent` is
+  missing.
+- **A companion `checkpoint_status` tool** — rejected: adds an eighth tool
+  and a second round trip to answer a question the resume call already has,
+  and clients select tools by description, so "call this first" is a request
+  the protocol cannot enforce.
+- **Direct flip to `empty` without notice** — rejected: turning absence from
+  an error into a success is observable behaviour; the v0.x stability promise
+  requires a prior-minor notice and the staged path gives real deployments a
+  release to opt in first.
+
+## Reversal condition
+
+If the OpenChamber/OpenCode smoke run (or field reports from other strict
+clients) shows `oneOf` output schemas being rejected or mis-handled, apply the
+permissive single-object fallback above in the same commit that enables the
+default flip, and record the client/version evidence in this ADR. If no such
+report appears, flip the default in v0.21.0 as announced. If the flip then
+produces reports of behavioural breakage that opt-in adoption did not reveal,
+keep `"error"` as the default for the remainder of v0.x and reopen the
+contract question with the breakage evidence rather than extending the flip.

--- a/docs/decisions/015-checkpoint-resume-empty-result.md
+++ b/docs/decisions/015-checkpoint-resume-empty-result.md
@@ -68,8 +68,9 @@ single permissive object declaring all six keys (`id`, `created_at`, `state`,
 `message_count`, `found`, `agent_id`), none required,
 `additionalProperties: false`, while keeping `structuredContent` on both
 paths. The wire payloads do not change; only the schema's validation strength
-does. The release gate before the default flip is a real OpenChamber/OpenCode
-smoke run against this schema, not just the contract tests.
+does. The release gate is a real OpenChamber/OpenCode smoke run against this
+schema — not just the contract tests — and it must pass before v0.20.0 ships,
+because the union is validated on every structured result from that release.
 
 ## Consequences
 
@@ -107,11 +108,15 @@ smoke run against this schema, not just the contract tests.
 
 ## Reversal condition
 
-If the OpenChamber/OpenCode smoke run (or field reports from other strict
-clients) shows `oneOf` output schemas being rejected or mis-handled, apply the
-permissive single-object fallback above in the same commit that enables the
-default flip, and record the client/version evidence in this ADR. If no such
-report appears, flip the default in v0.21.0 as announced. If the flip then
-produces reports of behavioural breakage that opt-in adoption did not reveal,
-keep `"error"` as the default for the remainder of v0.x and reopen the
-contract question with the breakage evidence rather than extending the flip.
+The real-client gate must pass before v0.20.0 ships: the union schema ships in
+that release and strict clients validate it on every structured result. If the
+OpenChamber/OpenCode smoke run (or field reports from other strict clients)
+shows `oneOf` output schemas being rejected or mis-handled, apply the
+permissive single-object fallback above in the next release after detection
+(at latest with the v0.21.0 default flip), and record the client/version
+evidence in this ADR. Keep `"error"` as the default until a smoke run re-proves
+the schema on a real client. If no such report appears, flip the default in
+v0.21.0 as announced. If the flip then produces reports of behavioural
+breakage that opt-in adoption did not reveal, keep `"error"` as the default
+for the remainder of v0.x and reopen the contract question with the breakage
+evidence rather than extending the flip.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,6 +23,8 @@ consequences, reversal condition.
 | [011](011-consolidation-propose-apply.md) | Consolidation is propose/apply with tombstone receipts; Ollama summarises locally | Accepted |
 | [012](012-tool-definition-quality.md) | Tool definitions are engineered against the TDQS rubric and pinned by contract tests | Accepted |
 | [013](013-structured-tool-results.md) | Tool results carry structuredContent twins with declared output schemas | Accepted |
+| [014](014-agent-id-canonical.md) | agent_id is the canonical agent parameter; agent remains a deprecated alias | Accepted |
+| [015](015-checkpoint-resume-empty-result.md) | checkpoint_resume returns a successful absence result under on_missing=empty | Accepted |
 
 ## Writing a new one
 


### PR DESCRIPTION
## Summary

- Add `on_missing` to `checkpoint_resume`: `error` remains the default and `empty` makes a genuine missing checkpoint a successful structured result.
- Preserve the v0.19.1 default text-only error path and keep daemon/storage/decode failures as prose-only errors.
- Advertise disjoint checkpoint/absence output-schema branches; add wire-level regression coverage and update generated agent guidance and ADR/API docs.

Fixes #123

## Compatibility

- Omitted `on_missing` and explicit `error` retain the historical no-checkpoint response.
- `empty` returns `{ "found": false, "agent_id": "..." }` only for genuine absence.
- The default remains `error` for v0.20.0; the v0.21.0 default flip is documented separately.

## Validation

- `go vet`, `go test`, and `go build` for both modules.
- `go test -race -count=1 -timeout=300s ./...` in `cmd/graymatter`.
- Independent native whole-diff review: pass (OCR not used).

## Release follow-up

Before v0.20.0 ships, run the ADR-015 real OpenChamber/OpenCode smoke for the `oneOf` schema and `found:false` result.