### PR TITLE
feat(mcp): let checkpoint_resume report a missing checkpoint as a result

### DIFF
--- a/cmd/graymatter/internal/mcp/checkpoint_on_missing_test.go
+++ b/cmd/graymatter/internal/mcp/checkpoint_on_missing_test.go
@@ -1,0 +1,263 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/angelnicolasc/graymatter/cmd/graymatter/internal/session"
+)
+
+// Issue #123: a fresh agent having no checkpoint is an ordinary session-start
+// state. It stays an isError result by default - flipping that would change the
+// contract for every existing caller - and becomes a successful structured
+// result only for a client that asks for it with on_missing=empty. Everything
+// else, including real daemon/storage/decode failures, is unaffected.
+
+// The absent case, in both modes, on a backend that has nothing saved.
+func TestCheckpointResume_AbsenceIsAnErrorByDefaultAndAResultOnRequest(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+	}{
+		{"on_missing omitted", map[string]any{"agent_id": "ghost"}},
+		{"on_missing error", map[string]any{"agent_id": "ghost", "on_missing": "error"}},
+		{"on_missing empty string", map[string]any{"agent_id": "ghost", "on_missing": ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := s.handleCheckpointResume(ctx, reflectReq(tc.args))
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("the default must stay the historical isError result, got: %s", resultText(t, res))
+			}
+			if !strings.Contains(resultText(t, res), "no checkpoint found") {
+				t.Errorf("error text changed: %s", resultText(t, res))
+			}
+			if res.StructuredContent != nil {
+				t.Errorf("the default result must stay text-only, got structured: %#v", res.StructuredContent)
+			}
+		})
+	}
+
+	res, err := s.handleCheckpointResume(ctx, reflectReq(map[string]any{
+		"agent_id": "ghost", "on_missing": "empty",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("on_missing=empty must report absence as a success, got: %s", resultText(t, res))
+	}
+	assertAbsent(t, res, "ghost")
+	// The human-readable half is still there, as it is for every other success.
+	if !strings.Contains(resultText(t, res), "ghost") {
+		t.Errorf("absence result carries no prose naming the agent: %s", resultText(t, res))
+	}
+}
+
+// A present checkpoint is the ordinary payload in every mode: on_missing must
+// not touch the success path.
+func TestCheckpointResume_APresentCheckpointIsUnchangedInEveryMode(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	if res, _ := s.handleCheckpointSave(ctx, reflectReq(map[string]any{
+		"agent_id": "a1", "state": `{"step":3}`,
+	})); res.IsError {
+		t.Fatalf("checkpoint_save failed: %s", resultText(t, res))
+	}
+
+	for _, args := range []map[string]any{
+		{"agent_id": "a1"},
+		{"agent_id": "a1", "on_missing": "error"},
+		{"agent_id": "a1", "on_missing": "empty"},
+	} {
+		res, err := s.handleCheckpointResume(ctx, reflectReq(args))
+		if err != nil || res.IsError {
+			t.Fatalf("%v: resume failed: %v / %s", args, err, resultText(t, res))
+		}
+		payload := structuredMap(t, res)
+		if _, found := payload["found"]; found {
+			t.Errorf("%v: the resume payload must not gain a found field: %#v", args, payload)
+		}
+		if payload["id"] == "" || payload["id"] == nil {
+			t.Errorf("%v: resume payload lost its id: %#v", args, payload)
+		}
+		if payload["created_at"] == nil {
+			t.Errorf("%v: resume payload lost its created_at: %#v", args, payload)
+		}
+		if !strings.Contains(resultText(t, res), "restored") {
+			t.Errorf("%v: prose changed: %s", args, resultText(t, res))
+		}
+	}
+}
+
+// An unrecognized value is refused rather than quietly defaulted: a caller that
+// misspells the mode it wanted must not silently receive the mode it avoided.
+func TestCheckpointResume_AnUnknownOnMissingValueIsRefused(t *testing.T) {
+	s, _ := newTestServer(t)
+	for _, value := range []string{"Empty", "EMPTY", "none", "false", "ok"} {
+		res, err := s.handleCheckpointResume(context.Background(), reflectReq(map[string]any{
+			"agent_id": "ghost", "on_missing": value,
+		}))
+		if err != nil {
+			t.Fatalf("%q: handler error: %v", value, err)
+		}
+		if !res.IsError || !strings.Contains(resultText(t, res), "on_missing") {
+			t.Errorf("%q: expected a validation error naming on_missing, got: %s", value, resultText(t, res))
+		}
+	}
+}
+
+// on_missing converts exactly one error. A storage/decode failure is not an
+// absent checkpoint and must stay an error even under empty.
+func TestCheckpointResume_ARealFailureStaysAnErrorUnderEmpty(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.backend = &resumeFailureBackend{
+		DirectBackend: s.backend.(*DirectBackend),
+		err:           errors.New("bolt: database not open"),
+	}
+
+	for _, args := range []map[string]any{
+		{"agent_id": "a1"},
+		{"agent_id": "a1", "on_missing": "empty"},
+	} {
+		res, err := s.handleCheckpointResume(context.Background(), reflectReq(args))
+		if err != nil {
+			t.Fatalf("%v: handler error: %v", args, err)
+		}
+		if !res.IsError {
+			t.Fatalf("%v: a storage failure must stay an error, got: %s", args, resultText(t, res))
+		}
+		if !strings.Contains(resultText(t, res), "checkpoint resume error") {
+			t.Errorf("%v: unexpected error text: %s", args, resultText(t, res))
+		}
+	}
+}
+
+// The advertised schema has to describe both successful shapes, and the two
+// must not both validate one payload - otherwise a client cannot tell them
+// apart from the schema alone.
+func TestCheckpointResumeOutputSchema_DescribesBothShapesDisjointly(t *testing.T) {
+	tool := mcp.NewTool("checkpoint_resume", checkpointResumeOutputSchema())
+	raw, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		OutputSchema struct {
+			Type       string                     `json:"type"`
+			Properties map[string]json.RawMessage `json:"properties"`
+			Required   []string                   `json:"required"`
+			OneOf      []struct {
+				Required             []string                   `json:"required"`
+				Properties           map[string]json.RawMessage `json:"properties"`
+				AdditionalProperties *bool                      `json:"additionalProperties"`
+			} `json:"oneOf"`
+		} `json:"outputSchema"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if wire.OutputSchema.Type != "object" {
+		t.Errorf("output schema is not an object schema: %q", wire.OutputSchema.Type)
+	}
+	if len(wire.OutputSchema.OneOf) != 2 {
+		t.Fatalf("expected both shapes in the union, got %d: %s", len(wire.OutputSchema.OneOf), raw)
+	}
+
+	// This package's output-schema contract reads the TOP-LEVEL properties
+	// (structured_contract_test.go), so the union of both halves' fields has to
+	// be declared there or a legitimate payload reads as undeclared.
+	for _, key := range []string{"id", "created_at", "state", "message_count", "found", "agent_id"} {
+		if _, declared := wire.OutputSchema.Properties[key]; !declared {
+			t.Errorf("top-level properties omit %q, so a valid payload key is undeclared", key)
+		}
+	}
+	// And no top-level required list: the two shapes disagree about which keys
+	// are mandatory, which is what the oneOf says instead.
+	if len(wire.OutputSchema.Required) != 0 {
+		t.Errorf("top-level required = %v; it cannot hold for both shapes", wire.OutputSchema.Required)
+	}
+
+	var payload, absent int
+	for _, alt := range wire.OutputSchema.OneOf {
+		required := strings.Join(alt.Required, ",")
+		switch {
+		case strings.Contains(required, "id") && strings.Contains(required, "created_at"):
+			payload++
+			if _, has := alt.Properties["found"]; has {
+				t.Error("the resume payload must not declare found")
+			}
+		case strings.Contains(required, "found") && strings.Contains(required, "agent_id"):
+			absent++
+			if _, has := alt.Properties["id"]; has {
+				t.Error("the absence result must not declare id")
+			}
+		default:
+			t.Errorf("unrecognized alternative, required=%q", required)
+		}
+		// What makes the union unambiguous: neither half tolerates the other's
+		// fields, so no payload can satisfy both.
+		if alt.AdditionalProperties == nil || *alt.AdditionalProperties {
+			t.Errorf("alternative required=%q allows additional properties, so the union is ambiguous", required)
+		}
+	}
+	if payload != 1 || absent != 1 {
+		t.Errorf("expected exactly one of each shape, got payload=%d absent=%d", payload, absent)
+	}
+}
+
+func assertAbsent(t *testing.T, res *mcp.CallToolResult, agentID string) {
+	t.Helper()
+	payload := structuredMap(t, res)
+	if found, ok := payload["found"].(bool); !ok || found {
+		t.Errorf("expected found=false, got %#v", payload["found"])
+	}
+	if payload["agent_id"] != agentID {
+		t.Errorf("expected agent_id=%q, got %#v", agentID, payload["agent_id"])
+	}
+	if _, has := payload["id"]; has {
+		t.Errorf("no checkpoint id may be invented for an absent checkpoint: %#v", payload)
+	}
+}
+
+// structuredMap re-encodes the structured content so the assertions run against
+// what a client receives on the wire, not against the Go value.
+func structuredMap(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if res.StructuredContent == nil {
+		t.Fatalf("result carries no structured content: %s", resultText(t, res))
+	}
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode structured content: %v", err)
+	}
+	return out
+}
+
+// resumeFailureBackend turns CheckpointResume into a non-absence failure while
+// leaving every other call to the real backend, the same embedding the
+// reflect-write failure fake uses.
+type resumeFailureBackend struct {
+	*DirectBackend
+	err error
+}
+
+func (b *resumeFailureBackend) CheckpointResume(string) (*session.Checkpoint, error) {
+	return nil, b.err
+}

--- a/cmd/graymatter/internal/mcp/handlers.go
+++ b/cmd/graymatter/internal/mcp/handlers.go
@@ -193,9 +193,31 @@ func (s *Server) handleCheckpointResume(ctx context.Context, req mcp.CallToolReq
 		return toolError("agent_id is required")
 	}
 
+	// Absence of a checkpoint is the only case on_missing governs, and the
+	// default keeps the historical isError result so no existing caller changes
+	// (issue #123). An unrecognized value is refused rather than quietly
+	// defaulted: silently treating on_missing="Empty" as "error" would hand the
+	// caller the very result it asked not to get.
+	onMissing, ok := getString(args, "on_missing")
+	if !ok || onMissing == "" {
+		onMissing = checkpointOnMissingError
+	}
+	if onMissing != checkpointOnMissingError && onMissing != checkpointOnMissingEmpty {
+		return toolError(fmt.Sprintf("on_missing must be %q or %q, got %q",
+			checkpointOnMissingError, checkpointOnMissingEmpty, onMissing))
+	}
+
 	cp, err := s.backend.CheckpointResume(agentID)
 	if err != nil {
 		if errors.Is(err, session.ErrNoCheckpoint) {
+			if onMissing == checkpointOnMissingEmpty {
+				// A fresh agent with nothing saved: an ordinary session-start
+				// state, reported as a successful result the caller can branch
+				// on. Only this one error is converted; everything below stays
+				// an error in either mode.
+				return toolStructured(checkpointAbsentResult{Found: false, AgentID: agentID},
+					fmt.Sprintf("No checkpoint found for agent %q.\n", agentID))
+			}
 			return toolError(fmt.Sprintf("no checkpoint found for agent %q: %v", agentID, err))
 		}
 		return toolError(fmt.Sprintf("checkpoint resume error: %v", err))

--- a/cmd/graymatter/internal/mcp/server.go
+++ b/cmd/graymatter/internal/mcp/server.go
@@ -16,6 +16,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -492,13 +493,17 @@ func (s *Server) registerTools() {
 	s.mcpSrv.AddTool(
 		mcp.NewTool("checkpoint_resume",
 			mcp.WithToolTitle("Load the latest checkpoint"),
-			mcp.WithDescription("Read an agent's most recent checkpoint without modifying anything: returns its ID, creation time (RFC3339), and the saved state as indented JSON, plus a message-turn count when messages were captured. Use at session start to detect and resume interrupted work; checkpoints are created with checkpoint_save. Errors with \"no checkpoint found\" when the agent has none."),
+			mcp.WithDescription("Read an agent's most recent checkpoint without modifying anything: returns its ID, creation time (RFC3339), and the saved state as indented JSON, plus a message-turn count when messages were captured. Use at session start to detect and resume interrupted work; checkpoints are created with checkpoint_save. Errors with \"no checkpoint found\" when the agent has none, unless on_missing=\"empty\" asks for that one case as a successful {\"found\": false, \"agent_id\": ...} result instead. Daemon, storage and decode failures stay errors in either mode."),
 			readOnlyTool(),
 			mcp.WithString("agent_id",
 				mcp.Required(),
 				mcp.Description("The agent whose latest checkpoint to load."),
 			),
-			outputSchemaOf[checkpointResumeResult](),
+			mcp.WithString("on_missing",
+				mcp.Description("How to report an agent that has no checkpoint at all: \"error\" (default, the historical text-only isError result) or \"empty\" (a successful {\"found\": false, \"agent_id\": ...} result). Only that one case is affected; a present checkpoint returns the ordinary payload and real failures stay errors."),
+				mcp.Enum(checkpointOnMissingError, checkpointOnMissingEmpty),
+			),
+			checkpointResumeOutputSchema(),
 		),
 		s.handleCheckpointResume,
 	)
@@ -568,6 +573,73 @@ func toolError(msg string) (*mcp.CallToolResult, error) {
 // declared contract and without any client-visible signal (TD-002); these
 // types are compile-time constants, so a failure is a programming error and
 // panicking at registration is the honest behaviour.
+// The two values of checkpoint_resume's on_missing (issue #123). The default is
+// deliberately the historical one: flipping it would change the wire contract
+// for every existing caller.
+const (
+	checkpointOnMissingError = "error"
+	checkpointOnMissingEmpty = "empty"
+)
+
+// checkpoint_resume advertises two successful shapes since #123: the resume
+// payload, and - only under on_missing=empty - the normal-absence result.
+//
+// Composed from the two GENERATED schemas rather than hand-authored, so neither
+// half can drift from its Go type. The shape is an object whose `properties`
+// carry the union of both halves' fields - what this package's output-schema
+// contract reads (structured_contract_test.go), and what a client browsing the
+// tool sees - with a `oneOf` over the two halves doing the actual constraining:
+// each half keeps its own required list and additionalProperties:false, so no
+// payload can satisfy both and a validator still rejects a mixed one. There is
+// deliberately no top-level required list, because the two shapes disagree
+// about which keys are mandatory; that is what the oneOf exists to say.
+func checkpointResumeOutputSchema() mcp.ToolOption {
+	payload := mustSchemaFor[checkpointResumeResult]()
+	absent := mustSchemaFor[checkpointAbsentResult]()
+	union, err := json.Marshal(map[string]any{
+		"type":       "object",
+		"properties": mergedProperties(payload, absent),
+		"oneOf":      []json.RawMessage{payload, absent},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("graymatter/mcp: cannot compose the checkpoint_resume output schema: %v", err))
+	}
+	return mcp.WithRawOutputSchema(union)
+}
+
+// mergedProperties is the union of the `properties` of the given object
+// schemas. The halves describe disjoint key sets, so there is nothing to
+// reconcile; a collision would mean one field had two declared types, which is
+// a contradiction rather than something to merge, so it panics instead.
+func mergedProperties(schemas ...json.RawMessage) map[string]json.RawMessage {
+	merged := map[string]json.RawMessage{}
+	for _, raw := range schemas {
+		var decoded struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			panic(fmt.Sprintf("graymatter/mcp: cannot read a generated schema's properties: %v", err))
+		}
+		for name, prop := range decoded.Properties {
+			if existing, clash := merged[name]; clash && !bytes.Equal(existing, prop) {
+				panic(fmt.Sprintf("graymatter/mcp: schema halves disagree about %q: %s vs %s",
+					name, existing, prop))
+			}
+			merged[name] = prop
+		}
+	}
+	return merged
+}
+
+func mustSchemaFor[T any]() json.RawMessage {
+	raw, err := mcp.SchemaForRaw[T]()
+	if err != nil {
+		var zero T
+		panic(fmt.Sprintf("graymatter/mcp: cannot generate output schema for %T: %v", zero, err))
+	}
+	return raw
+}
+
 func outputSchemaOf[T any]() mcp.ToolOption {
 	raw, err := mcp.SchemaForRaw[T]()
 	if err != nil {

--- a/cmd/graymatter/internal/mcp/tdqs_contract_test.go
+++ b/cmd/graymatter/internal/mcp/tdqs_contract_test.go
@@ -171,7 +171,7 @@ func TestToolSchemaContract(t *testing.T) {
 		"memory_add":          {props: []string{"agent_id", "text"}, required: []string{"agent_id", "text"}},
 		"memory_alias":        {props: []string{"agent_id", "term", "equivalents"}, required: []string{"agent_id", "term", "equivalents"}},
 		"checkpoint_save":     {props: []string{"agent_id", "state"}, required: []string{"agent_id"}},
-		"checkpoint_resume":   {props: []string{"agent_id"}, required: []string{"agent_id"}},
+		"checkpoint_resume":   {props: []string{"agent_id", "on_missing"}, required: []string{"agent_id"}},
 		"memory_reflect":      {props: []string{"action", "agent", "agent_id", "text", "target"}, required: []string{"action"}},
 	}
 

--- a/cmd/graymatter/internal/mcp/types.go
+++ b/cmd/graymatter/internal/mcp/types.go
@@ -70,6 +70,21 @@ type checkpointResumeResult struct {
 	MessageCount int            `json:"message_count,omitempty"`
 }
 
+// The normal-absence shape for checkpoint_resume under on_missing=empty
+// (issue #123). A fresh agent having no checkpoint is an ordinary session-start
+// state, not a backend failure, so a client that asks for it gets a successful
+// structured result rather than an isError one.
+//
+// Deliberately not the resume payload with empty fields: no id or created_at is
+// invented for a checkpoint that does not exist, and `found` is the
+// discriminator a client reads. The two shapes stay disjoint on the wire - each
+// generated schema carries its own required list and additionalProperties:false
+// - so the union the tool advertises is unambiguous.
+type checkpointAbsentResult struct {
+	Found   bool   `json:"found"`
+	AgentID string `json:"agent_id"`
+}
+
 type reflectResult struct {
 	Action string `json:"action"`
 	Agent  string `json:"agent"`


### PR DESCRIPTION
Fixes #123. The default wire contract is untouched; `on_missing: empty` is the opt-in.

## What changes

`checkpoint_resume` gains an optional `on_missing` with `error` (default) and `empty`:

| call | before | after |
| --- | --- | --- |
| no checkpoint, `on_missing` omitted or `error` | text-only `isError` | **unchanged** |
| no checkpoint, `on_missing: empty` | text-only `isError` | success, `{"found": false, "agent_id": "…"}` + prose |
| checkpoint present, any mode | resume payload | **unchanged**, no `found` field added |
| daemon / storage / decode failure, any mode | text-only `isError` | **unchanged** |
| `on_missing` misspelled (`"Empty"`, `"none"`, …) | — | refused with a validation error naming `on_missing` |

That last row is a deliberate choice worth your eye: an unrecognized value is **refused rather than quietly defaulted**, because silently treating `on_missing: "Empty"` as `error` hands the caller the exact result it asked to avoid. The enum is also declared in the input schema, so a schema-aware client is told before it calls.

## The output schema

This is the part that needed care, and where I ran into an existing contract of yours.

The absence result is its own type (`checkpointAbsentResult{found, agent_id}`), not the resume payload with empty fields — no `id` or `created_at` is invented for a checkpoint that does not exist, and `found` is the discriminator a client reads. So the tool advertises **two** successful shapes, and the schema has to describe both without either payload becoming ambiguous.

It is composed from the two **generated** schemas rather than hand-authored, so neither half can drift from its Go type:

```json
{ "type": "object",
  "properties": { "id": …, "created_at": …, "state": …, "message_count": …, "found": …, "agent_id": … },
  "oneOf": [ <resume schema>, <absence schema> ] }
```

- The top-level `properties` carry the union of both halves, because that is what `structured_contract_test.go` reads when it checks that every structured key is declared — a bare `oneOf` fails `TestToolsDeclareObjectOutputSchemas` ("outputSchema has no properties"), which is how I found the contract.
- The `oneOf` does the constraining. Each generated half keeps its own `required` list **and** `additionalProperties: false`, so no payload can satisfy both and a real validator rejects a mixed one.
- There is deliberately **no top-level `required`**: the two shapes disagree about which keys are mandatory, and that disagreement is exactly what the `oneOf` exists to express. A test asserts it stays empty, so nobody re-adds a list that cannot hold for both.

`mergedProperties` panics if the halves ever declare the same field differently, since that would be a contradiction rather than something to merge.

## Compatibility

- Default stays `error` for v0.20.0, as the issue's release plan asks. Nothing in this PR flips it.
- I did not run the OpenChamber/OpenCode smoke the plan calls for — that needs the real clients, so it is yours to do before the release. Everything below is local.
- `tdqs_contract_test.go`'s declared parameter inventory now lists `on_missing` for `checkpoint_resume`; that guard exists to make a new parameter a visible diff, so updating it is the intended workflow rather than a way around it.
- The tool description discloses both modes and keeps the `Errors with …` phrasing `TestToolDefinitionContract` requires.

## Tests

`cmd/graymatter/internal/mcp/checkpoint_on_missing_test.go`:

- absence stays an `isError` **and text-only** result for `on_missing` omitted, `"error"`, and `""` — the empty string is the shape a client that sets the field from an unset variable actually sends;
- absence under `empty` is a success whose structured content is re-encoded to JSON before being asserted, so the check runs against what a client receives, not the Go value: `found == false`, `agent_id` matches, and **no `id` key exists**;
- a present checkpoint is asserted identical in all three modes, including that it gains no `found` field;
- five misspelled values are refused;
- a non-absence backend failure stays an error in both modes, so `on_missing` converts exactly one error and not a class of them;
- the schema test above.

Verification, all from `cmd/graymatter/` since the diff is confined to that module: `go test -count=1 -timeout=600s ./...` passes in full (the package's existing checkpoint tests included), `go test -race -count=1 ./internal/mcp/` passes, `gofmt` and `go vet` clean. I did not get a full pass of the root library module: its `TestGrayMatterScaleCurve` needs more than the 5-minute default on this machine (it was still running at 4m06s when the timeout fired). Nothing in this PR touches that module.

Negative controls, tests kept and source reverted one piece at a time:

- making the `empty` branch unreachable → the absence test fails with `on_missing=empty must report absence as a success, got: no checkpoint found for agent "ghost"`;
- pointing the union's second half at `checkpointResumeResult` instead of the absence type → the schema test fails with `expected exactly one of each shape, got payload=2 absent=0`.
